### PR TITLE
Working and completing Pareto mode for SANA

### DIFF
--- a/src/arguments/defaultArguments.cpp
+++ b/src/arguments/defaultArguments.cpp
@@ -29,6 +29,6 @@ vector<string> defaultArguments = {
 "-combinedScoreAs sum",
 "-sec 0",
 "-maxGraphletSize 5",
-"-paretoInitial 10",
+"-paretoInitial 3",
 "-paretoCapacity 200"
 };

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -470,13 +470,11 @@ void SANA::initDataStructures(const Alignment& startA) {
     nodesHaveType = G1->hasNodeTypes();
 
     A = new vector<ushort>(startA.getMapping());
-    storedAlignments->insert(A);
 
     assignedNodesG2 = new vector<bool> (n2, false);
     for (uint i = 0; i < n1; i++) {
         (*assignedNodesG2)[(*A)[i]] = true;
     }
-    storedAssignedNodesG2[A] = assignedNodesG2;
     unassignedNodesG2        = new vector<ushort> (n2-n1);
     unassignedgenesG2        = new vector<ushort> ();
     unassignedmiRNAsG2       = new vector<ushort> ();
@@ -497,7 +495,6 @@ void SANA::initDataStructures(const Alignment& startA) {
 	    }
 	}
     }
-    storedUnassignedNodesG2[A] = unassignedNodesG2;
     //  Init unlockedNodesG1
     uint unlockedG1            = n1 - G1->getLockedCount();
     unLockedNodesG1            = vector<ushort> (unlockedG1);
@@ -510,18 +507,15 @@ void SANA::initDataStructures(const Alignment& startA) {
     assert(index == unlockedG1);
 
     if (needAligEdges or needSec) {
-        aligEdges          = startA.numAlignedEdges(*G1, *G2);
-        storedAligEdges[A] = aligEdges;
+        aligEdges = startA.numAlignedEdges(*G1, *G2);
     }
 
     if (needSquaredAligEdges) {
-        squaredAligEdges          = startA.numSquaredAlignedEdges(*G1, *G2);
-        storedSquaredAligEdges[A] = squaredAligEdges;
+        squaredAligEdges = startA.numSquaredAlignedEdges(*G1, *G2);
     }
 
     if (needInducedEdges) {
-        inducedEdges          = G2->numNodeInducedSubgraphEdges(*A);
-        storedInducedEdges[A] = inducedEdges;
+        inducedEdges = G2->numNodeInducedSubgraphEdges(*A);
     }
 
     if (needLocal) {
@@ -529,40 +523,34 @@ void SANA::initDataStructures(const Alignment& startA) {
         for (uint i = 0; i < n1; i++) {
             localScoreSum += sims[i][(*A)[i]];
         }
-        storedLocalScoreSum[A] = localScoreSum;
     }
 
     if (needWec) {
         Measure* wec    = MC->getMeasure("wec");
         double wecScore = wec->eval(*A);
         wecSum          = wecScore*2*g1Edges;
-        storedWecSum[A] = wecSum;
     }
 
     if(needEwec){
-        ewec             = (ExternalWeightedEdgeConservation*)(MC->getMeasure("ewec"));
-        ewecSum          = ewec->eval(*A);
-        storedEwecSum[A] = ewecSum;
+        ewec    = (ExternalWeightedEdgeConservation*)(MC->getMeasure("ewec"));
+        ewecSum = ewec->eval(*A);
     }
 
     if (needNC) {
-        Measure* nc    = MC->getMeasure("nc");
-        ncSum          = (nc->eval(*A))*trueA.back();
-        storedNcSum[A] = ncSum;
+        Measure* nc = MC->getMeasure("nc");
+        ncSum       = (nc->eval(*A))*trueA.back();
     }
 
     if(needTC){
-        Measure* tc = MC->getMeasure("tc");
+        Measure* tc  = MC->getMeasure("tc");
         maxTriangles = ((TriangleCorrectness*)tc)->getMaxTriangles();
-        TCSum = tc->eval(*A);
-        storedTCSum[A] = TCSum;
+        TCSum        = tc->eval(*A);
     }
 
     iterationsPerformed = 0;
     sampledProbability.clear();
 
     currentScore = eval(startA);
-    storedCurrentScore[A] = currentScore;
     timer.start();
 }
 
@@ -656,15 +644,14 @@ unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, d
 
     initDataStructures(startA);
     setInterruptSignal();
-    vector<string> measureNames; vector<double> scores;
-    scoreNamesToIndexes = mapScoresToIndexes(measureNames);
+    vector<double> scores;
+    scoreNamesToIndexes = mapScoresToIndexes();
     paretoFront = ParetoFront(paretoCapacity, numOfMeasures, measureNames);
     score = Score::pareto;
-    for(auto iter = scoreNamesToIndexes.begin(); iter != scoreNamesToIndexes.end(); iter++)
-        cout << iter->first << '\n';
+    initializeParetoFront();
 
     for (; ; ++iter) {
-	//Temperature = temperatureFunction(iter, TInitial, TDecay);
+	Temperature = temperatureFunction(iter, TInitial, TDecay);
 	if (interrupt) {
 	    return storedAlignments;
 	}
@@ -687,15 +674,14 @@ unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, l
 
     initDataStructures(startA);
     setInterruptSignal();
-    vector<string> measureNames; vector<double> scores;
-    scoreNamesToIndexes = mapScoresToIndexes(measureNames);
+    vector<double> scores;
+    scoreNamesToIndexes = mapScoresToIndexes();
     paretoFront = ParetoFront(paretoCapacity, numOfMeasures, measureNames);
     score = Score::pareto;
-    for(auto iter = scoreNamesToIndexes.begin(); iter != scoreNamesToIndexes.end(); ++iter)
-        cout << iter->first << '\n';
+    initializeParetoFront();
 
     for (; ; ++iter) {
-    	//Temperature = temperatureFunction(iter, TInitial, TDecay);
+    	Temperature = temperatureFunction(iter, TInitial, TDecay);
         if (interrupt) {
             return storedAlignments;
         }
@@ -713,19 +699,75 @@ unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, l
     return storedAlignments;
 }
 
-unordered_map<string, int> SANA::mapScoresToIndexes(vector<string> &measureNames) {
-    numOfMeasures = MC->numMeasures();
+unordered_map<string, int> SANA::mapScoresToIndexes() {
+    //numOfMeasures = MC->numMeasures(); Currently, SANA uses arbitrary measures and ignores others (even when defined).
+    numOfMeasures = 8;
+    #ifdef WEIGHTED
+    numOfMeasures = 10;
+    #endif
     measureNames = vector<string>(numOfMeasures);
-    for(int i = 0; i < numOfMeasures; ++i)
-        measureNames[i] = MC->getMeasure(i)->getName();
-    sort(measureNames.begin(), measureNames.end());
+    /*for(int i = 0; i < numOfMeasures; ++i)
+        measureNames[i] = MC->getMeasure(i)->getName();*/
+    //SANA is using these predifined measures:-----------------------------------------------------
+    measureNames[0] = "ec";
+    measureNames[1] = "ics";
+    measureNames[2] = "s3";
+    measureNames[3] = "sec";
+    measureNames[4] = "tc";
+    measureNames[5] = "local";
+    measureNames[6] = "wec";
+    measureNames[7] = "nc";
+    #ifdef WEIGHTED
+    measureNames[8] = "mec";
+    measureNames[9] = "ses";
+    #endif
+    //---------------------------------------------------------------------------------------------
+    sort(measureNames.begin(), measureNames.end()); //Must be sorted to function correctly.
+    measureNames.resize(distance(measureNames.begin(), unique(measureNames.begin(), measureNames.end()))); //Removes any duplicate measure names. Somehow, ICS measure appears twice... a good check to perform.
     unordered_map<string, int> toReturn;
     for(int i = 0; i < numOfMeasures; ++i)
     	toReturn[measureNames[i]] = i;
     return toReturn;
 }
 
+vector<double> SANA::translateScoresToVector() {
+    vector<double> addScores(numOfMeasures);
+    addScores[scoreNamesToIndexes["ec"]] = double(aligEdges) / g1Edges;
+    addScores[scoreNamesToIndexes["s3"]] = double(aligEdges) / (g1Edges + inducedEdges - aligEdges);
+    addScores[scoreNamesToIndexes["ics"]] = double(aligEdges) / inducedEdges;
+    addScores[scoreNamesToIndexes["sec"]] = double(aligEdges) / (g1Edges + aligEdges) / g2Edges * 0.5;
+    addScores[scoreNamesToIndexes["tc"]] = TCSum;
+    addScores[scoreNamesToIndexes["local"]] = double(localScoreSum) / n1;
+    addScores[scoreNamesToIndexes["wec"]] = double(wecSum) / (2 * g1Edges);
+    //addScores[scoreNamesToIndexes["ewec"]] = ewecSum;
+    addScores[scoreNamesToIndexes["nc"]] = double(ncSum) / trueA.back();
+#ifdef WEIGHTED
+    addScores[scoreNamesToIndexes["mec"]] = double(aligEdges) / (g1WeightedEdges + g2WeightedEdges);
+    addScores[scoreNamesToIndexes["ses"]] = squaredAligEdges;
+#endif
+    return addScores;
+}
+
+vector<double> SANA::getMeasureScores(double newAligEdges, double newInducedEdges, double newTCSum, double newLocalScoreSum, double newWecSum, double newNcSum, double newEwecSum, double newSquaredAligEdges) {
+    vector<double> addScores(numOfMeasures);
+    addScores[scoreNamesToIndexes["ec"]] = double(newAligEdges) / g1Edges;
+    addScores[scoreNamesToIndexes["s3"]] = double(newAligEdges) / (g1Edges + newInducedEdges - newAligEdges);
+    addScores[scoreNamesToIndexes["ics"]] = double(newAligEdges) / newInducedEdges;
+    addScores[scoreNamesToIndexes["sec"]] = (double(newAligEdges) / g1Edges + newAligEdges / g2Edges)*0.5;
+    addScores[scoreNamesToIndexes["tc"]] = double(newTCSum);
+    addScores[scoreNamesToIndexes["local"]] = double(newLocalScoreSum) / n1;
+    addScores[scoreNamesToIndexes["wec"]] = double(newWecSum) / (2 * g1Edges);
+    //addScores[scoreNamesToIndexes["ewec"]] = ewecWeight * (newEwecSum);
+    addScores[scoreNamesToIndexes["nc"]] = double(newNcSum) / trueA.back();
+#ifdef WEIGHTED
+    addScores[scoreNamesToIndexes["mec"]] = double(newAligEdges) / (g1WeightedEdges + g2WeightedEdges);
+    addScores[scoreNamesToIndexes["ses"]] = double(newSquaredAligEdges) / SquaredEdgeScore::getDenom();
+#endif	
+    return addScores;
+}
+
 void SANA::prepareMeasureDataByAlignment() {
+    assert(storedAlignments->find(A) != storedAlignments->end() and "Alignment does not exist in the Pareto front.");
     aligEdges        = (needAligEdges or needSec) ?  storedAligEdges[A] : -1;
     squaredAligEdges = (needSquaredAligEdges) ?  storedSquaredAligEdges[A] : -1;
     inducedEdges     = (needInducedEdges) ?  storedInducedEdges[A] : -1;
@@ -734,29 +776,77 @@ void SANA::prepareMeasureDataByAlignment() {
     wecSum           = (needWec) ?  storedWecSum[A] : -1;
     ewecSum          = (needEwec) ?  storedEwecSum[A] : -1;
     ncSum            = (needNC) ? storedNcSum[A] : -1;
-    //currentScore     = storedCurrentScore[A];
+    currentScore     = storedCurrentScore[A];
+
+    currentScores = paretoFront.procureScoresByAlignment(A);
+    currentMeasure = paretoFront.getRandomMeasure();
+
+    assignedNodesG2 = new vector<bool>(*storedAssignedNodesG2[A]);
+    if(!nodesHaveType)
+        unassignedNodesG2 = new vector<ushort>(*storedUnassignedNodesG2[A]);
+    else {
+        unassignedmiRNAsG2 = new vector<ushort>(*storedUnassignedmiRNAsG2[A]);
+        unassignedgenesG2 = new vector<ushort>(*storedUnassignedgenesG2[A]);
+    }
+
+    A = new vector<ushort>(*A);
 }
 
-void SANA::insertCurrentAndPrepareNewMeasureDataByAlignment() {
-	*newA = vector<ushort>(*A);
-	storedAlignments->insert(newA);
+void SANA::insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addScores) {
+    if(!(newA->empty())) //to avoid allocating a new alignment when we don't need to...
+        newA = new vector<ushort>(0);
+    bool inserted = false;
+    vector<vector<ushort>*> toRemove = paretoFront.addAlignmentScores(newA, addScores, inserted);
+    if (inserted) {
+        for (unsigned int i = 0; i < toRemove.size(); i++)
+            removeAlignmentData(toRemove[i]);
+        *newA = vector<ushort>(*A);
+        storedAlignments->insert(newA);
 
-    if(needAligEdges or needSec) storedAligEdges[A]        = aligEdges;
-    if(needSquaredAligEdges)     storedSquaredAligEdges[A] = squaredAligEdges;
-    if(needInducedEdges)         storedInducedEdges[A]     = inducedEdges;
-    if(needTC)                   storedTCSum[A]            = TCSum;
-    if(needLocal)                storedLocalScoreSum[A]    = localScoreSum;
-    if(needWec)                  storedWecSum[A]           = wecSum;
-    if(needEwec)                 storedEwecSum[A]          = ewecSum;
-    if(needNC)                   storedNcSum[A]            = ncSum;
-    ///*------------------------>*/storedCurrentScore[A]     = currentScore;
+        storedAssignedNodesG2[newA] = new vector<bool>(*assignedNodesG2);
+        if(!nodesHaveType)
+            storedUnassignedNodesG2[newA] = new vector<ushort>(*unassignedNodesG2);
+        else {
+            storedUnassignedmiRNAsG2[newA] = new vector<ushort>(*unassignedmiRNAsG2);
+            storedUnassignedgenesG2[newA] = new vector<ushort>(*unassignedgenesG2);
+        }
 
-    A = paretoFront.procureRandomAlignment();
+        if(needAligEdges or needSec) storedAligEdges[newA]        = aligEdges;
+        if(needSquaredAligEdges)     storedSquaredAligEdges[newA] = squaredAligEdges;
+        if(needInducedEdges)         storedInducedEdges[newA]     = inducedEdges;
+        if(needTC)                   storedTCSum[newA]            = TCSum;
+        if(needLocal)                storedLocalScoreSum[newA]    = localScoreSum;
+        if(needWec)                  storedWecSum[newA]           = wecSum;
+        if(needEwec)                 storedEwecSum[newA]          = ewecSum;
+        if(needNC)                   storedNcSum[newA]            = ncSum;
+        /*------------------------>*/storedCurrentScore[newA]     = currentScore;
+    }
+    else
+        delete A;
+    assert(paretoFront.size() == storedAlignments->size() and "Number of elements in paretoFront and storedAlignments don't match.");
+    A = paretoFront.procureRandomAlignment(); //are you allowed to return pointer from paretoFront?
     prepareMeasureDataByAlignment();
 }
 
 void SANA::removeAlignmentData(vector<ushort>* toRemove) {
     storedAlignments->erase(toRemove);
+
+    vector<bool>* removeAssignedNodesG2 = storedAssignedNodesG2[toRemove];
+    storedAssignedNodesG2.erase(toRemove);
+    delete removeAssignedNodesG2;
+    if(!nodesHaveType) {
+        vector<ushort>* removeUnassignedNodesG2 = storedUnassignedNodesG2[toRemove];
+        storedUnassignedNodesG2.erase(toRemove);
+        delete removeUnassignedNodesG2;
+    }
+    else {
+        vector<ushort>* removeUnassignedmiRNAsG2 = storedUnassignedmiRNAsG2[toRemove];
+        vector<ushort>* removeUnassignedgenesG2 = storedUnassignedgenesG2[toRemove];
+        storedUnassignedmiRNAsG2.erase(toRemove);
+        storedUnassignedgenesG2.erase(toRemove);
+        delete removeUnassignedmiRNAsG2;
+        delete removeUnassignedgenesG2;
+    }
 
     if(needAligEdges or needSec) storedAligEdges.erase(toRemove);
     if(needSquaredAligEdges)     storedSquaredAligEdges.erase(toRemove);
@@ -766,7 +856,30 @@ void SANA::removeAlignmentData(vector<ushort>* toRemove) {
     if(needWec)                  storedWecSum.erase(toRemove);
     if(needEwec)                 storedEwecSum.erase(toRemove);
     if(needNC)                   storedNcSum.erase(toRemove);
-    ///*------------------------>*/storedCurrentScore.erase(toRemove);
+    //TAKE CARE OF THE MEMORY LEAK!
+    delete toRemove;
+}
+
+void SANA::initializeParetoFront() {
+    vector<double> addScores = translateScoresToVector();
+    insertCurrentAndPrepareNewMeasureDataByAlignment(addScores);
+    cout << "Initializing " << paretoInitial << " random alignments." << endl;
+    cout << "Current size:";
+    while(paretoFront.size() < paretoInitial) {
+        cout << paretoFront.size() << ", ";
+        Alignment newAlig = getStartingAlignment();
+        initDataStructures(newAlig); //<-----Somehow fix this memory leak! (Caused by paretoFront code).
+        addScores = translateScoresToVector();
+        insertCurrentAndPrepareNewMeasureDataByAlignment(addScores);
+    }
+    cout << paretoFront.size() << endl;
+}
+
+bool SANA::dominates(vector<double> &left, vector<double> &right) {
+    for(unsigned int i = 0; i < left.size(); i++)
+        if(left[i] < right[i])
+            return false;
+    return true;
 }
 
 void SANA::SANAIteration() {
@@ -851,8 +964,6 @@ void SANA::performChange(int type) {
         ncSum                                = newNcSum;
         if (needLocal)
             (*localScoreSumMap) = newLocalScoreSumMap;
-        if(score == Score::pareto and ((iterationsPerformed % 512) == 0)) //maybe create a boolean for pareto mode to avoid string comparison.
-        	insertCurrentAndPrepareNewMeasureDataByAlignment();
 #if 0
         if(randomReal(gen)<=1) {
         double foo = eval(*A);
@@ -865,6 +976,12 @@ void SANA::performChange(int type) {
 #endif
         currentScore     = newCurrentScore;
         squaredAligEdges = newSquaredAligEdges;
+    }
+    if(score == Score::pareto and ((iterationsPerformed % 10000) == 0)) {
+        /*vector<double> addScores = getMeasureScores(aligEdges, inducedEdges, TCSum, localScoreSum,
+                                                    wecSum, ncSum, ewecSum, squaredAligEdges);*/
+        vector<double> addScores = translateScoresToVector();
+        insertCurrentAndPrepareNewMeasureDataByAlignment(addScores);
     }
 #ifdef CORES
     // Statistics on the emerging core alignment.
@@ -913,9 +1030,6 @@ void SANA::performSwap(int type) {
         squaredAligEdges    = newSquaredAligEdges;
         if (needLocal)
             (*localScoreSumMap) = newLocalScoreSumMap;
-        if (score == Score::pareto and (iterationsPerformed % 512 == 0)) //maybe create a boolean for pareto mode to avoid string comparison.
-            insertCurrentAndPrepareNewMeasureDataByAlignment();
-
 #if 0
         if (randomReal(gen) <= 1) {
             double foo = eval(*A);
@@ -926,6 +1040,12 @@ void SANA::performSwap(int type) {
             else cout << "s";
         }
 #endif
+    }
+    if(score == Score::pareto and ((iterationsPerformed % 10000) == 0)) {
+        /*vector<double> addScores = getMeasureScores(aligEdges, inducedEdges, TCSum, localScoreSum,
+                                                    wecSum, ncSum, ewecSum, squaredAligEdges);*/
+        vector<double> addScores = translateScoresToVector();
+        insertCurrentAndPrepareNewMeasureDataByAlignment(addScores);
     }
 #ifdef CORES
     // Statistics on the emerging core alignment.
@@ -1084,49 +1204,47 @@ bool SANA::scoreComparison(double newAligEdges, double newInducedEdges, double n
         makeChange = maxScore >= -1 * minScore or randomReal(gen) <= exp(energyInc / Temperature);
         break;
     }
-    case Score::pareto: //Short circuit return to let the pareto front decide
-    {
-        if ((iterationsPerformed % 512 != 0))
-            return true;
-        vector<double> addScores(numOfMeasures);  //what alignments to keep instead of simulated annealing.
-        addScores[scoreNamesToIndexes["ec"]] = (1.0*newAligEdges / g1Edges);
-        addScores[scoreNamesToIndexes["s3"]] = (1.0*newAligEdges / (g1Edges + newInducedEdges - newAligEdges));
-        addScores[scoreNamesToIndexes["ics"]] = (1.0*newAligEdges / newInducedEdges);
-        addScores[scoreNamesToIndexes["sec"]] = (1.0*newAligEdges / g1Edges + newAligEdges / g2Edges)*0.5;
-        addScores[scoreNamesToIndexes["tc"]] = (1.0*newTCSum);
-        addScores[scoreNamesToIndexes["local"]] = (1.0*newLocalScoreSum / n1);
-        addScores[scoreNamesToIndexes["wec"]] = (1.0*newWecSum / (2 * g1Edges));
-        //addScores[scoreNamesToIndexes["ewec"]] = ewecWeight * (newEwecSum);
-        addScores[scoreNamesToIndexes["nc"]] = (1.0*newNcSum / trueA.back());
-#ifdef WEIGHTED
-        addScores[scoreNamesToIndexes["mec"]] += (1.0*newAligEdges / (g1WeightedEdges + g2WeightedEdges));
-        addScores[scoreNamesToIndexes["ses"]] += 1.0*newSquaredAligEdges/SquaredEdgeScore::getDenom();
-#endif
-        /*cout << "aligEdges: " << newAligEdges << endl;
-        cout << "g1Edges: " << g1Edges << endl;
-        cout << "newInducedEdges: " << newInducedEdges << endl;
-        cout << "g2Edges: " << g2Edges << endl;
-        cout << "newTCSum: " << newTCSum << endl;
-        cout << "newLocalScoreSum: " << newLocalScoreSum << endl;
-        cout << "n1: " << n1 << endl;
-        cout << "newWecSum: " << newWecSum << endl;
-        cout << "newNcSum: " << newNcSum << endl;
-        cout << "trueA_back: " << trueA.back() << endl;
-#ifdef WEIGHTED
-        cout << "g1WeightedEdges: " << g1WeightedEdges << endl;
-        cout << "g2WeightedEdges: " << g2WeightedEdges << endl;
-        cout << "newSquaredAligEdges: " << newSquaredAligEdges << endl;
-#endif*/
-        newA = new vector<ushort>(0);
-        vector<vector<ushort>*> toRemove = paretoFront.addAlignmentScores(newA, addScores, makeChange);
-        if (makeChange) {
-            for (unsigned int i = 0; i < toRemove.size(); ++i)
-                removeAlignmentData(toRemove[i]);
+    case Score::pareto:
+    { //This determines whether we should update the current alignment.
+        vector<double> addScores = getMeasureScores(newAligEdges, newInducedEdges, newTCSum, newLocalScoreSum, newWecSum, newNcSum, newEwecSum, newSquaredAligEdges);
+        if(dominates(addScores, currentScores))
+        {
+            currentScores = addScores;
+            makeChange = true;
+            newCurrentScore = 0;
+            newCurrentScore += ecWeight * (newAligEdges / g1Edges);
+            newCurrentScore += s3Weight * (newAligEdges / (g1Edges + newInducedEdges - newAligEdges));
+            newCurrentScore += icsWeight * (newAligEdges / newInducedEdges);
+            newCurrentScore += TCWeight * (newTCSum);
+            newCurrentScore += localWeight * (newLocalScoreSum / n1);
+            newCurrentScore += secWeight * (newAligEdges / g1Edges + newAligEdges / g2Edges)*0.5;
+            newCurrentScore += wecWeight * (newWecSum / (2 * g1Edges));
+            newCurrentScore += ncWeight * (newNcSum / trueA.back());
         }
-        //std::cout << "ParetoFront:\n";
-        //paretoFront.printAlignmentScores(cout);
-        //cin.get();
-        return makeChange;
+        else
+        {
+            /*energyInc = newCurrentScore - currentScore;
+            wasBadMove = energyInc < 0;
+            badProbability = exp(energyInc / T);
+            makeChange = (energyInc >= 0 or randomReal(gen) <= exp(energyInc / T));
+            if(makeChange)
+                currentScores = addScores;*/
+            newCurrentScore = 0;
+            newCurrentScore += ecWeight * (newAligEdges / g1Edges);
+            newCurrentScore += s3Weight * (newAligEdges / (g1Edges + newInducedEdges - newAligEdges));
+            newCurrentScore += icsWeight * (newAligEdges / newInducedEdges);
+            newCurrentScore += TCWeight * (newTCSum);
+            newCurrentScore += localWeight * (newLocalScoreSum / n1);
+            newCurrentScore += secWeight * (newAligEdges / g1Edges + newAligEdges / g2Edges)*0.5;
+            newCurrentScore += wecWeight * (newWecSum / (2 * g1Edges));
+            newCurrentScore += ncWeight * (newNcSum / trueA.back());
+            energyInc = newCurrentScore - currentScore;
+            wasBadMove = energyInc < 0;
+            badProbability = exp(energyInc / Temperature);
+            makeChange = (addScores[currentMeasure] > currentScores[currentMeasure] || energyInc >= 0 or
+ randomReal(gen) <= exp(energyInc / Temperature));
+            if(makeChange) currentScores = addScores;
+        }
         break;
     }
     }

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -1313,7 +1313,7 @@ static int _edgeVal;
 // between the value of this ladder and the ladder with one edge added or removed.  Mathematically
 // it should be edgeVal^2 - (edgeVal+1)^2 which is (2e + 1), but for some reason I had to make
 // it 2*(e+1).  That seemed to work better.  So yeah... big ugly hack.
-#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, j)), 2*((_edgeVal<1000?_edgeVal:0) + 1))
+#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, (*A)[j])), 2*((_edgeVal<1000?_edgeVal:0) + 1))
 int SANA::squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
     int res = 0, diff;
     ushort neighbor;
@@ -1359,7 +1359,7 @@ int SANA::squaredAligEdgesIncSwapOp(ushort source1, ushort source2, ushort targe
     // address case swapping between adjacent nodes with adjacent images:
     if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2))
     {
-        res += 2 * SQRDIFF(target1,target2);
+        res += 2 * SQRDIFF(target1,source2);
     }
     return res;
 }

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -825,6 +825,7 @@ void SANA::insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addS
         delete A;
     assert(paretoFront.size() == storedAlignments->size() and "Number of elements in paretoFront and storedAlignments don't match.");
     A = paretoFront.procureRandomAlignment(); //are you allowed to return pointer from paretoFront?
+    assert(storedAlignments->find(A) != storedAlignments->end() && "There exists an alignment in the Pareto front which does not exist inside storedAlignments");
     prepareMeasureDataByAlignment();
 }
 
@@ -1304,7 +1305,7 @@ static int _edgeVal;
 // between the value of this ladder and the ladder with one edge added or removed.  Mathematically
 // it should be edgeVal^2 - (edgeVal+1)^2 which is (2e + 1), but for some reason I had to make
 // it 2*(e+1).  That seemed to work better.  So yeah... big ugly hack.
-#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, (*A)[j])), 2*((_edgeVal<1000?_edgeVal:0) + 1))
+#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, j)), 2*((_edgeVal<1000?_edgeVal:0) + 1))
 int SANA::squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
     int res = 0, diff;
     ushort neighbor;

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -183,8 +183,8 @@ private:
     Score score;
 
     //For pareto mode
-    int paretoInitial;
-    int paretoCapacity;
+    unsigned int paretoInitial;
+    unsigned int paretoCapacity;
 
     //restart scheme
     bool restart;
@@ -315,17 +315,32 @@ private:
 
 
     //Mostly for pareto front, to hold multiple alignments and scores
-    unordered_map<string, int> mapScoresToIndexes(vector<string> &measureNames);
+    unordered_map<string, int> mapScoresToIndexes();
     void prepareMeasureDataByAlignment();
-    void insertCurrentAndPrepareNewMeasureDataByAlignment();
+    void insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addScores);
+    vector<double> translateScoresToVector();
+    void initializeParetoFront();
     void removeAlignmentData(vector<ushort>* toRemove);
+    vector<double> getMeasureScores(double newAligEdges, double newInducedEdges, double newTCSum,
+                                     double newLocalScoreSum, double newWecSum, double newNcSum,
+                                     double newEwecSum, double newSquaredAligEdges);
+    bool dominates(vector<double> &left, vector<double> &right);
     int numOfMeasures;
+    vector<string> measureNames;
+    int currentMeasure;
+    vector<double> currentScores;
     ParetoFront paretoFront;
-    vector<ushort>* newA;
+    vector<ushort>* newA = new vector<ushort>(0);
+    vector<bool>* newAN = new vector<bool>(0);
+    vector<ushort>* newUAN = new vector<ushort>(0);
+    vector<ushort>* newUmiRNA = new vector<ushort>(0);
+    vector<ushort>* newUG = new vector<ushort>(0);
     unordered_map<string, int> scoreNamesToIndexes;
     unordered_set<vector<ushort>*>* storedAlignments = new unordered_set<vector<ushort>*>;
     unordered_map<vector<ushort>*, vector<bool>*> storedAssignedNodesG2;
     unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedNodesG2;
+    unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedmiRNAsG2;
+    unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedgenesG2;
     unordered_map<vector<ushort>*, int> storedAligEdges;
     unordered_map<vector<ushort>*, int> storedSquaredAligEdges;
     unordered_map<vector<ushort>*, int> storedInducedEdges;

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -319,8 +319,9 @@ private:
     void prepareMeasureDataByAlignment();
     void insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addScores);
     vector<double> translateScoresToVector();
-    void initializeParetoFront();
+    void insertCurrentAlignmentAndData();
     void removeAlignmentData(vector<ushort>* toRemove);
+    void initializeParetoFront();
     vector<double> getMeasureScores(double newAligEdges, double newInducedEdges, double newTCSum,
                                      double newLocalScoreSum, double newWecSum, double newNcSum,
                                      double newEwecSum, double newSquaredAligEdges);
@@ -330,7 +331,6 @@ private:
     int currentMeasure;
     vector<double> currentScores;
     ParetoFront paretoFront;
-    vector<ushort>* newA = new vector<ushort>(0);
     vector<bool>* newAN = new vector<bool>(0);
     vector<ushort>* newUAN = new vector<ushort>(0);
     vector<ushort>* newUmiRNA = new vector<ushort>(0);

--- a/src/modes/ParetoMode.cpp
+++ b/src/modes/ParetoMode.cpp
@@ -22,7 +22,7 @@ void ParetoMode::run(ArgumentParser& args) {
     method = initMethod(G1, G2, args, M);
     vector<Alignment> B = runParetoMode(method, &G1, &G2);
     cout << "Size: " << B.size() << endl;
-    for(int i = 0; i < B.size(); i++) {
+    for(unsigned int i = 0; i < B.size(); i++) {
 	cout << "Iteration: " << i << endl;
         Alignment A = Alignment(B[i]);
         cout << "One" << endl; 

--- a/src/modes/ParetoMode.cpp
+++ b/src/modes/ParetoMode.cpp
@@ -20,16 +20,25 @@ void ParetoMode::run(ArgumentParser& args) {
     initMeasures(M, G1, G2, args);
     Method* method;
     method = initMethod(G1, G2, args, M);
-    //Alignment A = method->runAndPrintTime();
-    vector<Alignment> *B = runParetoMode(method, &G1, &G2);
-    Alignment A = Alignment((*B)[0]);
-    //Alignment A = method->run();
+    vector<Alignment> B = runParetoMode(method, &G1, &G2);
+    cout << "Size: " << B.size() << endl;
+    for(int i = 0; i < B.size(); i++) {
+	cout << "Iteration: " << i << endl;
+        Alignment A = Alignment(B[i]);
+        cout << "One" << endl; 
 
-    A.printDefinitionErrors(G1,G2);
-    assert(A.isCorrectlyDefined(G1, G2) and "Resulting alignment is not correctly defined");
+        A.printDefinitionErrors(G1,G2);
+        cout << "Two" << endl; 
+        assert(A.isCorrectlyDefined(G1, G2) and "Resulting alignment is not correctly defined");
+        cout << "Three" << endl; 
 
-    saveReport(G1, G2, A, M, method, args.strings["-o"]);
-    saveLocalMeasures(G1, G2, A, M, method, args.strings["-localScoresFile"]);
+        string reportName = args.strings["-o"] + "_" + to_string(i);
+        saveReport(G1, G2, A, M, method, reportName);
+        cout << "Four" << endl;
+        string localMeasuresFileName = args.strings["-localScoresFile"] + "_" + to_string(i);
+        saveLocalMeasures(G1, G2, A, M, method, localMeasuresFileName);
+        cout << "Five" << endl;
+    }
     delete method;
 }
 
@@ -60,13 +69,16 @@ void ParetoMode::setArgsForParetoMode(ArgumentParser& args) {
     args.strings["-method"] = "sana";
 }
 
-vector<Alignment>* ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2) {
+vector<Alignment> ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2) {
     cout << "Start execution of " << method->getName() << " in Pareto Mode." << endl;
     Timer T;
     T.start();
     //Method* METHOD = new SANA;
     //static_cast<SANA*>(METHOD)->derived_int;
-    //unordered_set<vector<unsigned short>*> *A = static_cast<SANA*>(method)->paretoRun();
+    unordered_set<vector<unsigned short>*> *A = static_cast<SANA*>(method)->paretoRun();
+    vector<Alignment> alignments;
+    for(auto i = A->begin(); i != A->end(); i++)
+        alignments.push_back( Alignment(**i) );
     //A->push_back(method->paretoRun());
     T.elapsed();
     cout << "Executed " << method->getName() << " in " << T.elapsedString() << endl;
@@ -75,17 +87,17 @@ vector<Alignment>* ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G
 
     // Needs to be reimplemented with unordered_set<vector<unsigned short>>*
     
-    /*if(G1->hasNodeTypes()){
+    if(G1->hasNodeTypes()){
         G1->reIndexGraph(method->getReverseMap(G1->getNodeTypes_ReIndexMap()));
-        (*A)[0].reIndexAfter_Iterations(G1->getNodeTypes_ReIndexMap());
+        alignments[0].reIndexAfter_Iterations(G1->getNodeTypes_ReIndexMap());
     }
     // if locking is enabled but hasnodeType is not
     else if(G1->getLockedCount() > 0){
          G1->reIndexGraph(method->getReverseMap(G1->getLocking_ReIndexMap()));
-          (*A)[0].reIndexAfter_Iterations(G1->getLocking_ReIndexMap());
+          alignments[0].reIndexAfter_Iterations(G1->getLocking_ReIndexMap());
     }
-    method->checkLockingBeforeReport((*A)[0]);
-    method->checkLockingBeforeReport((*A)[0]);*/
-    return new vector<Alignment>;
+    method->checkLockingBeforeReport(alignments[0]);
+    method->checkLockingBeforeReport(alignments[0]);
+    return alignments;
 }
     

--- a/src/modes/ParetoMode.cpp
+++ b/src/modes/ParetoMode.cpp
@@ -20,24 +20,19 @@ void ParetoMode::run(ArgumentParser& args) {
     initMeasures(M, G1, G2, args);
     Method* method;
     method = initMethod(G1, G2, args, M);
-    vector<Alignment> B = runParetoMode(method, &G1, &G2);
-    cout << "Size: " << B.size() << endl;
-    for(unsigned int i = 0; i < B.size(); i++) {
-	cout << "Iteration: " << i << endl;
-        Alignment A = Alignment(B[i]);
-        cout << "One" << endl; 
+    vector<Alignment> alignments = runParetoMode(method, &G1, &G2);
+    printAlignments(alignments);
+    printEdgeLists(&G1, &G2, alignments);
+    for(unsigned int i = 0; i < alignments.size(); i++) {
+        Alignment A = Alignment(alignments[i]);
 
         A.printDefinitionErrors(G1,G2);
-        cout << "Two" << endl; 
         assert(A.isCorrectlyDefined(G1, G2) and "Resulting alignment is not correctly defined");
-        cout << "Three" << endl; 
 
-        string reportName = args.strings["-o"] + "_" + to_string(i);
+        string reportName = args.strings["-o"] + "_pareto_" + to_string(i);
         saveReport(G1, G2, A, M, method, reportName);
-        cout << "Four" << endl;
-        string localMeasuresFileName = args.strings["-localScoresFile"] + "_" + to_string(i);
+        string localMeasuresFileName = args.strings["-localScoresFile"] + "_pareto_" + to_string(i);
         saveLocalMeasures(G1, G2, A, M, method, localMeasuresFileName);
-        cout << "Five" << endl;
     }
     delete method;
 }
@@ -73,13 +68,12 @@ vector<Alignment> ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2
     cout << "Start execution of " << method->getName() << " in Pareto Mode." << endl;
     Timer T;
     T.start();
-    //Method* METHOD = new SANA;
-    //static_cast<SANA*>(METHOD)->derived_int;
     unordered_set<vector<unsigned short>*> *A = static_cast<SANA*>(method)->paretoRun();
+    
     vector<Alignment> alignments;
     for(auto i = A->begin(); i != A->end(); i++)
         alignments.push_back( Alignment(**i) );
-    //A->push_back(method->paretoRun());
+    
     T.elapsed();
     cout << "Executed " << method->getName() << " in " << T.elapsedString() << endl;
 
@@ -87,17 +81,47 @@ vector<Alignment> ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2
 
     // Needs to be reimplemented with unordered_set<vector<unsigned short>>*
     
-    if(G1->hasNodeTypes()){
-        G1->reIndexGraph(method->getReverseMap(G1->getNodeTypes_ReIndexMap()));
-        alignments[0].reIndexAfter_Iterations(G1->getNodeTypes_ReIndexMap());
+    for(unsigned int i = 0; i < alignments.size(); i++) {
+        if(G1->hasNodeTypes()){
+            G1->reIndexGraph(method->getReverseMap(G1->getNodeTypes_ReIndexMap()));
+            alignments[i].reIndexAfter_Iterations(G1->getNodeTypes_ReIndexMap());
+        }
+        // if locking is enabled but hasnodeType is not
+        else if(G1->getLockedCount() > 0){
+            G1->reIndexGraph(method->getReverseMap(G1->getLocking_ReIndexMap()));
+            alignments[i].reIndexAfter_Iterations(G1->getLocking_ReIndexMap());
+        }
+        method->checkLockingBeforeReport(alignments[i]);
+        method->checkLockingBeforeReport(alignments[i]);
     }
-    // if locking is enabled but hasnodeType is not
-    else if(G1->getLockedCount() > 0){
-         G1->reIndexGraph(method->getReverseMap(G1->getLocking_ReIndexMap()));
-          alignments[0].reIndexAfter_Iterations(G1->getLocking_ReIndexMap());
-    }
-    method->checkLockingBeforeReport(alignments[0]);
-    method->checkLockingBeforeReport(alignments[0]);
     return alignments;
 }
-    
+
+void ParetoMode::printAlignments(vector<Alignment>& alignments) {
+    ofstream output("sana.out");
+    for(unsigned int j = 0; j < alignments[0].size(); j++) {
+        for(unsigned int i = 0; i < alignments.size(); i++) {
+            output << alignments[i][j];
+            if(i < alignments.size()-1)
+                output << '\t';
+        }
+        if(j < alignments[0].size() - 1)
+            output << endl;
+    }
+    output.close();
+}
+
+typedef unordered_map<ushort,string> NodeIndexMap;
+void ParetoMode::printEdgeLists(Graph* G1, Graph* G2, vector<Alignment>& alignments) {
+    NodeIndexMap mapG1 = G1->getIndexToNodeNameMap();
+    NodeIndexMap mapG2 = G2->getIndexToNodeNameMap();
+    ofstream edgeListStream("sana.align");
+    for (unsigned int j = 0; j < alignments[0].size(); j++) {
+        edgeListStream << mapG1[j];
+        for(unsigned int i = 0; i < alignments.size(); i++)
+            edgeListStream << "\t" << mapG2[alignments[i][j]];
+        if(j < alignments[0].size() - 1)
+            edgeListStream << endl;
+    }
+    edgeListStream.close();
+}

--- a/src/modes/ParetoMode.hpp
+++ b/src/modes/ParetoMode.hpp
@@ -15,7 +15,7 @@ public:
 
     static void createFolders();
     void setArgsForParetoMode(ArgumentParser& args);
-    vector<Alignment>* runParetoMode(Method *M, Graph *G1, Graph *G2);
+    vector<Alignment> runParetoMode(Method *M, Graph *G1, Graph *G2);
 };
 
 #endif /* PARETOMODE_HPP_ */

--- a/src/modes/ParetoMode.hpp
+++ b/src/modes/ParetoMode.hpp
@@ -16,6 +16,8 @@ public:
     static void createFolders();
     void setArgsForParetoMode(ArgumentParser& args);
     vector<Alignment> runParetoMode(Method *M, Graph *G1, Graph *G2);
+    void printAlignments(vector<Alignment>& alignments);
+    void printEdgeLists(Graph* G1, Graph* G2, vector<Alignment>& alignments);
 };
 
 #endif /* PARETOMODE_HPP_ */

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -105,13 +105,16 @@ void saveReport(const Graph& G1, Graph& G2, const Alignment& A,
   ofstream outfile,
            alignfile;
   reportFileName = ensureFileNameExistsAndOpenOutFile("report", reportFileName, outfile, G1.getName(), G2.getName(), method, A);
-  alignfile.open((reportFileName.substr(0,reportFileName.length()-4) + ".align").c_str());
 
-  A.write(outfile);
-  A.writeEdgeList(&G1, &G2, alignfile);
+  if(!reportFileName.find("_pareto_")) {
+    alignfile.open((reportFileName.substr(0,reportFileName.length()-4) + ".align").c_str());
+    A.write(outfile);
+    A.writeEdgeList(&G1, &G2, alignfile);
+  }
   makeReport(G1, G2, A, M, method, outfile, multiPairwiseIteration);
   outfile.close();
-  alignfile.close();
+  if(!reportFileName.find("_pareto_"))
+    alignfile.close();
   cout << "Took " << T.elapsed() << " seconds to save the alignment and scores." << endl;
 }
 

--- a/src/utils/ParetoFront.cpp
+++ b/src/utils/ParetoFront.cpp
@@ -55,15 +55,19 @@ alignmentPtr ParetoFront::removeAlignment(alignmentPtr alignmentPosition, vector
     return alignmentPosition;
 }
 
-alignmentPtr ParetoFront::removeRandom()
+alignmentPtr ParetoFront::removeRandom(alignmentPtr dontRemove)
 {
-    bool test = true;
+    bool test;
     singleValueIterator iter;
     do {
-        unsigned int iterate = rand() % (capacity - 1) + 1;
         test = false;
+        unsigned int iterate = rand() % capacity;
         iter = paretoFront[0].begin();
         advance(iter, iterate);
+        if(iter->second == dontRemove) {
+            test = true;
+            continue;
+        }
         for(unsigned int i = 1; i < numberOfMeasures; i++) {
             if(iter == paretoFront[i].begin()) {
                 test = true;
@@ -160,9 +164,7 @@ vector<alignmentPtr> ParetoFront::tryToInsertAlignmentScore(alignmentPtr algmtPt
     if(currentSize < capacity)
         currentSize++;
     else
-        toReturn.push_back(removeRandom());
-    //if(toReturn.size() == 0)
-        //toReturn.push_back(NULL);
+        toReturn.push_back(removeRandom(algmtPtr));
     return toReturn;
 }
 
@@ -180,15 +182,12 @@ vector<alignmentPtr> ParetoFront::insertDominatingAlignmentScore(alignmentPtr al
             minDistanceIndexFromEnd = i;
         }
     }
-    //findScoresByAlignment[iterators[0]->second] = vector<double>(newScores);
     findScoresByAlignment[algmtPtr] = vector<double>(newScores);
     vector<alignmentPtr> toReturn = removeNewlyDominiated(iterators[minDistanceIndexFromEnd], minDistanceIndexFromEnd, newScores);
     if(currentSize < capacity)
         currentSize++;
     else
-        toReturn.push_back(removeRandom());
-    //if(toReturn.size() == 0)
-        //toReturn.push_back(NULL);
+        toReturn.push_back(removeRandom(algmtPtr));
     return toReturn;
 }
 
@@ -245,13 +244,13 @@ ostream& ParetoFront::printParetoFront(ostream &os)
 ostream& ParetoFront::printAlignmentScores(ostream &os)
 {
     unsigned int i = 0;
-    //os << findScoresByAlignment.size() << ' ' << paretoFront[0].size() << ' ' << currentSize << '\n';
+    os << "Pareto Front size: " << currentSize << ", " << "The Pareto Front scores are as follows: \n";
     for(unsigned int j = 0; j < numberOfMeasures; j++) {
         if(measureNames[j].size() <= 10)
-            cout << setw(10) << right << measureNames[j] << ' ';
+            os << setw(10) << right << measureNames[j] << ' ';
         else
-            cout << setw(10) << right << measureNames[j].substr(0, 10) << ' ';
-    } cout << '\n';
+            os << setw(10) << right << measureNames[j].substr(0, 10) << ' ';
+    } os << '\n';
     for(auto iter = findScoresByAlignment.begin(); iter != findScoresByAlignment.end(); iter++)
     {
         for(unsigned int j = 0; j < numberOfMeasures; j++) {

--- a/src/utils/ParetoFront.hpp
+++ b/src/utils/ParetoFront.hpp
@@ -2,6 +2,7 @@
 #define PARETOFRONT_HPP
 
 #include <iostream>
+#include <iomanip>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -9,6 +10,7 @@
 #include <time.h>
 #include <algorithm>
 #include <fstream>
+#include <cassert>
 
 using namespace std;
 
@@ -39,8 +41,8 @@ class ParetoFront {
         vector<alignmentPtr> emptyVector();
             
         vector<alignmentPtr> removeNewlyDominiated(singleValueIterator &iterIN, unsigned int i, vector<double>& newScores);
-        vector<alignmentPtr> tryToInsertAlignmentScore(alignmentPtr algmtPtr, vector<double> &newScores, bool decision);
-        vector<alignmentPtr> insertDominatingAlignmentScore(alignmentPtr algmtPtr, vector<double> &newScores, bool decision);
+        vector<alignmentPtr> tryToInsertAlignmentScore(alignmentPtr algmtPtr, vector<double> &newScores, bool &decision);
+        vector<alignmentPtr> insertDominatingAlignmentScore(alignmentPtr algmtPtr, vector<double> &newScores, bool &decision);
         vector<alignmentPtr> insertAlignmentScore(alignmentPtr algmtPtr, vector<double> &newScores);
     public:
         ParetoFront() {}
@@ -64,14 +66,16 @@ class ParetoFront {
             return *this;
         }
 
-        const vector<double>& procureScoresByAlignment(alignmentPtr) const;
+        vector<double> procureScoresByAlignment(alignmentPtr) const;
         alignmentPtr procureRandomAlignment() const;
-        vector<alignmentPtr> addAlignmentScores(alignmentPtr algmtPtr, vector<double> &newScores, bool decision);
+        vector<alignmentPtr> addAlignmentScores(alignmentPtr algmtPtr, vector<double> &newScores, bool &decision);
 
         //ostream& printAllScoresByMeasures(ostream &os);
         //ostream& printAllParetoContainerNames(ostream &os);
         //ostream& printAllScoresByAlignments(ostream &os);
         ostream& printParetoFront(ostream &os);
         ostream& printAlignmentScores(ostream &os);
+        unsigned int size();
+        int getRandomMeasure();
 };
 #endif

--- a/src/utils/ParetoFront.hpp
+++ b/src/utils/ParetoFront.hpp
@@ -37,7 +37,7 @@ class ParetoFront {
         bool initialPass(vector<double> &newScores);
             
         alignmentPtr removeAlignment(alignmentPtr alignmentPosition, vector<double> &scores);
-        alignmentPtr removeRandom();
+        alignmentPtr removeRandom(alignmentPtr dontRemove);
         vector<alignmentPtr> emptyVector();
             
         vector<alignmentPtr> removeNewlyDominiated(singleValueIterator &iterIN, unsigned int i, vector<double>& newScores);


### PR DESCRIPTION
Upon pulling this into the repo, you will be able to execute the command such as:

./sana -g1 yeast -g2 human -mode pareto

and be able to witness pareto mode in action.

Pareto mode gives Sana the ability to hold multiple alignments, each alignment's existence is dictated by  it's scores and ability to be inserted into the Pareto front. An alignment can exist in, or be inserted into, the Pareto front if there's no other Alignment, also residing in the Pareto front, whose scores are higher in every measure.

Currently, for the simulated annealing, the energy function to decide to accept a change or swap in the network for a particular alignment is calculated as a sum across all measures, since it currently gives the best results. However, this may need to be changed in the future for something more suitable, for instance, something more relevant toward the Pareto front.