### PR TITLE
Minor .gitignore updates and integer type changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Makefile
+.idea/
+cmake-build-debug/
 CMakeCache.txt
 CMakeFiles/
 *.cmake

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SANA
 ## Contributions
 To contribute to this project, please make sure to adhere to the
-[Google C++ style guide](https://google.github.io/styleguide/cppguide.html). If you're unsure if it follows the
+[Google C++ style guide](https://google.github.io/styleguide/cppguide.html). If you're unsure that it follows the
 Style Guide, you can use Google's cpplint in their [styleguide repo](https://github.com/google/styleguide).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# SANA
+## Contributions
+To contribute to this project, please make sure to adhere to the
+[Google C++ style guide](https://google.github.io/styleguide/cppguide.html). If you're unsure if it follows the
+Style Guide, you can use Google's cpplint in their [styleguide repo](https://github.com/google/styleguide).

--- a/src/lib-sana/Graph/BinaryGraph.hpp
+++ b/src/lib-sana/Graph/BinaryGraph.hpp
@@ -10,7 +10,7 @@ public:
     BinaryGraph(){};
     ~BinaryGraph(){};
 
-    virtual void AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int &weight = 1) throw(GraphInvalidIndexError);
+    virtual void AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int &weight) throw(GraphInvalidIndexError);
     virtual void RemoveEdge(const unsigned int &node1, const unsigned int &node2) throw(GraphInvalidIndexError);
 
     virtual void SetNumNodes(const unsigned int &numNodes);

--- a/src/lib-sana/Graph/Graph.cpp
+++ b/src/lib-sana/Graph/Graph.cpp
@@ -49,17 +49,17 @@ void Graph::RemoveEdge(const unsigned int &node1, const unsigned int &node2) thr
         throw GraphInvalidIndexError("Invalid node index passed into RemoveEdge");
 
     //update adjacency lists
-    for (uint i = 0; i < adjLists[node1].size(); i++) {
+    for (unsigned int i = 0; i < adjLists[node1].size(); i++) {
         if (adjLists[node1][i] == node2) {
-            ushort lastNeighbor = adjLists[node1][adjLists[node1].size()-1];
+            unsigned int lastNeighbor = adjLists[node1][adjLists[node1].size()-1];
             adjLists[node1][i] = lastNeighbor;
             adjLists[node1].pop_back();
             break;
         }
     }
-    for (uint i = 0; i < adjLists[node2].size(); i++) {
+    for (unsigned int i = 0; i < adjLists[node2].size(); i++) {
         if (adjLists[node2][i] == node1) {
-            ushort lastNeighbor = adjLists[node2][adjLists[node2].size()-1];
+            unsigned int lastNeighbor = adjLists[node2][adjLists[node2].size()-1];
             adjLists[node2][i] = lastNeighbor;
             adjLists[node2].pop_back();
             break;

--- a/src/lib-sana/Graph/Graph.hpp
+++ b/src/lib-sana/Graph/Graph.hpp
@@ -30,9 +30,9 @@ public:
     unordered_map<string,ushort> getNodeNameToIndexMap() const;
     unordered_map<ushort,string> getIndexToNodeNameMap() const;
 
-    virtual void AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int &weight = 1) throw(GraphInvalidIndexError) ;
+    virtual void AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int &weight) throw(GraphInvalidIndexError);
     virtual void RemoveEdge(const unsigned int &node1, const unsigned int &node2) throw(GraphInvalidIndexError);
-  
+
     virtual void AddRandomEdge();
     virtual void RemoveRandomEdge();
     virtual int RandomNode();
@@ -50,7 +50,6 @@ public:
     virtual void ClearGraph();
 
 private:
-
     unsigned int numNodes;
     unsigned int numEdges;
     vector<vector<unsigned int> > adjLists;

--- a/src/lib-sana/Graph/WeightedGraph.cpp
+++ b/src/lib-sana/Graph/WeightedGraph.cpp
@@ -1,7 +1,7 @@
 #include "WeightedGraph.hpp"
 
-void WeightedGraph::AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int& weight) throw(GraphInvalidIndexError) {
-    Graph::AddEdge(node1, node2);
+void WeightedGraph::AddEdge(const unsigned int &node1, const unsigned int &node2, const unsigned int& weight = 1) {
+    Graph::AddEdge(node1, node2, weight);
     adjacencyMatrix[node1][node2] = adjacencyMatrix[node2][node1] = weight;
 }
 


### PR DESCRIPTION
There are multiple lines where there is unintentional narrowing of integers. The types are changed to not only fix this issue, but also to increase portability. 

`ushort` or `uint` are not C++ standard and are not guaranteed to work with every C++ compiler.