### PR TITLE
adding /dev/null as lockfile if only lock-same-names is on

### DIFF
--- a/src/arguments/methodSelector.cpp
+++ b/src/arguments/methodSelector.cpp
@@ -151,6 +151,9 @@ Method* initSANA(Graph& G1, Graph& G2, ArgumentParser& args, MeasureCombination&
     if (args.strings["-lock"] != ""){
       sana->setLockFile(args.strings["-lock"] );
     }
+    if(args.bools["-lock-same-names"] && args.strings["-lock"].size()== 0){
+        sana->setLockFile("/dev/null");
+    }
     return sana;
 }
 


### PR DESCRIPTION
Now using `-lock-same-names` will be enough. No need to add `-lock /dev/null` manually in the command line.