### PR TITLE
Change ushort to uint. Change back matrix interface. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = g++
 
 #CXXFLAGS = -I "src/utils" -Wall -fno-inline -O2 -std=c++11 -g3
 #CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 -DWEIGHTED #-pg -ggdb -Bstatic #-static 
-CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 -DSPARSE #-DWEIGHTED -DCORES -ggdb #-pg
+CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 #-DSPARSE #-DWEIGHTED -DCORES -ggdb #-pg
 
 INCLUDES =
 LFLAGS =

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = g++
 
 #CXXFLAGS = -I "src/utils" -Wall -fno-inline -O2 -std=c++11 -g3
 #CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 -DWEIGHTED #-pg -ggdb -Bstatic #-static 
-CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 #-DWEIGHTED -DCORES -ggdb #-pg
+CXXFLAGS = -I "src/utils" -U__STRICT_ANSI__ -Wall -std=c++11 -O3 -DSPARSE #-DWEIGHTED -DCORES -ggdb #-pg
 
 INCLUDES =
 LFLAGS =
@@ -17,7 +17,8 @@ UTILS_SRC = 								\
 	src/utils/SkipList.cpp						\
 	src/utils/SeedMatrix.cpp					\
 	src/utils/LinearRegression.cpp					\
-	src/utils/ParetoFront.cpp
+	src/utils/ParetoFront.cpp                                       \
+        src/utils/Matrix.cpp                                            
 
 ARGUMENTS_SRC = 							\
 	src/arguments/ArgumentParser.cpp				\

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -236,7 +236,7 @@ uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
     uint count = 0;
     for (const auto& edge: G1EdgeList) {
         uint node1 = edge[0], node2 = edge[1];
-        count += G2Matrix.get(A[node1], A[node2]);
+        count += G2Matrix[A[node1]][A[node2]];
     }
     return count;
 }
@@ -263,7 +263,7 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     for (const auto& edge: G1EdgeList) {
         uint hole1 = A[edge[0]];
         uint hole2 = A[edge[1]];
-        G2Matrix.set(G2Matrix.get(hole1, hole2) + 1, hole1, hole2);
+        G2Matrix[hole1][hole2] += 1;
     }
 #endif
 
@@ -271,7 +271,7 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     uint n2 = G2.getNumNodes(); 
     for(uint i = 0; i < n2; i++){
         for(uint j = 0; j < i; j++){
-            int rungs  = G2Matrix.get(i, j);
+            int rungs  = G2Matrix[i][j];
             count += rungs * rungs;
         }
     }
@@ -291,7 +291,7 @@ Graph Alignment::commonSubgraph(const Graph& G1, const Graph& G2) const {
     vector<vector<uint> > edgeList(0);
     for (const auto& edge: G1EdgeList) {
         uint node1 = edge[0], node2 = edge[1];
-        if (G2Matrix.get(A[node1], A[node2])) {
+        if (G2Matrix[A[node1]][A[node2]]) {
             edgeList.push_back(edge);
         }
     }

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -230,7 +230,7 @@ void Alignment::writeEdgeList(Graph const * G1, Graph const * G2, ostream& edgeL
 uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
     G2.getMatrix(G2Matrix);
 
     uint count = 0;
@@ -244,7 +244,7 @@ uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
 int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
     G2.getMatrix(G2Matrix);
 
 #if 0
@@ -283,7 +283,7 @@ Graph Alignment::commonSubgraph(const Graph& G1, const Graph& G2) const {
 
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
 
     G2.getMatrix(G2Matrix);
 

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -230,17 +230,13 @@ void Alignment::writeEdgeList(Graph const * G1, Graph const * G2, ostream& edgeL
 uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<ushort> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-#ifdef WEIGHTED
-        vector<vector<ushort> > G2AdjMatrix;
-#else
-    vector<vector<bool> > G2AdjMatrix;
-#endif
-    G2.getAdjMatrix(G2AdjMatrix);
+    Matrix G2Matrix;
+    G2.getMatrix(G2Matrix);
 
     uint count = 0;
     for (const auto& edge: G1EdgeList) {
         ushort node1 = edge[0], node2 = edge[1];
-        count += G2AdjMatrix[A[node1]][A[node2]];
+        count += G2Matrix.get(A[node1], A[node2]);
     }
     return count;
 }
@@ -248,12 +244,8 @@ uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
 int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<ushort> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-#ifdef WEIGHTED
-    vector<vector<ushort> > G2AdjMatrix;
-#else
-    vector<vector<bool> > G2AdjMatrix;
-#endif
-    G2.getAdjMatrix(G2AdjMatrix);
+    Matrix G2Matrix;
+    G2.getMatrix(G2Matrix);
 
 #if 0
     Pseudo-code (assuming you have initially removed g1 from g2)
@@ -271,7 +263,7 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     for (const auto& edge: G1EdgeList) {
         ushort hole1 = A[edge[0]];
         ushort hole2 = A[edge[1]];
-        G2AdjMatrix[hole1][hole2] += 1;
+        G2Matrix[hole1][hole2] += 1;
     }
 #endif
 
@@ -279,7 +271,7 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     uint n2 = G2.getNumNodes(); 
     for(uint i = 0; i < n2; i++){
         for(uint j = 0; j < i; j++){
-            int rungs  = G2AdjMatrix[i][j];
+            int rungs  = G2Matrix.get(i, j);
             count += rungs * rungs;
         }
     }
@@ -291,19 +283,15 @@ Graph Alignment::commonSubgraph(const Graph& G1, const Graph& G2) const {
 
     vector<vector<ushort> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-#ifdef WEIGHTED
-        vector<vector<ushort> > G2AdjMatrix;
-#else
-        vector<vector<bool> > G2AdjMatrix;
-#endif
+    Matrix G2Matrix;
 
-    G2.getAdjMatrix(G2AdjMatrix);
+    G2.getMatrix(G2Matrix);
 
     //only add edges preserved by alignment
     vector<vector<ushort> > edgeList(0);
     for (const auto& edge: G1EdgeList) {
         ushort node1 = edge[0], node2 = edge[1];
-        if (G2AdjMatrix[A[node1]][A[node2]]) {
+        if (G2Matrix.get(A[node1], A[node2])) {
             edgeList.push_back(edge);
         }
     }

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -230,7 +230,7 @@ void Alignment::writeEdgeList(Graph const * G1, Graph const * G2, ostream& edgeL
 uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
     G2.getMatrix(G2Matrix);
 
     uint count = 0;
@@ -244,7 +244,7 @@ uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
 int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
     G2.getMatrix(G2Matrix);
 
 #if 0
@@ -283,7 +283,7 @@ Graph Alignment::commonSubgraph(const Graph& G1, const Graph& G2) const {
 
     vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
 
     G2.getMatrix(G2Matrix);
 

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -263,7 +263,7 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     for (const auto& edge: G1EdgeList) {
         ushort hole1 = A[edge[0]];
         ushort hole2 = A[edge[1]];
-        G2Matrix[hole1][hole2] += 1;
+        G2Matrix.set(G2Matrix.get(hole1, hole2) + 1, hole1, hole2);
     }
 #endif
 

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -5,17 +5,17 @@ using namespace std;
 
 Alignment::Alignment() {}
 
-Alignment::Alignment(const vector<ushort>& mapping): A(mapping) {}
+Alignment::Alignment(const vector<uint>& mapping): A(mapping) {}
 
 Alignment::Alignment(const Alignment& alig): A(alig.A) {}
 
 Alignment::Alignment(Graph* G1, Graph* G2, const vector<vector<string> >& mapList) {
-    unordered_map<string,ushort> mapG1 = G1->getNodeNameToIndexMap();
-    unordered_map<string,ushort> mapG2 = G2->getNodeNameToIndexMap();
-    ushort n1 = mapList.size();
-    ushort n2 = G2->getNumNodes();
-    A = vector<ushort>(G1->getNumNodes(), n2); //n2 used to note invalid value
-    for (ushort i = 0; i < n1; i++) {
+    unordered_map<string,uint> mapG1 = G1->getNodeNameToIndexMap();
+    unordered_map<string,uint> mapG2 = G2->getNodeNameToIndexMap();
+    uint n1 = mapList.size();
+    uint n2 = G2->getNumNodes();
+    A = vector<uint>(G1->getNumNodes(), n2); //n2 used to note invalid value
+    for (uint i = 0; i < n1; i++) {
         string nodeG1 = mapList[i][0];
         string nodeG2 = mapList[i][1];
         A[mapG1[nodeG1]] = mapG2[nodeG2];
@@ -58,12 +58,12 @@ Alignment Alignment::loadPartialEdgeList(Graph* G1, Graph* G2, string fileName, 
         mapList[i][0] = edges[2*i];
         mapList[i][1] = edges[2*i+1];
     }
-    unordered_map<string,ushort> mapG1 = G1->getNodeNameToIndexMap();
-    unordered_map<string,ushort> mapG2 = G2->getNodeNameToIndexMap();
-    ushort n1 = G1->getNumNodes();
-    ushort n2 = G2->getNumNodes();
-    vector<ushort> A(n1, n2); //n2 used to note invalid value
-    for (ushort i = 0; i < mapList.size(); i++) {
+    unordered_map<string,uint> mapG1 = G1->getNodeNameToIndexMap();
+    unordered_map<string,uint> mapG2 = G2->getNodeNameToIndexMap();
+    uint n1 = G1->getNumNodes();
+    uint n2 = G2->getNumNodes();
+    vector<uint> A(n1, n2); //n2 used to note invalid value
+    for (uint i = 0; i < mapList.size(); i++) {
         string nodeG1 = mapList[i][0];
         string nodeG2 = mapList[i][1];
 
@@ -128,7 +128,7 @@ Alignment Alignment::loadMapping(string fileName) {
     string line;
     getline(infile, line); //reads only the first line, ignores the rest
     istringstream iss(line);
-    vector<ushort> A(0);
+    vector<uint> A(0);
     int n;
     while (iss >> n) A.push_back(n);
     infile.close();
@@ -137,9 +137,9 @@ Alignment Alignment::loadMapping(string fileName) {
 
 Alignment Alignment::random(uint n1, uint n2) {
     //taken from: http://stackoverflow.com/questions/311703/algorithm-for-sampling-without-replacement
-    vector<ushort> alignment(n1);
-    ushort t = 0; // total input records dealt with
-    ushort m = 0; // number of items selected so far
+    vector<uint> alignment(n1);
+    uint t = 0; // total input records dealt with
+    uint m = 0; // number of items selected so far
     double u;
     while (m < n1) {
         u = randDouble();
@@ -157,12 +157,12 @@ Alignment Alignment::random(uint n1, uint n2) {
 }
 
 Alignment Alignment::empty() {
-    vector<ushort> emptyMapping(0);
+    vector<uint> emptyMapping(0);
     return Alignment(emptyMapping);
 }
 
 Alignment Alignment::identity(uint n) {
-    vector<ushort> A(n);
+    vector<uint> A(n);
     for (uint i = 0; i < n; i++) {
         A[i] = i;
     }
@@ -174,22 +174,22 @@ Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
         throw runtime_error("cannot load correct mapping");
     }
 
-    unordered_map<ushort,string> G1Index2Name = G1.getIndexToNodeNameMap();
-    unordered_map<string,ushort> G2Name2Index = G2.getNodeNameToIndexMap();
+    unordered_map<uint,string> G1Index2Name = G1.getIndexToNodeNameMap();
+    unordered_map<string,uint> G2Name2Index = G2.getNodeNameToIndexMap();
 
     uint n = G1.getNumNodes();
-    vector<ushort> A(n);
+    vector<uint> A(n);
     for (uint i = 0; i < n; i++) {
         A[i] = G2Name2Index[G1Index2Name[i]];
     }
     return Alignment(A);
 }
 
-vector<ushort> Alignment::getMapping() const {
+vector<uint> Alignment::getMapping() const {
     return A;
 }
 
-ushort& Alignment::operator[] (ushort node) {
+uint& Alignment::operator[] (uint node) {
     return A[node];
 }
 
@@ -203,7 +203,7 @@ Alignment &Alignment::operator=(Alignment other) {
     return *this;
 }
 
-const ushort& Alignment::operator[](const ushort node) const {
+const uint& Alignment::operator[](const uint node) const {
     return A[node];
 }
 
@@ -218,7 +218,7 @@ void Alignment::write(ostream& stream) const {
     stream << endl;
 }
 
-typedef unordered_map<ushort,string> NodeIndexMap;
+typedef unordered_map<uint,string> NodeIndexMap;
 void Alignment::writeEdgeList(Graph const * G1, Graph const * G2, ostream& edgeListStream) const {
     NodeIndexMap mapG1 = G1->getIndexToNodeNameMap();
     NodeIndexMap mapG2 = G2->getIndexToNodeNameMap();
@@ -228,21 +228,21 @@ void Alignment::writeEdgeList(Graph const * G1, Graph const * G2, ostream& edgeL
 
 
 uint Alignment::numAlignedEdges(const Graph& G1, const Graph& G2) const {
-    vector<vector<ushort> > G1EdgeList;
+    vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
     Matrix G2Matrix;
     G2.getMatrix(G2Matrix);
 
     uint count = 0;
     for (const auto& edge: G1EdgeList) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         count += G2Matrix.get(A[node1], A[node2]);
     }
     return count;
 }
 
 int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
-    vector<vector<ushort> > G1EdgeList;
+    vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
     Matrix G2Matrix;
     G2.getMatrix(G2Matrix);
@@ -261,8 +261,8 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
     // Before computing rung sizes, we need to add the edges
     // from G1 that we pruned back to G2
     for (const auto& edge: G1EdgeList) {
-        ushort hole1 = A[edge[0]];
-        ushort hole2 = A[edge[1]];
+        uint hole1 = A[edge[0]];
+        uint hole2 = A[edge[1]];
         G2Matrix.set(G2Matrix.get(hole1, hole2) + 1, hole1, hole2);
     }
 #endif
@@ -281,16 +281,16 @@ int Alignment::numSquaredAlignedEdges(const Graph& G1, const Graph& G2) const {
 Graph Alignment::commonSubgraph(const Graph& G1, const Graph& G2) const {
     uint n = G1.getNumNodes();
 
-    vector<vector<ushort> > G1EdgeList;
+    vector<vector<uint> > G1EdgeList;
     G1.getEdgeList(G1EdgeList);
     Matrix G2Matrix;
 
     G2.getMatrix(G2Matrix);
 
     //only add edges preserved by alignment
-    vector<vector<ushort> > edgeList(0);
+    vector<vector<uint> > edgeList(0);
     for (const auto& edge: G1EdgeList) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         if (G2Matrix.get(A[node1], A[node2])) {
             edgeList.push_back(edge);
         }
@@ -319,8 +319,8 @@ bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) {
 void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) {
     uint n1 = G1.getNumNodes();
     uint n2 = G2.getNumNodes();
-    unordered_map<ushort,string> G1Names = G1.getIndexToNodeNameMap();
-    unordered_map<ushort,string> G2Names = G2.getIndexToNodeNameMap();
+    unordered_map<uint,string> G1Names = G1.getIndexToNodeNameMap();
+    unordered_map<uint,string> G2Names = G2.getIndexToNodeNameMap();
 
     vector<bool> G2AssignedNodes(n2, false);
     int count = 0;
@@ -342,13 +342,13 @@ void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) {
 Alignment Alignment::randomAlignmentWithLocking(Graph* G1, Graph* G2){
     assert(G1->getLockedCount() == G2->getLockedCount());
 
-    unordered_map<ushort,string> g1_NameMap = G1->getIndexToNodeNameMap();
-    unordered_map<string,ushort> g2_IndexMap = G2->getNodeNameToIndexMap();
+    unordered_map<uint,string> g1_NameMap = G1->getIndexToNodeNameMap();
+    unordered_map<string,uint> g2_IndexMap = G2->getNodeNameToIndexMap();
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
 
-    vector<ushort> A(n1, n2); //n2 used to note invalid value
-    for (ushort i = 0; i < n1; i++) {
+    vector<uint> A(n1, n2); //n2 used to note invalid value
+    for (uint i = 0; i < n1; i++) {
         if(!G1->isLocked(i))
             continue;
         string node1 = g1_NameMap[i];
@@ -378,14 +378,14 @@ Alignment Alignment::randomAlignmentWithLocking(Graph* G1, Graph* G2){
 Alignment Alignment::randomAlignmentWithNodeType(Graph* G1, Graph* G2){
         assert(G1->getLockedCount() == G2->getLockedCount());
 
-        unordered_map<ushort,string> g1_NameMap = G1->getIndexToNodeNameMap();
-        unordered_map<string,ushort> g2_IndexMap = G2->getNodeNameToIndexMap();
+        unordered_map<uint,string> g1_NameMap = G1->getIndexToNodeNameMap();
+        unordered_map<string,uint> g2_IndexMap = G2->getNodeNameToIndexMap();
         uint n1 = G1->getNumNodes();
         uint n2 = G2->getNumNodes();
 
-        vector<ushort> G2_UnlockedGeneIndexes;
-        vector<ushort> G2_UnlockedRNAIndexes;
-        for(ushort i=0;i<n2;i++){
+        vector<uint> G2_UnlockedGeneIndexes;
+        vector<uint> G2_UnlockedRNAIndexes;
+        for(uint i=0;i<n2;i++){
             if(G2->isLocked(i))
                 continue;
             if(G2->nodeTypes[i] == Graph::NODE_TYPE_GENE) //  "gene")
@@ -394,8 +394,8 @@ Alignment Alignment::randomAlignmentWithNodeType(Graph* G1, Graph* G2){
                 G2_UnlockedRNAIndexes.push_back(i);
         }
 
-        vector<ushort> A(n1, n2); //n2 used to note invalid value
-        for (ushort i = 0; i < n1; i++) {
+        vector<uint> A(n1, n2); //n2 used to note invalid value
+        for (uint i = 0; i < n1; i++) {
             // Aligns all the locked nodes together
             if(!G1->isLocked(i))
                 continue;
@@ -449,17 +449,17 @@ Alignment Alignment::randomAlignmentWithNodeType(Graph* G1, Graph* G2){
 
 
 
-void Alignment::reIndexBefore_Iterations(unordered_map<ushort, ushort> reIndexMap){
-    vector<ushort> resA = vector<ushort> (A.size());
+void Alignment::reIndexBefore_Iterations(unordered_map<uint, uint> reIndexMap){
+    vector<uint> resA = vector<uint> (A.size());
     for(uint i=0; i< A.size();i++){
-        ushort b = reIndexMap[i];
+        uint b = reIndexMap[i];
         resA[b] = A[i];
     }
     A = resA;
 }
 
-void Alignment::reIndexAfter_Iterations(unordered_map<ushort, ushort> reIndexMap){
-    vector<ushort> resA = vector<ushort> (A.size());
+void Alignment::reIndexAfter_Iterations(unordered_map<uint, uint> reIndexMap){
+    vector<uint> resA = vector<uint> (A.size());
     for(uint i=0; i< A.size();i++){
         resA[i] = A[reIndexMap[i]];
     }

--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -34,13 +34,13 @@ public:
 
     Alignment();
     Alignment(const Alignment& alig);
-    Alignment(const vector<ushort>& mapping);
+    Alignment(const vector<uint>& mapping);
     Alignment(Graph* G1, Graph* G2, const vector<vector<string> >& mapList);
 
-    vector<ushort> getMapping() const;
+    vector<uint> getMapping() const;
 
-    ushort& operator[](ushort node);
-    const ushort& operator[](const ushort node) const;
+    uint& operator[](uint node);
+    const uint& operator[](const uint node) const;
     Alignment &operator=(Alignment);
     uint size() const;
 
@@ -66,13 +66,13 @@ public:
     static Alignment randomAlignmentWithNodeType(Graph *G1, Graph *G2);
 
     // These two reIndex the alignment based on the reIndex Map from G1
-    void reIndexBefore_Iterations(unordered_map<ushort, ushort> reIndexMap);
-    void reIndexAfter_Iterations(unordered_map<ushort, ushort> reverseReIndexMap);
+    void reIndexBefore_Iterations(unordered_map<uint, uint> reIndexMap);
+    void reIndexAfter_Iterations(unordered_map<uint, uint> reverseReIndexMap);
 
-    ushort& getBack() { return A.back(); }
+    uint& getBack() { return A.back(); }
 private:
 
-    vector<ushort> A;
+    vector<uint> A;
 
 };
 

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -268,8 +268,8 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
         if(g.matrix.isConnected(node1, node2)){
             //errorMsg << "duplicate edges not allowed (in either direction), node numbers are " << node1 << " " << node2 << '\n';
 	    unordered_map<ushort,string> index2name = g.getIndexToNodeNameMap();
-	    errorMsg << "In graph[" << graphName << "]: duplicate edges not allowed (in either direction), node names are " 
-                     << index2name[node1] << " " << index2name[node2] << '\n';
+	    errorMsg << "In graph[" << graphName << "]: duplicate edges not allowed (in either direction), node names are " <<
+                      index2name[node1] << " " << index2name[node2] << '\n';
             throw runtime_error(errorMsg.str().c_str());
         }
         if(node1 == node2) {

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -257,7 +257,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     nodes.shrink_to_fit();
     const size_t nodeSize = nodes.size();
     g.adjLists = vector<vector<uint> > (nodeSize, vector<uint>(0));
-    g.matrix = Matrix<WEIGHTED_VALUE>(nodeSize);
+    g.matrix = Matrix<MATRIX_UNIT>(nodeSize);
     uint node1;
     uint node2;
     const size_t edgeListLen = edgeList.size();
@@ -411,7 +411,7 @@ Graph::Graph() :
 
 Graph::Graph(const Graph& G) {
     edgeList = vector<vector<uint> > (G.edgeList);
-    matrix = Matrix<WEIGHTED_VALUE> (G.matrix);
+    matrix = Matrix<MATRIX_UNIT> (G.matrix);
     adjLists = vector<vector<uint> > (G.adjLists);
     connectedComponents = vector<vector<uint> > (G.connectedComponents);
     lockedList = vector<bool> (G.lockedList);
@@ -429,7 +429,7 @@ Graph::Graph(const Graph& G) {
 
 Graph::Graph(uint n, const vector<vector<uint> > edges) {
     adjLists = vector<vector<uint> > (n, vector<uint> (0));
-    matrix = Matrix<WEIGHTED_VALUE> (n);
+    matrix = Matrix<MATRIX_UNIT> (n);
     edgeList = edges;
 
     lockedList = vector<bool> (n, false);
@@ -481,7 +481,7 @@ uint Graph::getNumConnectedComponents() const {
     return connectedComponents.size();
 }
 
-void Graph::getMatrix(Matrix<WEIGHTED_VALUE>& matrixCopy) const {
+void Graph::getMatrix(Matrix<MATRIX_UNIT>& matrixCopy) const {
     matrixCopy = matrix;
 }
 
@@ -497,7 +497,7 @@ const vector<vector<uint> >& Graph::getConnectedComponents() const {
     return connectedComponents;
 }
 
-void Graph::setMatrix(Matrix<WEIGHTED_VALUE>& matrixCopy) {
+void Graph::setMatrix(Matrix<MATRIX_UNIT>& matrixCopy) {
     matrix = matrixCopy;
 }
 
@@ -551,7 +551,7 @@ void Graph::loadGwFile(const string& fileName) {
     }
 
     adjLists = vector<vector<uint> > (n, vector<uint>(0));
-    matrix = Matrix<WEIGHTED_VALUE>(n);
+    matrix = Matrix<MATRIX_UNIT>(n);
 #ifdef WEIGHTED
     char dump;
     uint edgeValue;
@@ -649,7 +649,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     SparseMatrix<uint> sparse_graph2(n);
 
     adjLists = vector<vector<uint> > (n, vector<uint>(0));
-    matrix = Matrix<WEIGHTED_VALUE>(n);
+    matrix = Matrix<MATRIX_UNIT>(n);
     //edgeList = vector<vector<uint> > (m, vector<uint>(2));
     lockedList = vector<bool> (n, false);
     lockedTo = vector<string> (n, "");
@@ -762,7 +762,7 @@ Graph Graph::nodeInducedSubgraph(const vector<uint>& nodes) const {
     unordered_set<uint> nodeSet(nodes.begin(), nodes.end());
     Graph G;
     G.adjLists = vector<vector<uint> > (n, vector<uint> (0));
-    G.matrix = Matrix<WEIGHTED_VALUE>(n);
+    G.matrix = Matrix<MATRIX_UNIT>(n);
     //only add edges between induced nodes
     for (const auto& edge: edgeList) {
         uint node1 = edge[0], node2 = edge[1];
@@ -1640,7 +1640,7 @@ unordered_map<uint, uint> Graph::getNodeTypes_ReIndexMap() const{
 
 void Graph::reIndexGraph(unordered_map<uint, uint> reIndexMap){
     uint n = getNumNodes();
-    Matrix<WEIGHTED_VALUE> matrixCopy(n);
+    Matrix<MATRIX_UNIT> matrixCopy(n);
     for (uint i = 0; i < n; i++) {
          for (uint j = 0; j < n; j++){
                uint a = reIndexMap[i];

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -706,44 +706,44 @@ void Graph::multGwFile(const string& fileName, uint path) {
     initConnectedComponents();
 }
 
-bool comp_vectors(const vector<uint>* a,const vector<uint>* b) {
-   return a->size() > b->size();
+bool comp_vectors(const vector<uint>& a,const vector<uint>& b) {
+   return a.size() > b.size();
 }
 
 void Graph::initConnectedComponents() {
-    //this function takes most of the initialization time
     uint n = getNumNodes();
-    vector<vector<uint>* > aux(0);
-    unordered_set<uint> nodes(n);
-    for (uint i = 0; i < n; i++) nodes.insert(i);
+    vector<bool> nodesAreChecked(n);
+
+    queue<uint> nodes;
+    for (uint i = 0; i < n; ++i) nodes.push(i);
 
     while (nodes.size() > 0) {
-        uint u = *nodes.begin();
-        nodes.erase(nodes.begin());
-        unordered_set<uint> group;
-        group.insert(u);
-        queue<uint> Q;
-        Q.push(u);
-        while (not Q.empty()) {
-            uint v = Q.front();
-            Q.pop();
-            unordered_set<uint> vNeighbors(adjLists[v].begin(), adjLists[v].end());
-            for (const auto& node: group) vNeighbors.erase(node);
-            for (const auto& node: vNeighbors) nodes.erase(node);
-            group.insert(vNeighbors.begin(), vNeighbors.end());
-            for (const auto& node: vNeighbors) Q.push(node);
+        uint startOfConnected = nodes.front();
+        nodes.pop();
+
+        if (nodesAreChecked[startOfConnected]) continue;
+
+        vector<uint> connected;
+
+        queue<uint> neighbors;
+        neighbors.push(startOfConnected);
+
+        while (not neighbors.empty()) {
+            uint node = neighbors.front();
+            neighbors.pop();
+            if (nodesAreChecked[node]) continue;
+
+            connected.push_back(node);
+            nodesAreChecked[node] = true;
+            
+            for (const uint & neighbor: adjLists[node]) {
+               if (not nodesAreChecked[neighbor]) 
+                   neighbors.push(neighbor);         
+            }
         }
-        aux.push_back(new vector<uint> (group.begin(), group.end()));
+        connectedComponents.push_back(connected);
     }
-    sort(aux.begin(), aux.end(), comp_vectors);
-    connectedComponents = vector<vector<uint> > (aux.size(), vector<uint> (0));
-    for (uint i = 0; i < connectedComponents.size(); i++) {
-        connectedComponents[i] = vector<uint> (aux[i]->size());
-        for (uint j = 0; j < aux[i]->size(); j++) {
-            connectedComponents[i][j] = (*aux[i])[j];
-        }
-    }
-    for(uint i = 0; i < aux.size();++i) delete aux[i];
+    sort(connectedComponents.begin(), connectedComponents.end(), comp_vectors);
 }
 
 uint Graph::numNodeInducedSubgraphEdges(const vector<uint>& subgraphNodes) const {

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -277,11 +277,11 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
           throw runtime_error(errorMsg.str().c_str());
         }
 
-		// Note that when WEIGHTED is on, the adjacency matrix contains full integers, not just bits.
+        // Note that when WEIGHTED is on, the adjacency matrix contains full integers, not just bits.
         #ifdef WEIGHTED
-                g.matrix.connect(edgeList[i][2], node1, node2);
+            g.matrix.connect(edgeList[i][2], node1, node2);
         #else
-                g.matrix.connect(true, node1, node2);
+            g.matrix.connect(true, node1, node2);
         #endif
         g.adjLists[node1].push_back(node2);
         g.adjLists[node2].push_back(node1);
@@ -779,7 +779,7 @@ Graph Graph::nodeInducedSubgraph(const vector<ushort>& nodes) const {
             newEdge[1] = newNode2;
             G.edgeList.push_back(newEdge);
 #ifdef WEIGHTED
-            G.matrix.connect(matrix[node1][node2], newNode1, newNode2);
+            G.matrix.connect(matrix.get(node1, node2), newNode1, newNode2);
 #else
             G.matrix.connect(true, newNode1, newNode2);
 #endif
@@ -1707,7 +1707,7 @@ uint Graph::getWeightedNumEdges() {
     if (weightedNumEdges != 0) return weightedNumEdges;
     weightedNumEdges = 0;
     for (auto c : edgeList)
-        weightedNumEdges += matrix[c[0]][c[1]];
+        weightedNumEdges += matrix.get(c[0], c[1]);
     return weightedNumEdges;
 }
 #endif

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -620,7 +620,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     //ignore header
     for (int i = 0; i < 4; i++) getline(infile, line);
     //read number of nodes
-    int n;
+    uint n;
     getline(infile, line);
     istringstream iss(line);
     if (!(iss >> n) or n <= 0) {
@@ -629,7 +629,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     }
     //read (and ditch) nodes
     string node;
-    for (int i = 0; i < n; i++) {
+    for (uint i = 0; i < n; i++) {
         getline(infile, line);
         istringstream iss(line);
         if (!(iss >> node)) {
@@ -638,15 +638,15 @@ void Graph::multGwFile(const string& fileName, uint path) {
         }
     }
     //read number of edges
-    int m;
+    uint m;
     getline(infile, line);
     istringstream iss2(line);
     if (!(iss2 >> m)) {
         errorMsg << "Failed to read edge number: " << line;
         throw runtime_error(errorMsg.str().c_str());
     }
-    SparseMatrix<int> sparse_graph1(n);
-    SparseMatrix<int> sparse_graph2(n);
+    SparseMatrix<ushort> sparse_graph1(n);
+    SparseMatrix<ushort> sparse_graph2(n);
 
     adjLists = vector<vector<ushort> > (n, vector<ushort>(0));
     matrix = Matrix(n);
@@ -656,10 +656,10 @@ void Graph::multGwFile(const string& fileName, uint path) {
     nodeTypes = vector<int> (n, -1);
 
     //read edges
-    for (int i = 0; i < m; i++) {
+    for (uint i = 0; i < m; i++) {
         getline(infile, line);
         istringstream iss(line);
-        int node1, node2;
+        uint node1, node2;
         if (!(iss >> node1 >> node2)) {
             errorMsg << "Failed to read edge: " << line;
             throw runtime_error(errorMsg.str().c_str());
@@ -670,17 +670,17 @@ void Graph::multGwFile(const string& fileName, uint path) {
         sparse_graph2.set(1,node1,node2);
         sparse_graph2.set(1,node2,node1);
     }
-    for(uint i=1; i<path ; i++){
-        SparseMatrix<int> final = sparse_graph2.multiply(sparse_graph1);
-        for(int k=1;k<=n;k++){
-            for(int j=1;j<= n;j++){
+    for(uint i=0; i<path ; i++){
+        SparseMatrix<ushort> final = sparse_graph2.multiply(sparse_graph1);
+        for(uint k=0;k<n;k++){
+            for(uint j=0;j<n;j++){
                 sparse_graph2.set(final.get(k,j),k,j);
             }
         }
     }
-    int elements = 0;
-    for(int k=1;k<=n;k++){
-            for(int j=1;j<= n;j++){
+    uint elements = 0;
+    for(uint k=0;k<n;k++){
+            for(uint j=0;j< n;j++){
                 if(sparse_graph2.get(k,j) > 0){
                     elements++;
                 }
@@ -688,9 +688,9 @@ void Graph::multGwFile(const string& fileName, uint path) {
     }
 
     edgeList = vector<vector<ushort> > (elements, vector<ushort>(2));
-    int count = 0;
-    for(int i=1;i<=n;i++){
-        for(int j=1;j<= n;j++){
+    uint count = 0;
+    for(uint i=0;i<n;i++){
+        for(uint j=0;j<n;j++){
             if(sparse_graph2.get(i,j) > 0){
                 matrix.connect(true, i - 1, j - 1);
                 adjLists[i-1].push_back(j-1);

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -257,11 +257,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     nodes.shrink_to_fit();
     const size_t nodeSize = nodes.size();
     g.adjLists = vector<vector<ushort> > (nodeSize, vector<ushort>(0));
-#ifdef WEIGHTED
-    g.adjMatrix = vector<vector<ushort> > (nodeSize, vector<ushort>(nodeSize, 0));
-#else
-    g.adjMatrix = vector<vector<bool> > (nodeSize, vector<bool>(nodeSize, false));
-#endif
+    g.matrix = Matrix(nodeSize);
     uint node1;
     uint node2;
     const size_t edgeListLen = edgeList.size();
@@ -269,13 +265,11 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     for(unsigned i = 0; i < edgeListLen; ++i){
         node1 = edgeList[i][0];
         node2 = edgeList[i][1];
-
-	// the below should be abstracted into a function, eg g.connected(node1, node2)
-	// Inside that function is the only place you'd need to know if adjMatrix exists or not.
-        if(g.adjMatrix[node1][node2] || g.adjMatrix[node2][node1]){
+        if(g.matrix.isConnected(node1, node2)){
             //errorMsg << "duplicate edges not allowed (in either direction), node numbers are " << node1 << " " << node2 << '\n';
 	    unordered_map<ushort,string> index2name = g.getIndexToNodeNameMap();
-	    errorMsg << "In graph[" << graphName << "]: duplicate edges not allowed (in either direction), node names are " << index2name[node1] << " " << index2name[node2] << '\n';
+	    errorMsg << "In graph[" << graphName << "]: duplicate edges not allowed (in either direction), node names are " 
+                     << index2name[node1] << " " << index2name[node2] << '\n';
             throw runtime_error(errorMsg.str().c_str());
         }
         if(node1 == node2) {
@@ -283,17 +277,14 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
           throw runtime_error(errorMsg.str().c_str());
         }
 
-		// These should be abstracted into g.connect(node1, node2) to cause these two nodes
-		// to get an edge between them.
 		// Note that when WEIGHTED is on, the adjacency matrix contains full integers, not just bits.
         #ifdef WEIGHTED
-                g.adjMatrix[node1][node2] = g.adjMatrix[node2][node1] = edgeList[i][2];
+                g.matrix.connect(edgeList[i][2], node1, node2);
         #else
-                g.adjMatrix[node1][node2] = g.adjMatrix[node2][node1] = true;
+                g.matrix.connect(true, node1, node2);
         #endif
         g.adjLists[node1].push_back(node2);
         g.adjLists[node2].push_back(node1);
-
     }
     // init rest of graph
     g.lockedList = vector<bool> (nodeSize, false);
@@ -409,11 +400,7 @@ Graph::Graph() :
     geneIndexList(vector<uint>(0)),
     miRNAIndexList(vector<uint>(0)),
     edgeList(vector<vector<ushort> > (0)),
-#ifdef WEIGHTED
-    adjMatrix(vector<vector<ushort> > (0)),
-#else
-    adjMatrix(vector<vector<bool> > (0)),
-#endif
+    matrix(0),
     adjLists(vector<vector<ushort> > (0)),
     connectedComponents(vector<vector<ushort>>(0)),
     lockedList(vector<bool> (0)),
@@ -424,11 +411,7 @@ Graph::Graph() :
 
 Graph::Graph(const Graph& G) {
     edgeList = vector<vector<ushort> > (G.edgeList);
-#ifdef WEIGHTED
-    adjMatrix = vector<vector<ushort> > (G.adjMatrix);
-#else
-    adjMatrix = vector<vector<bool> > (G.adjMatrix);
-#endif
+    matrix = Matrix (G.matrix);
     adjLists = vector<vector<ushort> > (G.adjLists);
     connectedComponents = vector<vector<ushort> > (G.connectedComponents);
     lockedList = vector<bool> (G.lockedList);
@@ -446,11 +429,7 @@ Graph::Graph(const Graph& G) {
 
 Graph::Graph(uint n, const vector<vector<ushort> > edges) {
     adjLists = vector<vector<ushort> > (n, vector<ushort> (0));
-#ifdef WEIGHTED
-    adjMatrix = vector<vector<ushort> > (n, vector<ushort> (n, 0));
-#else
-    adjMatrix = vector<vector<bool> > (n, vector<bool> (n, false));
-#endif
+    matrix = Matrix(n);
     edgeList = edges;
 
     lockedList = vector<bool> (n, false);
@@ -465,9 +444,9 @@ Graph::Graph(uint n, const vector<vector<ushort> > edges) {
         adjLists[node1].push_back(node2);
         adjLists[node2].push_back(node1);
 #ifdef WEIGHTED
-        adjMatrix[node1][node2] = adjMatrix[node2][node1] = 1;
+        matrix.connect(1, node1, node2);
 #else
-        adjMatrix[node1][node2] = adjMatrix[node2][node1] = true;
+        matrix.connect(true, node1, node2); 
 #endif
     }
     updateUnlockedGeneCount();
@@ -482,7 +461,7 @@ uint Graph::getNumEdges() const {
 #if 0
     cout << "Statistics for Graph " << name << endl;
     cout << "adjList.size() = " << adjLists.size() << endl;
-    cout << "adjMatrix.size() = " << adjMatrix.size() << endl;
+    cout << "matrix.size() = " << matrix.size() << endl;
     cout << "edgeList.size() = " << edgeList.size() << endl;
     cout << "nodeNameToIndexMap.size() = " << nodeNameToIndexMap.size() << endl;
     cout << "lockedList.size() = " << lockedList.size() << endl;
@@ -502,13 +481,8 @@ uint Graph::getNumConnectedComponents() const {
     return connectedComponents.size();
 }
 
-#ifdef WEIGHTED
-void Graph::getAdjMatrix(vector<vector<ushort> >& adjMatrixCopy) const {
-    adjMatrixCopy = vector<vector<ushort> > (adjMatrix);
-#else
-void Graph::getAdjMatrix(vector<vector<bool> >& adjMatrixCopy) const {
-    adjMatrixCopy = vector<vector<bool> > (adjMatrix);
-#endif
+void Graph::getMatrix(Matrix& matrixCopy) const {
+    matrixCopy = matrix;
 }
 
 void Graph::getAdjLists(vector<vector<ushort> >& adjListsCopy) const {
@@ -522,12 +496,9 @@ void Graph::getEdgeList(vector<vector<ushort> >& edgeListCopy) const {
 const vector<vector<ushort> >& Graph::getConnectedComponents() const {
     return connectedComponents;
 }
-#ifdef WEIGHTED
-void Graph::setAdjMatrix(vector<vector<ushort> >& adjMatrixCopy) {
-#else
-void Graph::setAdjMatrix(vector<vector<bool> >& adjMatrixCopy) {
-#endif
-    adjMatrix = adjMatrixCopy;
+
+void Graph::setMatrix(Matrix& matrixCopy) {
+    matrix = matrixCopy;
 }
 
 void Graph::setAdjLists(vector<vector<ushort> >& adjListsCopy) {
@@ -580,12 +551,10 @@ void Graph::loadGwFile(const string& fileName) {
     }
 
     adjLists = vector<vector<ushort> > (n, vector<ushort>(0));
+    matrix = Matrix(n);
 #ifdef WEIGHTED
-    adjMatrix = vector<vector<ushort> > (n, vector<ushort>(n, 0));
     char dump;
     ushort edgeValue;
-#else
-    adjMatrix = vector<vector<bool> > (n, vector<bool>(n, false));
 #endif
     edgeList = vector<vector<ushort> > (m, vector<ushort>(2));
     lockedList = vector<bool> (n, false);
@@ -618,7 +587,7 @@ void Graph::loadGwFile(const string& fileName) {
 #endif
         node1--; node2--; //-1 because of remapping
         
-        if(adjMatrix[node1][node2] || adjMatrix[node2][node1]){
+        if(matrix.isConnected(node1, node2)){
             errorMsg << "duplicate edges not allowed (in either direction), node numbers are " << node1+1 << " " << node2+1 << '\n';
 	    //errorMsg << "In graph [" << graphName << "]: duplicate edges not allowed (in either direction), node names are " << nodeName2IndexMap[node1+1] << " " << nodeName2IndexMap[node2+1] << '\n';
             throw runtime_error(errorMsg.str().c_str());
@@ -631,9 +600,9 @@ void Graph::loadGwFile(const string& fileName) {
         edgeList[i][1] = node2;
 
 #ifdef WEIGHTED
-        adjMatrix[node1][node2] = adjMatrix[node2][node1] = edgeValue;
+        matrix.connect(edgeValue, node1, node2);
 #else
-        adjMatrix[node1][node2] = adjMatrix[node2][node1] = true;
+        matrix.connect(true, node1, node2);
 #endif
         adjLists[node1].push_back(node2);
         adjLists[node2].push_back(node1);
@@ -680,11 +649,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     SparseMatrix<int> sparse_graph2(n);
 
     adjLists = vector<vector<ushort> > (n, vector<ushort>(0));
-#ifdef WEIGHTED
-    adjMatrix = vector<vector<ushort> > (n, vector<ushort>(n, 0));
-#else
-    adjMatrix = vector<vector<bool> > (n, vector<bool>(n, false));
-#endif
+    matrix = Matrix(n);
     //edgeList = vector<vector<ushort> > (m, vector<ushort>(2));
     lockedList = vector<bool> (n, false);
     lockedTo = vector<string> (n, "");
@@ -727,8 +692,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     for(int i=1;i<=n;i++){
         for(int j=1;j<= n;j++){
             if(sparse_graph2.get(i,j) > 0){
-                adjMatrix[i-1][j-1] = true;
-                adjMatrix[j-1][i-1] = true;
+                matrix.connect(true, i - 1, j - 1);
                 adjLists[i-1].push_back(j-1);
                 adjLists[j-1].push_back(i-1);
                 edgeList[count][0] = i-1;
@@ -801,11 +765,7 @@ Graph Graph::nodeInducedSubgraph(const vector<ushort>& nodes) const {
     unordered_set<ushort> nodeSet(nodes.begin(), nodes.end());
     Graph G;
     G.adjLists = vector<vector<ushort> > (n, vector<ushort> (0));
-#ifdef WEIGHTED
-    G.adjMatrix = vector<vector<ushort> > (n, vector<ushort> (n, 0));
-#else
-    G.adjMatrix = vector<vector<bool> > (n, vector<bool> (n, false));
-#endif
+    G.matrix = Matrix(n);
     //only add edges between induced nodes
     for (const auto& edge: edgeList) {
         ushort node1 = edge[0], node2 = edge[1];
@@ -819,9 +779,9 @@ Graph Graph::nodeInducedSubgraph(const vector<ushort>& nodes) const {
             newEdge[1] = newNode2;
             G.edgeList.push_back(newEdge);
 #ifdef WEIGHTED
-            G.adjMatrix[newNode1][newNode2] = G.adjMatrix[newNode2][newNode1] = adjMatrix[node1][node2];
+            G.matrix.connect(matrix[node1][node2], newNode1, newNode2);
 #else
-            G.adjMatrix[newNode1][newNode2] = G.adjMatrix[newNode2][newNode1] = true;
+            G.matrix.connect(true, newNode1, newNode2);
 #endif
         }
     }
@@ -988,7 +948,7 @@ ushort Graph::randomNode() {
 
 //note: does not update CCs
 void Graph::addEdge(ushort node1, ushort node2) {
-    adjMatrix[node1][node2] = adjMatrix[node2][node1] = true;
+    matrix.connect(true, node1, node2);
     vector<ushort> edge(2);
     edge[0] = node1;
     edge[1] = node2;
@@ -999,7 +959,8 @@ void Graph::addEdge(ushort node1, ushort node2) {
 
 //note: does not update CCs
 void Graph::removeEdge(ushort node1, ushort node2) {
-    adjMatrix[node1][node2] = adjMatrix[node2][node1] = false;
+    matrix.set(false, node1, node2);
+    matrix.set(false, node2, node1);
     uint m = getNumEdges();
     //update edge list
     for (uint i = 0; i < m; i++) {
@@ -1033,7 +994,7 @@ void Graph::removeEdge(ushort node1, ushort node2) {
 //note: does not update CCs
 void Graph::addRandomEdge() {
     ushort node1 = 0, node2 = 0;
-    while (node1 == node2 or adjMatrix[node1][node2]) {
+    while (node1 == node2 or matrix.get(node1, node2)) {
         node1 = randomNode();
         node2 = randomNode();
     }
@@ -1043,7 +1004,7 @@ void Graph::addRandomEdge() {
 //note: does not update CCs
 void Graph::removeRandomEdge() {
     ushort node1 = 0, node2 = 0;
-    while (node1 == node2 or not adjMatrix[node1][node2]) {
+    while (node1 == node2 or not matrix.get(node1, node2)) {
         node1 = randomNode();
         node2 = randomNode();
     }
@@ -1451,7 +1412,7 @@ bool Graph::isWellDefined() {
     //check that all indices in adj lists are within bounds
     //check that every edge in the adj lists appears in the adj matrix
     //check that no node is neighbor to itself in the adj lists
-    uint numNodes = adjMatrix.size();
+    uint numNodes = matrix.size();
     for (uint i = 0; i < adjLists.size(); i++) {
         for (uint j = 0; j < adjLists[i].size(); j++) {
             uint neighbor = adjLists[i][j];
@@ -1465,8 +1426,8 @@ bool Graph::isWellDefined() {
                 isWellDefined = false;
 
             }
-            if (not adjMatrix[i][neighbor] or not adjMatrix[i][neighbor]) {
-                cerr << "node " << i << " adjacent to node " << adjMatrix[i][neighbor];
+            if (not matrix.get(i, neighbor) or not matrix.get(i, neighbor)) {
+                cerr << "node " << i << " adjacent to node " << matrix.get(i, neighbor);
                 cerr << " in the adj lists but not on the adj matrix" << endl;
                 isWellDefined = false;
             }
@@ -1481,7 +1442,7 @@ bool Graph::isWellDefined() {
     }
     //check that no node is adj to itself in the adj matrix
     for (uint i = 0; i < numNodes; i++) {
-        if (adjMatrix[i][i]) {
+        if (matrix.get(i, i)) {
             cerr << "Adjacency matrix ill defined: node " << i << " adjacent to itself" << endl;
             isWellDefined = false;
         }
@@ -1490,12 +1451,12 @@ bool Graph::isWellDefined() {
     //check that every edge in the adj matrix appears in the adj lists (twice)
     for (uint i = 0; i < numNodes; i++) {
         for (uint j = 0; j < i; j++) {
-            if (adjMatrix[i][j] != adjMatrix[j][i]) {
+            if (matrix.get(i, j) != matrix.get(j, i)) {
                 cerr << "Adjacency matrix ill defined: node (" << i << "," << j;
                 cerr << ") is not symmetric" << endl;
                 isWellDefined = false;
             }
-            if (adjMatrix[i][j]) {
+            if (matrix.get(i, j)) {
                 bool found = false;
                 for (uint k = 0; not found and k < adjLists[i].size(); k++) {
                     if (adjLists[i][k] == j) {
@@ -1536,7 +1497,7 @@ bool Graph::isWellDefined() {
             cerr << "Edge list ill defined: node out of range" << edgeList[i][0] << endl;
             isWellDefined = false;
         }
-        if (not adjMatrix[edgeList[i][0]][edgeList[i][1]]) {
+        if (not matrix.get(edgeList[i][0], edgeList[i][1])) {
             cerr << "Nodes " << edgeList[i][0] << " and " << edgeList[i][1];
             cerr << " adjacent in the edge list but not in the adjacency matrix" << endl;
             isWellDefined = false;
@@ -1557,7 +1518,7 @@ bool Graph::isWellDefined() {
     //check that every edge in adj matrix appears in the edge list
     for (uint i = 0; i < numNodes; i++) {
         for (uint j = 0; j < i; j++) {
-            if (adjMatrix[i][j]) {
+            if (matrix.get(i, j)) {
                 bool found = false;
                 for (uint k = 0; not found and k < edgeList.size(); k++) {
                     if ((edgeList[k][0] == i and edgeList[k][1] == j) or
@@ -1683,20 +1644,15 @@ unordered_map<ushort, ushort> Graph::getNodeTypes_ReIndexMap() const{
 
 void Graph::reIndexGraph(unordered_map<ushort, ushort> reIndexMap){
     uint n = getNumNodes();
-    // Adj Matrix
-#ifdef WEIGHTED
-    vector<vector<ushort> > adjMatrixCopy (n, vector<ushort> (n));
-#else
-    vector<vector<bool> > adjMatrixCopy (n, vector<bool> (n));
-#endif
+    Matrix matrixCopy(n);
     for (uint i = 0; i < n; i++) {
          for (uint j = 0; j < n; j++){
-              ushort a = reIndexMap[i];
+               ushort a = reIndexMap[i];
                ushort b = reIndexMap[j];
-               adjMatrixCopy[a][b] = adjMatrix[i][j];
+               matrixCopy.set(matrix.get(i, j), a, b);
          }
      }
-    adjMatrix = adjMatrixCopy;
+    matrix = matrixCopy;
 
     // Adj List
     vector<vector<ushort> > adjListsCopy(n, vector<ushort> (0));
@@ -1751,7 +1707,7 @@ uint Graph::getWeightedNumEdges() {
     if (weightedNumEdges != 0) return weightedNumEdges;
     weightedNumEdges = 0;
     for (auto c : edgeList)
-        weightedNumEdges += adjMatrix[c[0]][c[1]];
+        weightedNumEdges += matrix[c[0]][c[1]];
     return weightedNumEdges;
 }
 #endif

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -180,7 +180,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
 
     vector<string> nodes;
     nodes.reserve(nodeLen);
-    unordered_map<string,ushort> nodeName2IndexMap;
+    unordered_map<string,uint> nodeName2IndexMap;
     nodeName2IndexMap.reserve(nodeLen);
 
     vector<vector<string> > edges;
@@ -216,9 +216,9 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     }
 
 #ifdef WEIGHTED
-    vector<vector<ushort>> edgeList(vecLen, vector<ushort> (3));
+    vector<vector<uint>> edgeList(vecLen, vector<uint> (3));
 #else
-    vector<vector<ushort>> edgeList(vecLen, vector<ushort> (2));
+    vector<vector<uint>> edgeList(vecLen, vector<uint> (2));
 #endif
     stringstream errorMsg;
     string edgeValue;
@@ -256,7 +256,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     }
     nodes.shrink_to_fit();
     const size_t nodeSize = nodes.size();
-    g.adjLists = vector<vector<ushort> > (nodeSize, vector<ushort>(0));
+    g.adjLists = vector<vector<uint> > (nodeSize, vector<uint>(0));
     g.matrix = Matrix(nodeSize);
     uint node1;
     uint node2;
@@ -267,7 +267,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
         node2 = edgeList[i][1];
         if(g.matrix.isConnected(node1, node2)){
             //errorMsg << "duplicate edges not allowed (in either direction), node numbers are " << node1 << " " << node2 << '\n';
-	    unordered_map<ushort,string> index2name = g.getIndexToNodeNameMap();
+	    unordered_map<uint,string> index2name = g.getIndexToNodeNameMap();
 	    errorMsg << "In graph[" << graphName << "]: duplicate edges not allowed (in either direction), node names are " <<
                       index2name[node1] << " " << index2name[node2] << '\n';
             throw runtime_error(errorMsg.str().c_str());
@@ -347,9 +347,9 @@ void Graph::edgeList2gw(string fin, string fout) {
     // }
 
 #ifdef WEIGHTED
-    vector<vector<ushort>> edgeList(edges.size(), vector<ushort> (3));
+    vector<vector<uint>> edgeList(edges.size(), vector<uint> (3));
 #else
-    vector<vector<ushort>> edgeList(edges.size(), vector<ushort> (2));
+    vector<vector<uint>> edgeList(edges.size(), vector<uint> (2));
 #endif
     stringstream errorMsg;
 
@@ -399,21 +399,21 @@ Graph::Graph() :
     unlockedmiRNACount(0),
     geneIndexList(vector<uint>(0)),
     miRNAIndexList(vector<uint>(0)),
-    edgeList(vector<vector<ushort> > (0)),
+    edgeList(vector<vector<uint> > (0)),
     matrix(0),
-    adjLists(vector<vector<ushort> > (0)),
-    connectedComponents(vector<vector<ushort>>(0)),
+    adjLists(vector<vector<uint> > (0)),
+    connectedComponents(vector<vector<uint>>(0)),
     lockedList(vector<bool> (0)),
     lockedTo(vector<string>(0)),
     lockedCount(0),
-    nodeNameToIndexMap(unordered_map<string,ushort>(0))
+    nodeNameToIndexMap(unordered_map<string,uint>(0))
     {}
 
 Graph::Graph(const Graph& G) {
-    edgeList = vector<vector<ushort> > (G.edgeList);
+    edgeList = vector<vector<uint> > (G.edgeList);
     matrix = Matrix (G.matrix);
-    adjLists = vector<vector<ushort> > (G.adjLists);
-    connectedComponents = vector<vector<ushort> > (G.connectedComponents);
+    adjLists = vector<vector<uint> > (G.adjLists);
+    connectedComponents = vector<vector<uint> > (G.connectedComponents);
     lockedList = vector<bool> (G.lockedList);
     nodeTypes = vector<int> (G.nodeTypes);
     lockedTo = vector<string> (G.lockedTo);
@@ -427,8 +427,8 @@ Graph::Graph(const Graph& G) {
     miRNAIndexList = G.miRNAIndexList;
 }
 
-Graph::Graph(uint n, const vector<vector<ushort> > edges) {
-    adjLists = vector<vector<ushort> > (n, vector<ushort> (0));
+Graph::Graph(uint n, const vector<vector<uint> > edges) {
+    adjLists = vector<vector<uint> > (n, vector<uint> (0));
     matrix = Matrix(n);
     edgeList = edges;
 
@@ -440,7 +440,7 @@ Graph::Graph(uint n, const vector<vector<ushort> > edges) {
 
     //only add edges preserved by alignment
     for (const auto& edge: edges) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         adjLists[node1].push_back(node2);
         adjLists[node2].push_back(node1);
 #ifdef WEIGHTED
@@ -485,15 +485,15 @@ void Graph::getMatrix(Matrix& matrixCopy) const {
     matrixCopy = matrix;
 }
 
-void Graph::getAdjLists(vector<vector<ushort> >& adjListsCopy) const {
-    adjListsCopy = vector<vector<ushort> > (adjLists);
+void Graph::getAdjLists(vector<vector<uint> >& adjListsCopy) const {
+    adjListsCopy = vector<vector<uint> > (adjLists);
 }
 
-void Graph::getEdgeList(vector<vector<ushort> >& edgeListCopy) const {
+void Graph::getEdgeList(vector<vector<uint> >& edgeListCopy) const {
     edgeListCopy = edgeList;
 }
 
-const vector<vector<ushort> >& Graph::getConnectedComponents() const {
+const vector<vector<uint> >& Graph::getConnectedComponents() const {
     return connectedComponents;
 }
 
@@ -501,10 +501,10 @@ void Graph::setMatrix(Matrix& matrixCopy) {
     matrix = matrixCopy;
 }
 
-void Graph::setAdjLists(vector<vector<ushort> >& adjListsCopy) {
+void Graph::setAdjLists(vector<vector<uint> >& adjListsCopy) {
     adjLists = adjListsCopy;
 }
-void Graph::setEdgeList(vector<vector<ushort> >& edgeListCopy) {
+void Graph::setEdgeList(vector<vector<uint> >& edgeListCopy) {
     edgeList = edgeListCopy;
 }
 
@@ -550,13 +550,13 @@ void Graph::loadGwFile(const string& fileName) {
         throw runtime_error(errorMsg.str().c_str());
     }
 
-    adjLists = vector<vector<ushort> > (n, vector<ushort>(0));
+    adjLists = vector<vector<uint> > (n, vector<uint>(0));
     matrix = Matrix(n);
 #ifdef WEIGHTED
     char dump;
-    ushort edgeValue;
+    uint edgeValue;
 #endif
-    edgeList = vector<vector<ushort> > (m, vector<ushort>(2));
+    edgeList = vector<vector<uint> > (m, vector<uint>(2));
     lockedList = vector<bool> (n, false);
     lockedTo = vector<string> (n, "");
     nodeTypes = vector<int> (n, -1);
@@ -564,8 +564,8 @@ void Graph::loadGwFile(const string& fileName) {
     geneCount = miRNACount = 0;
 
     //read edges
-    ushort node1;
-    ushort node2;
+    uint node1;
+    uint node2;
 
     for (int i = 0; i < m; ++i) {
         getline(infile, line);
@@ -645,12 +645,12 @@ void Graph::multGwFile(const string& fileName, uint path) {
         errorMsg << "Failed to read edge number: " << line;
         throw runtime_error(errorMsg.str().c_str());
     }
-    SparseMatrix<ushort> sparse_graph1(n);
-    SparseMatrix<ushort> sparse_graph2(n);
+    SparseMatrix<uint> sparse_graph1(n);
+    SparseMatrix<uint> sparse_graph2(n);
 
-    adjLists = vector<vector<ushort> > (n, vector<ushort>(0));
+    adjLists = vector<vector<uint> > (n, vector<uint>(0));
     matrix = Matrix(n);
-    //edgeList = vector<vector<ushort> > (m, vector<ushort>(2));
+    //edgeList = vector<vector<uint> > (m, vector<uint>(2));
     lockedList = vector<bool> (n, false);
     lockedTo = vector<string> (n, "");
     nodeTypes = vector<int> (n, -1);
@@ -671,7 +671,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
         sparse_graph2.set(1,node2,node1);
     }
     for(uint i=0; i<path ; i++){
-        SparseMatrix<ushort> final = sparse_graph2.multiply(sparse_graph1);
+        SparseMatrix<uint> final = sparse_graph2.multiply(sparse_graph1);
         for(uint k=0;k<n;k++){
             for(uint j=0;j<n;j++){
                 sparse_graph2.set(final.get(k,j),k,j);
@@ -687,7 +687,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
             }
     }
 
-    edgeList = vector<vector<ushort> > (elements, vector<ushort>(2));
+    edgeList = vector<vector<uint> > (elements, vector<uint>(2));
     uint count = 0;
     for(uint i=0;i<n;i++){
         for(uint j=0;j<n;j++){
@@ -706,39 +706,39 @@ void Graph::multGwFile(const string& fileName, uint path) {
     initConnectedComponents();
 }
 
-bool comp_vectors(const vector<ushort>* a,const vector<ushort>* b) {
+bool comp_vectors(const vector<uint>* a,const vector<uint>* b) {
    return a->size() > b->size();
 }
 
 void Graph::initConnectedComponents() {
     //this function takes most of the initialization time
-    ushort n = getNumNodes();
-    vector<vector<ushort>* > aux(0);
-    unordered_set<ushort> nodes(n);
-    for (ushort i = 0; i < n; i++) nodes.insert(i);
+    uint n = getNumNodes();
+    vector<vector<uint>* > aux(0);
+    unordered_set<uint> nodes(n);
+    for (uint i = 0; i < n; i++) nodes.insert(i);
 
     while (nodes.size() > 0) {
-        ushort u = *nodes.begin();
+        uint u = *nodes.begin();
         nodes.erase(nodes.begin());
-        unordered_set<ushort> group;
+        unordered_set<uint> group;
         group.insert(u);
-        queue<ushort> Q;
+        queue<uint> Q;
         Q.push(u);
         while (not Q.empty()) {
-            ushort v = Q.front();
+            uint v = Q.front();
             Q.pop();
-            unordered_set<ushort> vNeighbors(adjLists[v].begin(), adjLists[v].end());
+            unordered_set<uint> vNeighbors(adjLists[v].begin(), adjLists[v].end());
             for (const auto& node: group) vNeighbors.erase(node);
             for (const auto& node: vNeighbors) nodes.erase(node);
             group.insert(vNeighbors.begin(), vNeighbors.end());
             for (const auto& node: vNeighbors) Q.push(node);
         }
-        aux.push_back(new vector<ushort> (group.begin(), group.end()));
+        aux.push_back(new vector<uint> (group.begin(), group.end()));
     }
     sort(aux.begin(), aux.end(), comp_vectors);
-    connectedComponents = vector<vector<ushort> > (aux.size(), vector<ushort> (0));
+    connectedComponents = vector<vector<uint> > (aux.size(), vector<uint> (0));
     for (uint i = 0; i < connectedComponents.size(); i++) {
-        connectedComponents[i] = vector<ushort> (aux[i]->size());
+        connectedComponents[i] = vector<uint> (aux[i]->size());
         for (uint j = 0; j < aux[i]->size(); j++) {
             connectedComponents[i][j] = (*aux[i])[j];
         }
@@ -746,35 +746,35 @@ void Graph::initConnectedComponents() {
     for(uint i = 0; i < aux.size();++i) delete aux[i];
 }
 
-uint Graph::numNodeInducedSubgraphEdges(const vector<ushort>& subgraphNodes) const {
-    unordered_set<ushort> nodeSet(subgraphNodes.begin(), subgraphNodes.end());
+uint Graph::numNodeInducedSubgraphEdges(const vector<uint>& subgraphNodes) const {
+    unordered_set<uint> nodeSet(subgraphNodes.begin(), subgraphNodes.end());
     uint count = 0;
     for (uint i = 0; i < subgraphNodes.size(); i++) {
-        ushort node1 = subgraphNodes[i];
+        uint node1 = subgraphNodes[i];
         for (uint j = 0; j < adjLists[node1].size(); j++) {
-            ushort node2 = adjLists[node1][j];
+            uint node2 = adjLists[node1][j];
             count += nodeSet.count(node2);
         }
     }
     return count/2;
 }
 
-Graph Graph::nodeInducedSubgraph(const vector<ushort>& nodes) const {
+Graph Graph::nodeInducedSubgraph(const vector<uint>& nodes) const {
     uint n = nodes.size();
-    vector<ushort> rev = reverseMapping(nodes, getNumNodes());
-    unordered_set<ushort> nodeSet(nodes.begin(), nodes.end());
+    vector<uint> rev = reverseMapping(nodes, getNumNodes());
+    unordered_set<uint> nodeSet(nodes.begin(), nodes.end());
     Graph G;
-    G.adjLists = vector<vector<ushort> > (n, vector<ushort> (0));
+    G.adjLists = vector<vector<uint> > (n, vector<uint> (0));
     G.matrix = Matrix(n);
     //only add edges between induced nodes
     for (const auto& edge: edgeList) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         if (nodeSet.count(node1) and nodeSet.count(node2)) {
-            ushort newNode1 = rev[node1];
-            ushort newNode2 = rev[node2];
+            uint newNode1 = rev[node1];
+            uint newNode2 = rev[node2];
             G.adjLists[newNode1].push_back(newNode2);
             G.adjLists[newNode2].push_back(newNode1);
-            vector<ushort> newEdge(2);
+            vector<uint> newEdge(2);
             newEdge[0] = newNode1;
             newEdge[1] = newNode2;
             G.edgeList.push_back(newEdge);
@@ -795,7 +795,7 @@ void Graph::printStats(int numConnectedComponentsToPrint, ostream& stream) const
     stream << "#connectedComponents = " << getNumConnectedComponents() << endl;
     stream << "Largest connectedComponents (nodes, edges) = ";
     for (int i = 0; i < min(numConnectedComponentsToPrint, getNumConnectedComponents()); i++) {
-        const vector<ushort>& nodes = getConnectedComponents()[i];
+        const vector<uint>& nodes = getConnectedComponents()[i];
         Graph H = nodeInducedSubgraph(nodes);
         stream << "(" << H.getNumNodes() << ", " << H.getNumEdges() << ") ";
     }
@@ -820,19 +820,19 @@ void Graph::getDistanceMatrix(vector<vector<short> >& dist) const {
 //a -1 indicates that the distance is infinite
 //floyd-warshall algorithm
 void Graph::computeDistanceMatrix(vector<vector<short> >& dist) const {
-    ushort n = getNumNodes();
+    uint n = getNumNodes();
     dist = vector<vector<short> > (n, vector<short> (n, -1));
     assert(false); // replace this with iterated Dijkstra, which is MUCH faster on sparse graphs
-    for (ushort v = 0; v < n; v++) {
+    for (uint v = 0; v < n; v++) {
         dist[v][v] = 0;
-        for (ushort i = 0; i < adjLists[v].size(); i++) {
-            ushort u = adjLists[v][i];
+        for (uint i = 0; i < adjLists[v].size(); i++) {
+            uint u = adjLists[v][i];
             dist[u][v] = 1;
         }
     }
-    for (ushort k = 0; k < n; k++) {
-        for (ushort i = 0; i < n; i++) {
-            for (ushort j = 0; j < n; j++) {
+    for (uint k = 0; k < n; k++) {
+        for (uint i = 0; i < n; i++) {
+            for (uint j = 0; j < n; j++) {
                 if (dist[i][k] != -1 and dist[k][j] != -1) {
                     if (dist[i][j] == -1 or dist[i][j] > dist[i][k] + dist[k][j]) {
                         dist[i][j] = dist[i][k] + dist[k][j];
@@ -847,7 +847,7 @@ void Graph::computeDistanceMatrix(vector<vector<short> >& dist) const {
 //The following e lines describe undirected edges with space-separated ids of their endpoints.
 //Node ids should be between 0 and n-1
 void Graph::writeGraphEdgeListFormat(const string& fileName) {
-    ushort n = getNumNodes();
+    uint n = getNumNodes();
     uint e = getNumEdges();
     ofstream outfile;
     outfile.open(fileName.c_str());
@@ -892,46 +892,46 @@ void Graph::writeGraphEdgeListFormatPINALOG(const string& fileName){
 }
 
 
-vector<ushort> Graph::numNodesAround(ushort node, ushort maxDist) const {
+vector<uint> Graph::numNodesAround(uint node, uint maxDist) const {
     uint n = getNumNodes();
-    vector<ushort> distances(n, n);
+    vector<uint> distances(n, n);
     distances[node] = 0;
-    queue<ushort> Q;
+    queue<uint> Q;
     Q.push(node);
     while (not Q.empty()) {
-        ushort u = Q.front();
+        uint u = Q.front();
         Q.pop();
-        ushort dist = distances[u];
+        uint dist = distances[u];
         if (dist == maxDist) break;
         for (uint i = 0; i < adjLists[u].size(); i++) {
-            ushort v = adjLists[u][i];
+            uint v = adjLists[u][i];
             if (distances[v] < n) continue;
             distances[v] = dist+1;
             Q.push(v);
         }
     }
-    vector<ushort> result(maxDist, 0);
+    vector<uint> result(maxDist, 0);
     for (uint i = 0; i < n; i++) {
         if (distances[i] < n and distances[i] > 0) result[distances[i]-1]++;
     }
     return result;
 }
 
-vector<ushort> Graph::numEdgesAround(ushort node, ushort maxDist) const {
+vector<uint> Graph::numEdgesAround(uint node, uint maxDist) const {
     uint n = getNumNodes();
-    vector<ushort> distances(n, n);
+    vector<uint> distances(n, n);
     vector<bool> visited(n, false);
     distances[node] = 0;
-    queue<ushort> Q;
+    queue<uint> Q;
     Q.push(node);
-    vector<ushort> result(maxDist, 0);
+    vector<uint> result(maxDist, 0);
     while (not Q.empty()) {
-        ushort u = Q.front();
+        uint u = Q.front();
         Q.pop();
-        ushort dist = distances[u];
+        uint dist = distances[u];
         if (dist == maxDist) break;
         for (uint i = 0; i < adjLists[u].size(); i++) {
-            ushort v = adjLists[u][i];
+            uint v = adjLists[u][i];
             if (not visited[v]) result[dist]++;
             if (distances[v] < n) continue;
             distances[v] = dist+1;
@@ -942,14 +942,14 @@ vector<ushort> Graph::numEdgesAround(ushort node, ushort maxDist) const {
     return result;
 }
 
-ushort Graph::randomNode() {
+uint Graph::randomNode() {
     return randInt(0, getNumNodes()-1);
 }
 
 //note: does not update CCs
-void Graph::addEdge(ushort node1, ushort node2) {
+void Graph::addEdge(uint node1, uint node2) {
     matrix.connect(true, node1, node2);
-    vector<ushort> edge(2);
+    vector<uint> edge(2);
     edge[0] = node1;
     edge[1] = node2;
     edgeList.push_back(edge);
@@ -958,7 +958,7 @@ void Graph::addEdge(ushort node1, ushort node2) {
 }
 
 //note: does not update CCs
-void Graph::removeEdge(ushort node1, ushort node2) {
+void Graph::removeEdge(uint node1, uint node2) {
     matrix.set(false, node1, node2);
     matrix.set(false, node2, node1);
     uint m = getNumEdges();
@@ -966,7 +966,7 @@ void Graph::removeEdge(ushort node1, ushort node2) {
     for (uint i = 0; i < m; i++) {
         if ((edgeList[i][0] == node1 and edgeList[i][1] == node2) or
             (edgeList[i][0] == node2 and edgeList[i][1] == node1)) {
-            vector<ushort> lastEdge = edgeList[m-1];
+            vector<uint> lastEdge = edgeList[m-1];
             edgeList[i] = lastEdge;
             edgeList.pop_back();
             break;
@@ -975,7 +975,7 @@ void Graph::removeEdge(ushort node1, ushort node2) {
     //update adjacency lists
     for (uint i = 0; i < adjLists[node1].size(); i++) {
         if (adjLists[node1][i] == node2) {
-            ushort lastNeighbor = adjLists[node1][adjLists[node1].size()-1];
+            uint lastNeighbor = adjLists[node1][adjLists[node1].size()-1];
             adjLists[node1][i] = lastNeighbor;
             adjLists[node1].pop_back();
             break;
@@ -983,7 +983,7 @@ void Graph::removeEdge(ushort node1, ushort node2) {
     }
     for (uint i = 0; i < adjLists[node2].size(); i++) {
         if (adjLists[node2][i] == node1) {
-            ushort lastNeighbor = adjLists[node2][adjLists[node2].size()-1];
+            uint lastNeighbor = adjLists[node2][adjLists[node2].size()-1];
             adjLists[node2][i] = lastNeighbor;
             adjLists[node2].pop_back();
             break;
@@ -993,7 +993,7 @@ void Graph::removeEdge(ushort node1, ushort node2) {
 
 //note: does not update CCs
 void Graph::addRandomEdge() {
-    ushort node1 = 0, node2 = 0;
+    uint node1 = 0, node2 = 0;
     while (node1 == node2 or matrix.get(node1, node2)) {
         node1 = randomNode();
         node2 = randomNode();
@@ -1003,7 +1003,7 @@ void Graph::addRandomEdge() {
 
 //note: does not update CCs
 void Graph::removeRandomEdge() {
-    ushort node1 = 0, node2 = 0;
+    uint node1 = 0, node2 = 0;
     while (node1 == node2 or not matrix.get(node1, node2)) {
         node1 = randomNode();
         node2 = randomNode();
@@ -1085,7 +1085,7 @@ vector<vector<uint> > Graph::computeGraphletDegreeVectors() {
     return gdvs;
 }
 
-unordered_map<string,ushort> Graph::getNodeNameToIndexMap() const {
+unordered_map<string,uint> Graph::getNodeNameToIndexMap() const {
     if(nodeNameToIndexMap.size() != 0){
       return nodeNameToIndexMap;
     }
@@ -1112,9 +1112,9 @@ unordered_map<string,ushort> Graph::getNodeNameToIndexMap() const {
     }
 
     //read nodes
-    unordered_map<string, ushort> res;
+    unordered_map<string, uint> res;
     string node;
-    for (ushort i = 0; i < (ushort) n; i++) {
+    for (uint i = 0; i < (uint) n; i++) {
         getline(infile, line);
         istringstream iss(line);
         if (!(iss >> node)) {
@@ -1127,9 +1127,9 @@ unordered_map<string,ushort> Graph::getNodeNameToIndexMap() const {
     return res;
 }
 
-unordered_map<ushort,string> Graph::getIndexToNodeNameMap() const {
-    unordered_map<string,ushort> reverse = getNodeNameToIndexMap();
-    unordered_map<ushort,string> res;
+unordered_map<uint,string> Graph::getIndexToNodeNameMap() const {
+    unordered_map<string,uint> reverse = getNodeNameToIndexMap();
+    unordered_map<uint,string> res;
     for (const auto &nameIndexPair : reverse ) {
         res[nameIndexPair.second] = nameIndexPair.first;
     }
@@ -1138,8 +1138,8 @@ unordered_map<ushort,string> Graph::getIndexToNodeNameMap() const {
 
 vector<string> Graph::getNodeNames() const {
     vector<string> result(getNumNodes());
-    unordered_map<ushort,string> map = getIndexToNodeNameMap();
-    for (ushort i = 0; i < getNumNodes(); i++) {
+    unordered_map<uint,string> map = getIndexToNodeNameMap();
+    for (uint i = 0; i < getNumNodes(); i++) {
         result[i] = map[i];
     }
     return result;
@@ -1290,7 +1290,7 @@ void writeGWNodes(ofstream& outfile, const vector<string>& nodeNames) {
     }
 }
 
-void writeGWEdges(ofstream& outfile, const vector<vector<ushort>>& edgeList) {
+void writeGWEdges(ofstream& outfile, const vector<vector<uint>>& edgeList) {
     uint numEdges = edgeList.size();
     outfile << numEdges << endl;
     for (uint i = 0; i < numEdges; i++) {
@@ -1304,7 +1304,7 @@ void writeGWEdges(ofstream& outfile, const vector<vector<ushort>>& edgeList) {
 }
 
 void Graph::saveInGWFormat(string outputFile, const vector<string>& nodeNames,
-    const vector<vector<ushort>>& edgeList) {
+    const vector<vector<uint>>& edgeList) {
     ofstream outfile;
     string pid = to_string(getpid()), saveIn = "/tmp/saveInGWFormat";
     string tempFile = saveIn+pid;
@@ -1317,14 +1317,14 @@ void Graph::saveInGWFormat(string outputFile, const vector<string>& nodeNames,
 }
 
 void Graph::saveInGWFormatShuffled(string outputFile, const vector<string>& nodeNames,
-    const vector<vector<ushort>>& edgeList) {
+    const vector<vector<uint>>& edgeList) {
 
     uint n = nodeNames.size();
-    vector<ushort> origPos2NewPos(n);
+    vector<uint> origPos2NewPos(n);
     for (uint i = 0; i < n; i++) origPos2NewPos[i] = i;
     randomShuffle(origPos2NewPos);
 
-    unordered_map<ushort, ushort> newPos2OrigPos;
+    unordered_map<uint, uint> newPos2OrigPos;
     newPos2OrigPos.reserve(n);
     for (uint i = 0; i < n; i++) {
         newPos2OrigPos[origPos2NewPos[i]] = i;
@@ -1336,7 +1336,7 @@ void Graph::saveInGWFormatShuffled(string outputFile, const vector<string>& node
     }
 
     uint m = edgeList.size();
-    vector<vector<ushort>> newEdgeList(m, vector<ushort> (2));
+    vector<vector<uint>> newEdgeList(m, vector<uint> (2));
     for (uint i = 0; i < m; i++) {
         newEdgeList[i][0] = origPos2NewPos[edgeList[i][0]];
         newEdgeList[i][1] = origPos2NewPos[edgeList[i][1]];
@@ -1361,7 +1361,7 @@ void Graph::saveInGWFormatWithNames(string outputFile) {
 
 void Graph::saveInShuffledOrder(string outputFile) {
     uint numNodes = getNumNodes();
-    unordered_map<ushort,string> index2Name = getIndexToNodeNameMap();
+    unordered_map<uint,string> index2Name = getIndexToNodeNameMap();
     vector<string> nodeNames(numNodes);
     for (uint i = 0; i < numNodes; i++) {
         nodeNames[i] = index2Name[i];
@@ -1390,19 +1390,19 @@ Graph Graph::randomNodeInducedSubgraph(uint numNodes) {
     uint n = getNumNodes();
     if (numNodes > n) 
         cerr << "the subgraph cannot have more nodes" << endl;
-    vector<ushort> v(getNumNodes());
+    vector<uint> v(getNumNodes());
     for (uint i = 0; i < n; i++) v[i] = i;
     randomShuffle(v);
-    v = vector<ushort> (v.begin(), v.begin()+numNodes);
+    v = vector<uint> (v.begin(), v.begin()+numNodes);
     return nodeInducedSubgraph(v);
 }
 
-Graph Graph::randomNodeShuffle(vector<ushort> &shuffle) {
+Graph Graph::randomNodeShuffle(vector<uint> &shuffle) {
     uint n = getNumNodes();
     for (uint i = 0; i < n; i++) shuffle[i] = i;
     assert(shuffle.size() == n);
     randomShuffle(shuffle);
-    shuffle = vector<ushort> (shuffle.begin(), shuffle.end());
+    shuffle = vector<uint> (shuffle.begin(), shuffle.end());
     return nodeInducedSubgraph(shuffle);
 }
 
@@ -1548,12 +1548,12 @@ bool Graph::sameNodeNames(const Graph& other) const {
 
 
 void Graph::setLockedList(vector<string>& nodes, vector<string> & pairs){
-    unordered_map<string,ushort> nodeMap = getNodeNameToIndexMap();
+    unordered_map<string,uint> nodeMap = getNodeNameToIndexMap();
     const int size = nodeMap.size();
     vector<bool> locked (size, false);
     vector<string> lockPairs (size, "");
     for(uint i = 0; i < nodes.size(); i++){
-        ushort index = nodeMap[nodes[i]];
+        uint index = nodeMap[nodes[i]];
         locked[index] = true;
         lockPairs[index] = pairs[i];
     }
@@ -1585,8 +1585,8 @@ int Graph::getLockedCount(){
  * For example if we have nodes 1,2,3,4,5 with 3,5 being locked they get reIndexed to
  * 1,2,3,4,5 -> 1,2,5,3,4
  */
-unordered_map<ushort, ushort> Graph::getLocking_ReIndexMap() const{
-    unordered_map<ushort, ushort> result;
+unordered_map<uint, uint> Graph::getLocking_ReIndexMap() const{
+    unordered_map<uint, uint> result;
     int n = getNumNodes();
     result.reserve(n);
     int unlockedIndex = 0;
@@ -1609,8 +1609,8 @@ unordered_map<ushort, ushort> Graph::getLocking_ReIndexMap() const{
  *         gene, miRNA, Locked gene or miRNA
  *
  */
-unordered_map<ushort, ushort> Graph::getNodeTypes_ReIndexMap() const{
-    unordered_map<ushort, ushort> result;
+unordered_map<uint, uint> Graph::getNodeTypes_ReIndexMap() const{
+    unordered_map<uint, uint> result;
     int n = getNumNodes();
     result.reserve(n);
     int unlocked_gene_count = 0;
@@ -1642,24 +1642,24 @@ unordered_map<ushort, ushort> Graph::getNodeTypes_ReIndexMap() const{
     return result;
 }
 
-void Graph::reIndexGraph(unordered_map<ushort, ushort> reIndexMap){
+void Graph::reIndexGraph(unordered_map<uint, uint> reIndexMap){
     uint n = getNumNodes();
     Matrix matrixCopy(n);
     for (uint i = 0; i < n; i++) {
          for (uint j = 0; j < n; j++){
-               ushort a = reIndexMap[i];
-               ushort b = reIndexMap[j];
+               uint a = reIndexMap[i];
+               uint b = reIndexMap[j];
                matrixCopy.set(matrix.get(i, j), a, b);
          }
      }
     matrix = matrixCopy;
 
     // Adj List
-    vector<vector<ushort> > adjListsCopy(n, vector<ushort> (0));
+    vector<vector<uint> > adjListsCopy(n, vector<uint> (0));
     for (uint i = 0; i < n; i++) {
        for(uint j= 0; j < adjLists[i].size(); j++){
-           ushort a = reIndexMap[i];
-           ushort b = reIndexMap[adjLists[i][j]];
+           uint a = reIndexMap[i];
+           uint b = reIndexMap[adjLists[i][j]];
            adjListsCopy[a].push_back(b);
        }
      }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -257,7 +257,7 @@ void Graph::loadFromEdgeListFile(string fin, string graphName, Graph& g, bool no
     nodes.shrink_to_fit();
     const size_t nodeSize = nodes.size();
     g.adjLists = vector<vector<uint> > (nodeSize, vector<uint>(0));
-    g.matrix = Matrix(nodeSize);
+    g.matrix = Matrix<WEIGHTED_VALUE>(nodeSize);
     uint node1;
     uint node2;
     const size_t edgeListLen = edgeList.size();
@@ -411,7 +411,7 @@ Graph::Graph() :
 
 Graph::Graph(const Graph& G) {
     edgeList = vector<vector<uint> > (G.edgeList);
-    matrix = Matrix (G.matrix);
+    matrix = Matrix<WEIGHTED_VALUE> (G.matrix);
     adjLists = vector<vector<uint> > (G.adjLists);
     connectedComponents = vector<vector<uint> > (G.connectedComponents);
     lockedList = vector<bool> (G.lockedList);
@@ -429,7 +429,7 @@ Graph::Graph(const Graph& G) {
 
 Graph::Graph(uint n, const vector<vector<uint> > edges) {
     adjLists = vector<vector<uint> > (n, vector<uint> (0));
-    matrix = Matrix(n);
+    matrix = Matrix<WEIGHTED_VALUE> (n);
     edgeList = edges;
 
     lockedList = vector<bool> (n, false);
@@ -481,7 +481,7 @@ uint Graph::getNumConnectedComponents() const {
     return connectedComponents.size();
 }
 
-void Graph::getMatrix(Matrix& matrixCopy) const {
+void Graph::getMatrix(Matrix<WEIGHTED_VALUE>& matrixCopy) const {
     matrixCopy = matrix;
 }
 
@@ -497,7 +497,7 @@ const vector<vector<uint> >& Graph::getConnectedComponents() const {
     return connectedComponents;
 }
 
-void Graph::setMatrix(Matrix& matrixCopy) {
+void Graph::setMatrix(Matrix<WEIGHTED_VALUE>& matrixCopy) {
     matrix = matrixCopy;
 }
 
@@ -551,7 +551,7 @@ void Graph::loadGwFile(const string& fileName) {
     }
 
     adjLists = vector<vector<uint> > (n, vector<uint>(0));
-    matrix = Matrix(n);
+    matrix = Matrix<WEIGHTED_VALUE>(n);
 #ifdef WEIGHTED
     char dump;
     uint edgeValue;
@@ -649,7 +649,7 @@ void Graph::multGwFile(const string& fileName, uint path) {
     SparseMatrix<uint> sparse_graph2(n);
 
     adjLists = vector<vector<uint> > (n, vector<uint>(0));
-    matrix = Matrix(n);
+    matrix = Matrix<WEIGHTED_VALUE>(n);
     //edgeList = vector<vector<uint> > (m, vector<uint>(2));
     lockedList = vector<bool> (n, false);
     lockedTo = vector<string> (n, "");
@@ -765,7 +765,7 @@ Graph Graph::nodeInducedSubgraph(const vector<uint>& nodes) const {
     unordered_set<uint> nodeSet(nodes.begin(), nodes.end());
     Graph G;
     G.adjLists = vector<vector<uint> > (n, vector<uint> (0));
-    G.matrix = Matrix(n);
+    G.matrix = Matrix<WEIGHTED_VALUE>(n);
     //only add edges between induced nodes
     for (const auto& edge: edgeList) {
         uint node1 = edge[0], node2 = edge[1];
@@ -1644,7 +1644,7 @@ unordered_map<uint, uint> Graph::getNodeTypes_ReIndexMap() const{
 
 void Graph::reIndexGraph(unordered_map<uint, uint> reIndexMap){
     uint n = getNumNodes();
-    Matrix matrixCopy(n);
+    Matrix<WEIGHTED_VALUE> matrixCopy(n);
     for (uint i = 0; i < n; i++) {
          for (uint j = 0; j < n; j++){
                uint a = reIndexMap[i];

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -73,8 +73,8 @@ public:
     uint getNumConnectedComponents() const;
 
 #ifndef NO_ADJ_MATRIX
-    void getMatrix(Matrix<WEIGHTED_VALUE>& matrix) const;
-    void setMatrix(Matrix<WEIGHTED_VALUE>& matrix);
+    void getMatrix(Matrix<MATRIX_UNIT>& matrix) const;
+    void setMatrix(Matrix<MATRIX_UNIT>& matrix);
 #endif
 
     void getAdjLists(vector<vector<uint> >& adjListsCopy) const;
@@ -170,7 +170,7 @@ private:
     //double maxsize;
     vector<vector<uint> > edgeList; //edges in no particular order
 #ifndef NO_ADJ_MATRIX
-    Matrix<WEIGHTED_VALUE> matrix;
+    Matrix<MATRIX_UNIT> matrix;
 #endif
     vector<vector<uint> > adjLists; //neighbors in no particular order
 

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -22,8 +22,8 @@
 #include "utils/utils.hpp"
 #include "utils/Timer.hpp"
 #include "computeGraphlets.hpp"
-#include "utils/utils.hpp"
-#include "SparseMatrix.h"
+#include "utils/Matrix.hpp"
+
 
 using namespace std;
 
@@ -71,15 +71,12 @@ public:
     uint getNumEdges() const;
     const vector<vector<ushort> >& getConnectedComponents() const;
     uint getNumConnectedComponents() const;
+
 #ifndef NO_ADJ_MATRIX
-#ifdef WEIGHTED
-    void getAdjMatrix(vector<vector<ushort> >& adjMatrixCopy) const;
-    void setAdjMatrix(vector<vector<ushort> >& adjMatrixCopy);
-#else
-    void getAdjMatrix(vector<vector<bool> >& adjMatrixCopy) const;
-    void setAdjMatrix(vector<vector<bool> >& adjMatrixCopy);
+    void getMatrix(Matrix& matrix) const;
+    void setMatrix(Matrix& matrix);
 #endif
-#endif
+
     void getAdjLists(vector<vector<ushort> >& adjListsCopy) const;
     void getEdgeList(vector<vector<ushort> > & edgeListCopy) const;
 
@@ -173,11 +170,7 @@ private:
     //double maxsize;
     vector<vector<ushort> > edgeList; //edges in no particular order
 #ifndef NO_ADJ_MATRIX
-#ifdef WEIGHTED
-    vector<vector<ushort> > adjMatrix;
-#else
-    vector<vector<bool> > adjMatrix;
-#endif
+    Matrix matrix;
 #endif
     vector<vector<ushort> > adjLists; //neighbors in no particular order
 
@@ -214,7 +207,7 @@ private:
     template<class Archive>
     void serialize(Archive& archive)
     {
-        archive(CEREAL_NVP(adjLists), CEREAL_NVP(adjMatrix), CEREAL_NVP(edgeList), CEREAL_NVP(lockedList),
+        archive(CEREAL_NVP(adjLists), CEREAL_NVP(matrix), CEREAL_NVP(edgeList), CEREAL_NVP(lockedList),
                 CEREAL_NVP(lockedTo), CEREAL_NVP(nodeTypes), CEREAL_NVP(miRNACount), CEREAL_NVP(geneCount), 
                 CEREAL_NVP(connectedComponents), CEREAL_NVP(unlockedGeneCount), CEREAL_NVP(unlockedmiRNACount), 
                 CEREAL_NVP(lockedCount), CEREAL_NVP(geneIndexList), CEREAL_NVP(miRNAIndexList), CEREAL_NVP(nodeNameToIndexMap));

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -73,8 +73,8 @@ public:
     uint getNumConnectedComponents() const;
 
 #ifndef NO_ADJ_MATRIX
-    void getMatrix(Matrix& matrix) const;
-    void setMatrix(Matrix& matrix);
+    void getMatrix(Matrix<WEIGHTED_VALUE>& matrix) const;
+    void setMatrix(Matrix<WEIGHTED_VALUE>& matrix);
 #endif
 
     void getAdjLists(vector<vector<uint> >& adjListsCopy) const;
@@ -170,7 +170,7 @@ private:
     //double maxsize;
     vector<vector<uint> > edgeList; //edges in no particular order
 #ifndef NO_ADJ_MATRIX
-    Matrix matrix;
+    Matrix<WEIGHTED_VALUE> matrix;
 #endif
     vector<vector<uint> > adjLists; //neighbors in no particular order
 

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -46,9 +46,9 @@ public:
     void serializeShadow(Graph& G);
 
     static void saveInGWFormat(string outputFile, const vector<string>& nodeNames,
-        const vector<vector<ushort>>& edgeList);
+        const vector<vector<uint>>& edgeList);
     static void saveInGWFormatShuffled(string outputFile, const vector<string>& nodeNames,
-        const vector<vector<ushort>>& edgeList);
+        const vector<vector<uint>>& edgeList);
 
     static void edgeList2gw(string fin, string fout);
 
@@ -60,7 +60,7 @@ public:
     Graph(const Graph& G);
     //double maxsize;
 
-    Graph(uint n, const vector<vector<ushort> > edgeList);
+    Graph(uint n, const vector<vector<uint> > edgeList);
 
     string getName() const;
 
@@ -69,7 +69,7 @@ public:
     uint getWeightedNumEdges();
 #endif
     uint getNumEdges() const;
-    const vector<vector<ushort> >& getConnectedComponents() const;
+    const vector<vector<uint> >& getConnectedComponents() const;
     uint getNumConnectedComponents() const;
 
 #ifndef NO_ADJ_MATRIX
@@ -77,11 +77,11 @@ public:
     void setMatrix(Matrix& matrix);
 #endif
 
-    void getAdjLists(vector<vector<ushort> >& adjListsCopy) const;
-    void getEdgeList(vector<vector<ushort> > & edgeListCopy) const;
+    void getAdjLists(vector<vector<uint> >& adjListsCopy) const;
+    void getEdgeList(vector<vector<uint> > & edgeListCopy) const;
 
-    void setAdjLists(vector<vector<ushort> >& adjListsCopy);
-    void setEdgeList(vector<vector<ushort> >& edgeListCopy);
+    void setAdjLists(vector<vector<uint> >& adjListsCopy);
+    void setEdgeList(vector<vector<uint> >& edgeListCopy);
 
     vector<string> getNodeNames() const;
 
@@ -92,12 +92,12 @@ public:
     void multGwFile(const string& fileName, uint path);
 
     //nodes are relabeled so that the new i-th node is the node nodes[i]-th in this
-    Graph nodeInducedSubgraph(const vector<ushort>& nodes) const;
+    Graph nodeInducedSubgraph(const vector<uint>& nodes) const;
 
-    uint numNodeInducedSubgraphEdges(const vector<ushort>& subgraphNodes) const;
+    uint numNodeInducedSubgraphEdges(const vector<uint>& subgraphNodes) const;
 
-    vector<ushort> numEdgesAround(ushort node, ushort maxDist) const;
-    vector<ushort> numNodesAround(ushort node, ushort maxDist) const;
+    vector<uint> numEdgesAround(uint node, uint maxDist) const;
+    vector<uint> numNodesAround(uint node, uint maxDist) const;
 
     void printStats(int numConnectedComponentsToPrint, ostream& stream) const;
 
@@ -110,12 +110,12 @@ public:
     void removeRandomEdges(double removedEdgesProportion);
     void rewireRandomEdges(double rewiredEdgesProportion);
 
-    ushort randomNode();
+    uint randomNode();
 
     vector<vector<uint> > loadGraphletDegreeVectors();
 
-    unordered_map<string,ushort> getNodeNameToIndexMap() const;
-    unordered_map<ushort,string> getIndexToNodeNameMap() const;
+    unordered_map<string,uint> getNodeNameToIndexMap() const;
+    unordered_map<uint,string> getIndexToNodeNameMap() const;
 
     void getDistanceMatrix(vector<vector<short> >& dist) const;
 
@@ -129,7 +129,7 @@ public:
     void saveGraphletsAsSigs(string outputFile);
 
     Graph randomNodeInducedSubgraph(uint numNodes);
-    Graph randomNodeShuffle(vector<ushort> &shuffle);
+    Graph randomNodeShuffle(vector<uint> &shuffle);
 
     bool isWellDefined();
 
@@ -142,10 +142,10 @@ public:
     string getLockedTo(uint index);
     int getLockedCount();
 
-    unordered_map<ushort, ushort> getLocking_ReIndexMap() const;
-    unordered_map<ushort, ushort> getNodeTypes_ReIndexMap() const;
+    unordered_map<uint, uint> getLocking_ReIndexMap() const;
+    unordered_map<uint, uint> getNodeTypes_ReIndexMap() const;
 
-    void reIndexGraph(unordered_map<ushort, ushort> reIndexMap);  // Changes the node indexes according to the map
+    void reIndexGraph(unordered_map<uint, uint> reIndexMap);  // Changes the node indexes according to the map
 
     //string getNodeType(uint i);
     int getNodeType(uint i);
@@ -161,21 +161,21 @@ public:
     int unlockedmiRNACount = -1;
     vector<uint> geneIndexList;
     vector<uint> miRNAIndexList;
-    void removeEdge(ushort node1, ushort node2);
+    void removeEdge(uint node1, uint node2);
 
 private:
     double maxGraphletSize = 4; //default is 4, 5 is too big
     string name;
     string path;
     //double maxsize;
-    vector<vector<ushort> > edgeList; //edges in no particular order
+    vector<vector<uint> > edgeList; //edges in no particular order
 #ifndef NO_ADJ_MATRIX
     Matrix matrix;
 #endif
-    vector<vector<ushort> > adjLists; //neighbors in no particular order
+    vector<vector<uint> > adjLists; //neighbors in no particular order
 
     //list of the nodes of each connected component, sorted from larger to smaller
-    vector<vector<ushort> > connectedComponents;
+    vector<vector<uint> > connectedComponents;
     //int maxsize;
 
     // NOTE: these don't change after reIndexing G1 (method #3 of locking),
@@ -186,13 +186,13 @@ private:
     int lockedCount = 0;
 
 
-    unordered_map<string,ushort> nodeNameToIndexMap;
+    unordered_map<string,uint> nodeNameToIndexMap;
 
     void updateUnlockedGeneCount();
 
     void initConnectedComponents();
 
-    void addEdge(ushort node1, ushort node2);
+    void addEdge(uint node1, uint node2);
     void addRandomEdge();
     void removeRandomEdge();
 

--- a/src/arguments/graphLoader.cpp
+++ b/src/arguments/graphLoader.cpp
@@ -284,8 +284,8 @@ void initGraphs(Graph& G1, Graph& G2, ArgumentParser& args) {
 
         vector<string> validLocksG1;
         vector<string> validLocksG2;
-        unordered_map<string,ushort> mapG1 = G1.getNodeNameToIndexMap();
-        unordered_map<string,ushort> mapG2 = G2.getNodeNameToIndexMap();
+        unordered_map<string,uint> mapG1 = G1.getNodeNameToIndexMap();
+        unordered_map<string,uint> mapG2 = G2.getNodeNameToIndexMap();
 
         for(uint i = 0; i < column1.size(); i++){
             bool validLock = true;

--- a/src/arguments/measureSelector.cpp
+++ b/src/arguments/measureSelector.cpp
@@ -335,7 +335,7 @@ void initMeasures(MeasureCombination& M, Graph& G1, Graph& G2, ArgumentParser& a
     } 
     else if (G1.sameNodeNames(G2)) {
         Alignment a(Alignment::correctMapping(G1,G2));
-        vector<ushort> mapping = a.getMapping();
+        vector<uint> mapping = a.getMapping();
         mapping.push_back(G1.getNumNodes());
         double ncWeight = 0;
         try{

--- a/src/complementaryProteins.cpp
+++ b/src/complementaryProteins.cpp
@@ -33,8 +33,8 @@ vector<vector<string> > getProteinPairs(string complementStatus, bool BioGRIDNet
 }
 
 vector<vector<string> > getAlignedPairs(const Graph& G1, const Graph& G2, const Alignment& A) {
-    unordered_map<ushort,string> G1Names = G1.getIndexToNodeNameMap();
-    unordered_map<ushort,string> G2Names = G2.getIndexToNodeNameMap();
+    unordered_map<uint,string> G1Names = G1.getIndexToNodeNameMap();
+    unordered_map<uint,string> G2Names = G2.getIndexToNodeNameMap();
     vector<vector<string> > res(A.size(), vector<string> (2));
     for (uint i = 0; i < A.size(); i++) {
         res[i][0] = G1Names[i];
@@ -85,8 +85,8 @@ void printComplementaryProteinCounts(const Alignment& A, bool BioGRIDNetworks) {
 vector<uint> countProteinPairsInNetworks(const Graph& G1, const Graph& G2, bool BioGRIDNetworks) {
     vector<vector<string> > complementProteins = getProteinPairs("1", BioGRIDNetworks);
     vector<vector<string> > nonComplementProteins = getProteinPairs("0", BioGRIDNetworks);
-    unordered_map<ushort,string> G1Names = G1.getIndexToNodeNameMap();
-    unordered_map<ushort,string> G2Names = G2.getIndexToNodeNameMap();
+    unordered_map<uint,string> G1Names = G1.getIndexToNodeNameMap();
+    unordered_map<uint,string> G2Names = G2.getIndexToNodeNameMap();
     uint n1 = G1.getNumNodes();
     uint n2 = G2.getNumNodes();
 
@@ -142,8 +142,8 @@ void printProteinPairCountInNetworks(bool BioGRIDNetworks) {
     Graph G2 = BioGRIDNetworks ? Graph::loadGraph("HSapiens") : Graph::loadGraph("human");
     vector<vector<string> > complementProteins = getProteinPairs("1", BioGRIDNetworks);
     vector<vector<string> > nonComplementProteins = getProteinPairs("0", BioGRIDNetworks);
-    unordered_map<ushort,string> G1Names = G1.getIndexToNodeNameMap();
-    unordered_map<ushort,string> G2Names = G2.getIndexToNodeNameMap();
+    unordered_map<uint,string> G1Names = G1.getIndexToNodeNameMap();
+    unordered_map<uint,string> G2Names = G2.getIndexToNodeNameMap();
     uint n1 = G1.getNumNodes();
     uint n2 = G2.getNumNodes();
 
@@ -209,8 +209,8 @@ void printProteinPairCountInNetworks(bool BioGRIDNetworks) {
 }
 
 void fillTableColumn(vector<vector<string> >& table, uint col, vector<vector<float> >* simMatrix,
-    const vector<vector<ushort> >& complementProteins, const vector<vector<ushort> >& nonComplementProteins,
-    const vector<vector<ushort> >& randomProteins) {
+    const vector<vector<uint> >& complementProteins, const vector<vector<uint> >& nonComplementProteins,
+    const vector<vector<uint> >& randomProteins) {
     uint nComp = complementProteins.size();
     uint nNoComp = nonComplementProteins.size();
     uint nRand = randomProteins.size();
@@ -236,21 +236,21 @@ void printLocalTopologicalSimilarities(Graph& G1, Graph& G2, bool BioGRIDNetwork
     vector<vector<string> > nonComplementProteinNames = getProteinPairs("0", BioGRIDNetworks);
     uint nComp = complementProteinNames.size();
     uint nNoComp = nonComplementProteinNames.size();
-    unordered_map<string,ushort> G1Indices = G1.getNodeNameToIndexMap();
-    unordered_map<string,ushort> G2Indices = G2.getNodeNameToIndexMap();
+    unordered_map<string,uint> G1Indices = G1.getNodeNameToIndexMap();
+    unordered_map<string,uint> G2Indices = G2.getNodeNameToIndexMap();
 
-    vector<vector<ushort> > complementProteins(nComp, vector<ushort> (2));
+    vector<vector<uint> > complementProteins(nComp, vector<uint> (2));
     for (uint i = 0; i < nComp; i++) {
         complementProteins[i][0] = G1Indices[complementProteinNames[i][0]];
         complementProteins[i][1] = G2Indices[complementProteinNames[i][1]];
     }
-    vector<vector<ushort> > nonComplementProteins(nNoComp, vector<ushort> (2));
+    vector<vector<uint> > nonComplementProteins(nNoComp, vector<uint> (2));
     for (uint i = 0; i < nComp; i++) {
         nonComplementProteins[i][0] = G1Indices[nonComplementProteinNames[i][0]];
         nonComplementProteins[i][1] = G2Indices[nonComplementProteinNames[i][1]];
     }
     const uint NUM_RANDOM_PAIRS = 200;
-    vector<vector<ushort> > randomProteins(NUM_RANDOM_PAIRS, vector<ushort> (2));
+    vector<vector<uint> > randomProteins(NUM_RANDOM_PAIRS, vector<uint> (2));
     uint n1 = G1.getNumNodes();
     uint n2 = G2.getNumNodes();
     for (uint i = 0; i < NUM_RANDOM_PAIRS; i++) {

--- a/src/measures/ExternalWeightedEdgeConservation.cpp
+++ b/src/measures/ExternalWeightedEdgeConservation.cpp
@@ -21,7 +21,7 @@ double ExternalWeightedEdgeConservation::eval(const Alignment& A){
     double score = 0;
     for (const auto& edge: edgeListG1) {
         uint node1 = edge[0], node2 = edge[1];
-        if (matrixG2.get(A[node1], A[node2])) {
+        if (matrixG2[A[node1]][A[node2]]) {
             std::string n1s = nodeNamesG1[node1], n2s = nodeNamesG1[node2];
             std::string an1s = nodeNamesG2[A[node1]], an2s = nodeNamesG2[A[node2]];
             int e1 = getRowIndex(n1s, n2s); //Row for G1 and Col for G2

--- a/src/measures/ExternalWeightedEdgeConservation.cpp
+++ b/src/measures/ExternalWeightedEdgeConservation.cpp
@@ -14,13 +14,13 @@ ExternalWeightedEdgeConservation::ExternalWeightedEdgeConservation(Graph* G1, Gr
 }
 
 double ExternalWeightedEdgeConservation::eval(const Alignment& A){
-    std::vector<std::vector<ushort> > edgeListG1;
+    std::vector<std::vector<uint> > edgeListG1;
     G1->getEdgeList(edgeListG1);
     //std::vector<std::vector<bool> > adjMatrixG2;
     //G2->getAdjMatrix(adjMatrixG2);
     double score = 0;
     for (const auto& edge: edgeListG1) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         if (matrixG2.get(A[node1], A[node2])) {
             std::string n1s = nodeNamesG1[node1], n2s = nodeNamesG1[node2];
             std::string an1s = nodeNamesG2[A[node1]], an2s = nodeNamesG2[A[node2]];
@@ -127,30 +127,30 @@ int ExternalWeightedEdgeConservation::getRowIndex(std::string n1, std::string n2
     return getRowIndex(n1Index, n2Index);
 }
 
-int ExternalWeightedEdgeConservation::getColIndex(ushort n1, ushort n2){
+int ExternalWeightedEdgeConservation::getColIndex(uint n1, uint n2){
     bool orderCorrect = n1 < n2;
     if(!orderCorrect){
-        ushort n3 = n1;
+        uint n3 = n1;
         n1 = n2;
         n2 = n3;
     }
     return colIndex[n1][n2];
 }
 
-int ExternalWeightedEdgeConservation::getRowIndex(ushort n1, ushort n2){
+int ExternalWeightedEdgeConservation::getRowIndex(uint n1, uint n2){
     bool orderCorrect = n1 < n2;
     if(!orderCorrect){
-        ushort n3 = n1;
+        uint n3 = n1;
         n1 = n2;
         n2 = n3;
     }
     return rowIndex[n1][n2];
 }
 /* Deprecated, do not use.
-double ExternalWeightedEdgeConservation::simScore(ushort source, ushort target, const Alignment& A){
+double ExternalWeightedEdgeConservation::simScore(uint source, uint target, const Alignment& A){
     double score = 0;
     for (uint i = 0; i < adjListG1[source].size(); ++i) {
-        ushort neighbor = adjListG1[source][i];
+        uint neighbor = adjListG1[source][i];
         if (adjMatrixG2[target][A[neighbor]]) {
             int e1 = getRowIndex(source, neighbor);
             int e2 = getColIndex(target, A[neighbor]);
@@ -161,8 +161,8 @@ double ExternalWeightedEdgeConservation::simScore(ushort source, ushort target, 
     return score;
 }
 
-double ExternalWeightedEdgeConservation::changeOp(ushort source, ushort oldTarget, ushort newTarget, const Alignment& A){
-    ushort neighbor;
+double ExternalWeightedEdgeConservation::changeOp(uint source, uint oldTarget, uint newTarget, const Alignment& A){
+    uint neighbor;
     int e1, e2;
     double score = 0;
     int size1 = adjListG1[source].size();
@@ -187,8 +187,8 @@ double ExternalWeightedEdgeConservation::changeOp(ushort source, ushort oldTarge
     return score;
 }
 
-double ExternalWeightedEdgeConservation::swapOp(ushort source1, ushort source2, ushort target1, ushort target2, const Alignment& A){
-    ushort neighbor;
+double ExternalWeightedEdgeConservation::swapOp(uint source1, uint source2, uint target1, uint target2, const Alignment& A){
+    uint neighbor;
     int e1, e2;
     double score = 0;
     int size1 = adjListG1[source1].size();
@@ -212,7 +212,7 @@ double ExternalWeightedEdgeConservation::swapOp(ushort source1, ushort source2, 
     }
 
     for(int i = 0; i < size2; ++i){
-        ushort neighbor = adjListG1[source2][i];
+        uint neighbor = adjListG1[source2][i];
         if(adjMatrixG2[target2][A[neighbor]]){
             std::string n1s = nodeNamesG1[source2], n2s = nodeNamesG1[neighbor];
             std::string an1s = nodeNamesG2[target2], an2s = nodeNamesG2[A[neighbor]];

--- a/src/measures/ExternalWeightedEdgeConservation.cpp
+++ b/src/measures/ExternalWeightedEdgeConservation.cpp
@@ -6,8 +6,8 @@
 ExternalWeightedEdgeConservation::ExternalWeightedEdgeConservation(Graph* G1, Graph* G2, std::string scoresFile) : Measure(G1, G2, "ewec"){
     G1->getAdjLists(adjListG1);
     G2->getAdjLists(adjListG2);
-    G1->getAdjMatrix(adjMatrixG1);
-    G2->getAdjMatrix(adjMatrixG2);
+    G1->getMatrix(matrixG1);
+    G2->getMatrix(matrixG2);
     nodeNamesG1 = G1->getNodeNames();
     nodeNamesG2 = G2->getNodeNames();
     loadMatrix(scoresFile);
@@ -21,7 +21,7 @@ double ExternalWeightedEdgeConservation::eval(const Alignment& A){
     double score = 0;
     for (const auto& edge: edgeListG1) {
         ushort node1 = edge[0], node2 = edge[1];
-        if (adjMatrixG2[A[node1]][A[node2]]) {
+        if (matrixG2.get(A[node1], A[node2])) {
             std::string n1s = nodeNamesG1[node1], n2s = nodeNamesG1[node2];
             std::string an1s = nodeNamesG2[A[node1]], an2s = nodeNamesG2[A[node2]];
             int e1 = getRowIndex(n1s, n2s); //Row for G1 and Col for G2

--- a/src/measures/ExternalWeightedEdgeConservation.hpp
+++ b/src/measures/ExternalWeightedEdgeConservation.hpp
@@ -28,8 +28,8 @@ private:
     std::vector<std::vector<int>> rowIndex;
     std::vector<std::vector<uint> > adjListG1;
     std::vector<std::vector<uint> > adjListG2;
-    Matrix<WEIGHTED_VALUE> matrixG1;
-    Matrix<WEIGHTED_VALUE> matrixG2;
+    Matrix<MATRIX_UNIT> matrixG1;
+    Matrix<MATRIX_UNIT> matrixG2;
     std::vector<std::string> nodeNamesG1;
     std::vector<std::string> nodeNamesG2;
 

--- a/src/measures/ExternalWeightedEdgeConservation.hpp
+++ b/src/measures/ExternalWeightedEdgeConservation.hpp
@@ -15,19 +15,19 @@ public:
     ExternalWeightedEdgeConservation(Graph* G1, Graph* G2, std::string scoresFile);
     //virtual ~ExternalWeightedEdgeConservation();
     double eval(const Alignment& A);
-    //double simScore(ushort source, ushort target, const Alignment& A);
-    //double changeOp(ushort source, ushort oldTarget, ushort newTarget, const Alignment& A);
-    //double swapOp(ushort source1, ushort source2, ushort target1, ushort target2, const Alignment& A);
-    int getColIndex(ushort n1, ushort n2); //make these private before you push 
-    int getRowIndex(ushort n1, ushort n2);
+    //double simScore(uint source, uint target, const Alignment& A);
+    //double changeOp(uint source, uint oldTarget, uint newTarget, const Alignment& A);
+    //double swapOp(uint source1, uint source2, uint target1, uint target2, const Alignment& A);
+    int getColIndex(uint n1, uint n2); //make these private before you push 
+    int getRowIndex(uint n1, uint n2);
     double getScore(int colNum, int rowNum); //returns sim score given the indices of the col and row
 
 private:
     std::vector<std::vector<double>> simScores;
     std::vector<std::vector<int>> colIndex;
     std::vector<std::vector<int>> rowIndex;
-    std::vector<std::vector<ushort> > adjListG1;
-    std::vector<std::vector<ushort> > adjListG2;
+    std::vector<std::vector<uint> > adjListG1;
+    std::vector<std::vector<uint> > adjListG2;
     Matrix matrixG1;
     Matrix matrixG2;
     std::vector<std::string> nodeNamesG1;

--- a/src/measures/ExternalWeightedEdgeConservation.hpp
+++ b/src/measures/ExternalWeightedEdgeConservation.hpp
@@ -28,8 +28,8 @@ private:
     std::vector<std::vector<int>> rowIndex;
     std::vector<std::vector<uint> > adjListG1;
     std::vector<std::vector<uint> > adjListG2;
-    Matrix matrixG1;
-    Matrix matrixG2;
+    Matrix<WEIGHTED_VALUE> matrixG1;
+    Matrix<WEIGHTED_VALUE> matrixG2;
     std::vector<std::string> nodeNamesG1;
     std::vector<std::string> nodeNamesG2;
 

--- a/src/measures/ExternalWeightedEdgeConservation.hpp
+++ b/src/measures/ExternalWeightedEdgeConservation.hpp
@@ -28,13 +28,8 @@ private:
     std::vector<std::vector<int>> rowIndex;
     std::vector<std::vector<ushort> > adjListG1;
     std::vector<std::vector<ushort> > adjListG2;
-#ifdef WEIGHTED
-    std::vector<std::vector<ushort> > adjMatrixG1;
-    std::vector<std::vector<ushort> > adjMatrixG2;
-#else
-    std::vector<std::vector<bool> > adjMatrixG1;
-    std::vector<std::vector<bool> > adjMatrixG2;
-#endif
+    Matrix matrixG1;
+    Matrix matrixG2;
     std::vector<std::string> nodeNamesG1;
     std::vector<std::string> nodeNamesG2;
 

--- a/src/measures/LargestCommonConnectedSubgraph.cpp
+++ b/src/measures/LargestCommonConnectedSubgraph.cpp
@@ -10,14 +10,14 @@ LargestCommonConnectedSubgraph::~LargestCommonConnectedSubgraph() {
 
 double LargestCommonConnectedSubgraph::eval(const Alignment& A) {
     Graph CS = A.commonSubgraph(*G1, *G2);
-    vector<ushort> LCCSNodes = CS.getConnectedComponents()[0]; //largest CC
+    vector<uint> LCCSNodes = CS.getConnectedComponents()[0]; //largest CC
     uint n = LCCSNodes.size();
     double N = (double) n/G1->getNumNodes();
     if (not USE_MAGNA_DEFINITION) return N;
 
     // To Get the indexes of the common subgraph in G2
-    vector<ushort> LCCSNodesG2;
-    for(ushort node: LCCSNodes)
+    vector<uint> LCCSNodesG2;
+    for(uint node: LCCSNodes)
         LCCSNodesG2.push_back(A[node]);
 
     Graph G1InducedSubgraph = G1->nodeInducedSubgraph(LCCSNodes);
@@ -30,7 +30,7 @@ double LargestCommonConnectedSubgraph::eval(const Alignment& A) {
 
 double LargestCommonConnectedSubgraph::nodeProportion(const Alignment& A) {
     Graph CS = A.commonSubgraph(*G1, *G2);
-    vector<ushort> LCCSNodes = CS.getConnectedComponents()[0]; //largest CC
+    vector<uint> LCCSNodes = CS.getConnectedComponents()[0]; //largest CC
     uint n = LCCSNodes.size();
     return (double) n/G1->getNumNodes();
 }

--- a/src/measures/Measure.hpp
+++ b/src/measures/Measure.hpp
@@ -16,7 +16,7 @@ public:
     virtual bool isLocal();
     virtual double balanceWeight() {return 0;};
     
-    virtual vector<ushort> getMappingforNC() const {return vector<ushort>{0};}
+    virtual vector<uint> getMappingforNC() const {return vector<uint>{0};}
 protected:
     Graph* G1;
     Graph* G2;

--- a/src/measures/MeasureCombination.cpp
+++ b/src/measures/MeasureCombination.cpp
@@ -325,7 +325,7 @@ void MeasureCombination::setWeight(const string& measureName, double weight) {
 Pairwise Alignment  LocalMeasure1       LocalMeasure2       Weighted Sum
 821    723            0.334               0.214               0.548
 */
-typedef unordered_map<ushort,string> NodeIndexMap;
+typedef unordered_map<uint,string> NodeIndexMap;
 void MeasureCombination::writeLocalScores(ostream & outFile, Graph const & G1, Graph const & G2, Alignment const & A) const {
   NodeIndexMap mapG1 = G1.getIndexToNodeNameMap();
   NodeIndexMap mapG2 = G2.getIndexToNodeNameMap();

--- a/src/measures/NetGO.cpp
+++ b/src/measures/NetGO.cpp
@@ -78,8 +78,8 @@ double NetGO::eval(const Alignment& A) {
     unordered_map<uint,uint> goCountG1 = GoSimilarity::getGoCounts(*G1);
     unordered_map<uint,uint> goCountG2 = GoSimilarity::getGoCounts(*G2);
 #if 0
-    map<ushort,string> namesG1 = G1->getIndexToNodeNameMap();
-    map<ushort,string> namesG2 = G2->getIndexToNodeNameMap();
+    map<uint,string> namesG1 = G1->getIndexToNodeNameMap();
+    map<uint,string> namesG2 = G2->getIndexToNodeNameMap();
 #endif
     double total = 0;
     for (uint i = 0; i < n1; i++) {

--- a/src/measures/NodeCorrectness.cpp
+++ b/src/measures/NodeCorrectness.cpp
@@ -46,11 +46,11 @@ double NodeCorrectness::eval(const Alignment& A) {
     return (double) count / trueA.getBack();
 }
 
-vector<ushort> NodeCorrectness::convertAlign(const Graph& G1, const Graph& G2, const vector<string>& E){
+vector<uint> NodeCorrectness::convertAlign(const Graph& G1, const Graph& G2, const vector<string>& E){
     //necessary variables
-    unordered_map<string,ushort> mapG1 = G1.getNodeNameToIndexMap();
-    unordered_map<string,ushort> mapG2 = G2.getNodeNameToIndexMap();
-    vector<ushort> alignment(G1.getNumNodes(), G2.getNumNodes());
+    unordered_map<string,uint> mapG1 = G1.getNodeNameToIndexMap();
+    unordered_map<string,uint> mapG2 = G2.getNodeNameToIndexMap();
+    vector<uint> alignment(G1.getNumNodes(), G2.getNumNodes());
     //this is the initial size of the provided true alignment file
     alignment.push_back(E.size()/2);
 
@@ -112,7 +112,7 @@ vector<ushort> NodeCorrectness::convertAlign(const Graph& G1, const Graph& G2, c
     return alignment;
 }
 
-vector<ushort> NodeCorrectness::getMappingforNC() const{
+vector<uint> NodeCorrectness::getMappingforNC() const{
     return trueA.getMapping();
 }
 

--- a/src/measures/NodeCorrectness.hpp
+++ b/src/measures/NodeCorrectness.hpp
@@ -8,8 +8,8 @@ public:
     NodeCorrectness(const Alignment& A);
     virtual ~NodeCorrectness();
     double eval(const Alignment& A);
-    virtual vector<ushort> getMappingforNC() const;
-    static vector<ushort> convertAlign(const Graph& G1, const Graph& G2, const vector<string>& E);        
+    virtual vector<uint> getMappingforNC() const;
+    static vector<uint> convertAlign(const Graph& G1, const Graph& G2, const vector<string>& E);        
     static bool fulfillsPrereqs(Graph* G1, Graph* G2);
     
 private:

--- a/src/measures/ShortestPathConservation.cpp
+++ b/src/measures/ShortestPathConservation.cpp
@@ -7,8 +7,8 @@ ShortestPathConservation::ShortestPathConservation(Graph* G1, Graph* G2) : Measu
     
     G1->getDistanceMatrix(distMatrixG1);
     G2->getDistanceMatrix(distMatrixG2);
-    ushort maxDistG1 = matrixMax(distMatrixG1);
-    ushort maxDistG2 = matrixMax(distMatrixG2);
+    uint maxDistG1 = matrixMax(distMatrixG1);
+    uint maxDistG2 = matrixMax(distMatrixG2);
     maxDist = max(maxDistG1, maxDistG2);
 }
 

--- a/src/measures/SquaredEdgeScore.cpp
+++ b/src/measures/SquaredEdgeScore.cpp
@@ -21,7 +21,12 @@ double SquaredEdgeScore::getDenom(void){return SES_DENOM;}
 
 double SquaredEdgeScore::eval(const Alignment& A) {
 #ifdef WEIGHTED
-    return (double) A.numSquaredAlignedEdges(*G1, *G2) / SES_DENOM;
+    #ifdef SPARSE
+        return -1; // A.numSquaredAlignedEdges has speed complexity of o(n^2)
+                   // It will not finish for big networks.
+    #else
+        return (double) A.numSquaredAlignedEdges(*G1, *G2) / SES_DENOM;
+    #endif
 #else
     // ses not make much sense for non-weighted
     return -1;

--- a/src/measures/TriangleCorrectness.cpp
+++ b/src/measures/TriangleCorrectness.cpp
@@ -22,20 +22,16 @@ double TriangleCorrectness::eval(const Alignment& A){
 int TriangleCorrectness::calculateTriangles(Graph* G){
     int numTriangles = 0;
     vector<vector<ushort> > GAdjLists;
-#ifdef WEIGHTED
-    vector<vector<ushort> > GAdjMatrix;
-#else
-    vector<vector<bool> > GAdjMatrix;
-#endif
+    Matrix GMatrix;
     G->getAdjLists(GAdjLists);
-    G->getAdjMatrix(GAdjMatrix);
+    G->getMatrix(GMatrix);
     for(uint i = 0; i < G->getNumNodes(); i++){
         for(uint j = 0; j < GAdjLists[i].size(); j++){
             for(uint k = 0; k < GAdjLists[i].size(); k++){
                 if(k != j){
                     ushort neighbor1 = GAdjLists[i][j];
                     ushort neighbor2 = GAdjLists[i][k];
-                    if(GAdjMatrix[neighbor1][neighbor2]){
+                    if(GMatrix.get(neighbor1, neighbor2)){
                         numTriangles++;
                     }
                 }

--- a/src/measures/TriangleCorrectness.cpp
+++ b/src/measures/TriangleCorrectness.cpp
@@ -22,7 +22,7 @@ double TriangleCorrectness::eval(const Alignment& A){
 int TriangleCorrectness::calculateTriangles(Graph* G){
     int numTriangles = 0;
     vector<vector<uint> > GAdjLists;
-    Matrix GMatrix;
+    Matrix<WEIGHTED_VALUE> GMatrix;
     G->getAdjLists(GAdjLists);
     G->getMatrix(GMatrix);
     for(uint i = 0; i < G->getNumNodes(); i++){

--- a/src/measures/TriangleCorrectness.cpp
+++ b/src/measures/TriangleCorrectness.cpp
@@ -22,7 +22,7 @@ double TriangleCorrectness::eval(const Alignment& A){
 int TriangleCorrectness::calculateTriangles(Graph* G){
     int numTriangles = 0;
     vector<vector<uint> > GAdjLists;
-    Matrix<WEIGHTED_VALUE> GMatrix;
+    Matrix<MATRIX_UNIT> GMatrix;
     G->getAdjLists(GAdjLists);
     G->getMatrix(GMatrix);
     for(uint i = 0; i < G->getNumNodes(); i++){

--- a/src/measures/TriangleCorrectness.cpp
+++ b/src/measures/TriangleCorrectness.cpp
@@ -21,7 +21,7 @@ double TriangleCorrectness::eval(const Alignment& A){
 
 int TriangleCorrectness::calculateTriangles(Graph* G){
     int numTriangles = 0;
-    vector<vector<ushort> > GAdjLists;
+    vector<vector<uint> > GAdjLists;
     Matrix GMatrix;
     G->getAdjLists(GAdjLists);
     G->getMatrix(GMatrix);
@@ -29,8 +29,8 @@ int TriangleCorrectness::calculateTriangles(Graph* G){
         for(uint j = 0; j < GAdjLists[i].size(); j++){
             for(uint k = 0; k < GAdjLists[i].size(); k++){
                 if(k != j){
-                    ushort neighbor1 = GAdjLists[i][j];
-                    ushort neighbor2 = GAdjLists[i][k];
+                    uint neighbor1 = GAdjLists[i][j];
+                    uint neighbor2 = GAdjLists[i][k];
                     if(GMatrix.get(neighbor1, neighbor2)){
                         numTriangles++;
                     }

--- a/src/measures/TriangleCorrectness.cpp
+++ b/src/measures/TriangleCorrectness.cpp
@@ -31,7 +31,7 @@ int TriangleCorrectness::calculateTriangles(Graph* G){
                 if(k != j){
                     uint neighbor1 = GAdjLists[i][j];
                     uint neighbor2 = GAdjLists[i][k];
-                    if(GMatrix.get(neighbor1, neighbor2)){
+                    if(GMatrix[neighbor1][neighbor2]){
                         numTriangles++;
                     }
                 }

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -21,7 +21,7 @@ double WeightedEdgeConservation::eval(const Alignment& A) {
     double score = 0;
     for (const auto& edge: edgeListG1) {
         uint node1 = edge[0], node2 = edge[1];
-        if (matrixG2.get(A[node1], A[node2])) {
+        if (matrixG2[A[node1]][A[node2]]) {
             score += (*simMatrix)[node1][A[node1]];
             score += (*simMatrix)[node2][A[node2]];
         }

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -16,16 +16,12 @@ double WeightedEdgeConservation::eval(const Alignment& A) {
     vector<vector<float> >* simMatrix = nodeSim->getSimMatrix();
     vector<vector<ushort> > edgeListG1;
     G1->getEdgeList(edgeListG1);
-#ifdef WEIGHTED
-    vector<vector<ushort> > adjMatrixG2;
-#else
-    vector<vector<bool> > adjMatrixG2;
-#endif
-    G2->getAdjMatrix(adjMatrixG2);
+    Matrix matrixG2;
+    G2->getMatrix(matrixG2);
     double score = 0;
     for (const auto& edge: edgeListG1) {
         ushort node1 = edge[0], node2 = edge[1];
-        if (adjMatrixG2[A[node1]][A[node2]]) {
+        if (matrixG2.get(A[node1], A[node2])) {
             score += (*simMatrix)[node1][A[node1]];
             score += (*simMatrix)[node2][A[node2]];
         }

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -14,13 +14,13 @@ LocalMeasure* WeightedEdgeConservation::getNodeSimMeasure() {
 
 double WeightedEdgeConservation::eval(const Alignment& A) {
     vector<vector<float> >* simMatrix = nodeSim->getSimMatrix();
-    vector<vector<ushort> > edgeListG1;
+    vector<vector<uint> > edgeListG1;
     G1->getEdgeList(edgeListG1);
     Matrix matrixG2;
     G2->getMatrix(matrixG2);
     double score = 0;
     for (const auto& edge: edgeListG1) {
-        ushort node1 = edge[0], node2 = edge[1];
+        uint node1 = edge[0], node2 = edge[1];
         if (matrixG2.get(A[node1], A[node2])) {
             score += (*simMatrix)[node1][A[node1]];
             score += (*simMatrix)[node2][A[node2]];

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -16,7 +16,7 @@ double WeightedEdgeConservation::eval(const Alignment& A) {
     vector<vector<float> >* simMatrix = nodeSim->getSimMatrix();
     vector<vector<uint> > edgeListG1;
     G1->getEdgeList(edgeListG1);
-    Matrix matrixG2;
+    Matrix<WEIGHTED_VALUE> matrixG2;
     G2->getMatrix(matrixG2);
     double score = 0;
     for (const auto& edge: edgeListG1) {

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -16,7 +16,7 @@ double WeightedEdgeConservation::eval(const Alignment& A) {
     vector<vector<float> >* simMatrix = nodeSim->getSimMatrix();
     vector<vector<uint> > edgeListG1;
     G1->getEdgeList(edgeListG1);
-    Matrix<WEIGHTED_VALUE> matrixG2;
+    Matrix<MATRIX_UNIT> matrixG2;
     G2->getMatrix(matrixG2);
     double score = 0;
     for (const auto& edge: edgeListG1) {

--- a/src/measures/localMeasures/EdgeCount.cpp
+++ b/src/measures/localMeasures/EdgeCount.cpp
@@ -22,17 +22,17 @@ void EdgeCount::initSimMatrix() {
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
     uint k = distWeights.size();
-    vector<vector<ushort> > densities1 (n1, vector<ushort> (k+1));
-    vector<vector<ushort> > densities2 (n2, vector<ushort> (k+1));
-    for (ushort i = 0; i < n1; i++) {
+    vector<vector<uint> > densities1 (n1, vector<uint> (k+1));
+    vector<vector<uint> > densities2 (n2, vector<uint> (k+1));
+    for (uint i = 0; i < n1; i++) {
         densities1[i] = G1->numEdgesAround(i, k);
-        for (ushort j = 1; j < k; j++) {
+        for (uint j = 1; j < k; j++) {
             densities1[i][j] += densities1[i][j-1];
         } 
     }
-    for (ushort i = 0; i < n2; i++) {
+    for (uint i = 0; i < n2; i++) {
         densities2[i] = G2->numEdgesAround(i, k);
-        for (ushort j = 1; j < k; j++) {
+        for (uint j = 1; j < k; j++) {
             densities2[i][j] += densities2[i][j-1];
         }
     }

--- a/src/measures/localMeasures/EdgeDensity.cpp
+++ b/src/measures/localMeasures/EdgeDensity.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-EdgeDensity::EdgeDensity(Graph* G1, Graph* G2, ushort maxDist) : LocalMeasure(G1, G2, "edged") {
+EdgeDensity::EdgeDensity(Graph* G1, Graph* G2, uint maxDist) : LocalMeasure(G1, G2, "edged") {
     string fileName = autogenMatricesFolder+G1->getName()+"_"+
         G2->getName()+"_edged";
     fileName += ".bin";
@@ -15,25 +15,25 @@ EdgeDensity::EdgeDensity(Graph* G1, Graph* G2, ushort maxDist) : LocalMeasure(G1
     loadBinSimMatrix(fileName);
 }
 
-double EdgeDensity::calcEdgeDensity (vector<vector<ushort> > adjList, ushort originNode, ushort numNodes, ushort maxDist) {
-    ushort UNINTIALIZED_DISTANCE = numNodes;
-    vector<ushort> distanceFromOrigin(numNodes,UNINTIALIZED_DISTANCE);
+double EdgeDensity::calcEdgeDensity (vector<vector<uint> > adjList, uint originNode, uint numNodes, uint maxDist) {
+    uint UNINTIALIZED_DISTANCE = numNodes;
+    vector<uint> distanceFromOrigin(numNodes,UNINTIALIZED_DISTANCE);
     vector<bool> visited(numNodes, false);
-    queue <ushort> Q;
+    queue <uint> Q;
 
-    ushort numEdgesWithinMaxDistance = 0;
-    ushort numNodesWithinMaxDistance = 0;
+    uint numEdgesWithinMaxDistance = 0;
+    uint numNodesWithinMaxDistance = 0;
     distanceFromOrigin[originNode] = 0;
     Q.push(originNode);
 
     while(not Q.empty()) {
-        ushort currentNode = Q.front();
+        uint currentNode = Q.front();
         Q.pop();
-        ushort dist = distanceFromOrigin[currentNode];
+        uint dist = distanceFromOrigin[currentNode];
         if(dist == maxDist) break;
         numNodesWithinMaxDistance++;
 
-        for(ushort neighbor : adjList[currentNode]) {
+        for(uint neighbor : adjList[currentNode]) {
             if(distanceFromOrigin[neighbor] == UNINTIALIZED_DISTANCE) {
                 distanceFromOrigin[neighbor] = dist + 1;
                 Q.push(neighbor);
@@ -44,12 +44,12 @@ double EdgeDensity::calcEdgeDensity (vector<vector<ushort> > adjList, ushort ori
         }
         visited[currentNode] = true;
     }
-    ushort totalEdges = (numNodesWithinMaxDistance * (numNodesWithinMaxDistance -1))/2;
+    uint totalEdges = (numNodesWithinMaxDistance * (numNodesWithinMaxDistance -1))/2;
     return numEdgesWithinMaxDistance/(double)totalEdges;
 }
 
-vector<double> EdgeDensity::generateVector(Graph* g, ushort maxDist) {
-    vector<vector<ushort> > adjList;
+vector<double> EdgeDensity::generateVector(Graph* g, uint maxDist) {
+    vector<vector<uint> > adjList;
     g->getAdjLists(adjList);
     vector<double> edged(g->getNumNodes());
     for(uint i = 0; i < g->getNumNodes(); ++i) {

--- a/src/measures/localMeasures/EdgeDensity.hpp
+++ b/src/measures/localMeasures/EdgeDensity.hpp
@@ -4,18 +4,18 @@
 
 class EdgeDensity: public LocalMeasure {
 public:
-    EdgeDensity(Graph* G1, Graph* G2, ushort maxDist);
+    EdgeDensity(Graph* G1, Graph* G2, uint maxDist);
     virtual ~EdgeDensity();
 private:
     void initSimMatrix();
     float compare(double n1, double n2);
-    double calcEdgeDensity(vector<vector<ushort> > adjList, ushort originNode, ushort numNodes, ushort maxDist);
-    vector<double> generateVector(Graph* g, ushort maxDist);
-    vector<ushort> numEdgesAround(ushort node, ushort maxDist) const;
+    double calcEdgeDensity(vector<vector<uint> > adjList, uint originNode, uint numNodes, uint maxDist);
+    vector<double> generateVector(Graph* g, uint maxDist);
+    vector<uint> numEdgesAround(uint node, uint maxDist) const;
     vector<double> edged1;
     vector<double> edged2;
-    vector<vector<ushort> > edgeList; //edges in no particular order
-    ushort maxDist;
+    vector<vector<uint> > edgeList; //edges in no particular order
+    uint maxDist;
 };
 
 #endif

--- a/src/measures/localMeasures/ExternalSimMatrix.cpp
+++ b/src/measures/localMeasures/ExternalSimMatrix.cpp
@@ -38,13 +38,13 @@ void ExternalSimMatrix::loadFormat0() {
 }
 
 void ExternalSimMatrix::loadFormat1() {
-    unordered_map<string,ushort> g1Map = G1->getNodeNameToIndexMap();
-    unordered_map<string,ushort> g2Map = G2->getNodeNameToIndexMap();
+    unordered_map<string,uint> g1Map = G1->getNodeNameToIndexMap();
+    unordered_map<string,uint> g2Map = G2->getNodeNameToIndexMap();
     vector<string> words = fileToStrings(file, false);
 
     for(uint i = 0; i < words.size(); i +=3) {
-        ushort n = g1Map[words[i]];
-        ushort m = g2Map[words[i+1]];
+        uint n = g1Map[words[i]];
+        uint m = g2Map[words[i+1]];
         sims[n][m] = stod(words[i+2]);
     }
 }

--- a/src/measures/localMeasures/GoSimilarity.cpp
+++ b/src/measures/localMeasures/GoSimilarity.cpp
@@ -133,12 +133,12 @@ void GoSimilarity::assertNoRepeatedEntries(const vector<vector<uint> >& goTerms)
 void GoSimilarity::simpleToInternalFormat(const Graph& G, string GOFileSimpleFormat, string GOFileInternalFormat) {
     string GName = G.getName();
 
-    unordered_map<string,ushort> aux = G.getNodeNameToIndexMap();
-    unordered_map<string,ushort> nodeToIndexMap(aux.begin(), aux.end());
+    unordered_map<string,uint> aux = G.getNodeNameToIndexMap();
+    unordered_map<string,uint> nodeToIndexMap(aux.begin(), aux.end());
 
     ifstream infile(GOFileSimpleFormat);
     string line;
-    ushort n = G.getNumNodes();
+    uint n = G.getNumNodes();
     vector<vector<uint> > goTerms(n, vector<uint> (0));
     while (getline(infile, line)) {
         istringstream iss(line);
@@ -158,8 +158,8 @@ void GoSimilarity::simpleToInternalFormat(const Graph& G, string GOFileSimpleFor
     }
     assertNoRepeatedEntries(goTerms);
     ofstream outfile(GOFileInternalFormat);
-    for (ushort i = 0; i < n; i++) {
-        for (ushort j = 0; j < goTerms[i].size(); j++) {
+    for (uint i = 0; i < n; i++) {
+        for (uint j = 0; j < goTerms[i].size(); j++) {
             outfile << goTerms[i][j] << " ";
         }
         outfile << endl;
@@ -192,7 +192,7 @@ vector<vector<uint> > GoSimilarity::loadGOTerms(
         acceptedTerms = unordered_set<uint>(v.begin(), v.end());
     }
 
-    ushort n = G.getNumNodes();
+    uint n = G.getNumNodes();
     vector<vector<uint> > goTerms(n, vector<uint> (0));
     uint i = 0;
     ifstream infile(GOFileInternalFormat);
@@ -252,9 +252,9 @@ GoSimilarity::~GoSimilarity() {
 }
 
 
-ushort GoSimilarity::numberAnnotatedProteins(const Graph& G) {
+uint GoSimilarity::numberAnnotatedProteins(const Graph& G) {
     vector<vector<uint> > terms = loadGOTerms(G);
-    ushort count = 0;
+    uint count = 0;
     for (uint i = 0; i < terms.size(); i++) {
         if (terms[i].size() > 0) count++;
     }

--- a/src/measures/localMeasures/GoSimilarity.hpp
+++ b/src/measures/localMeasures/GoSimilarity.hpp
@@ -38,7 +38,7 @@ private:
     static void simpleToInternalFormat(const Graph& G, string GOFileSimpleFormat, string GOFileInternalFormat);
     static void ensureGOFileInternalFormatExists(const Graph& G);
 
-    static ushort numberAnnotatedProteins(const Graph& G);
+    static uint numberAnnotatedProteins(const Graph& G);
 
     static void generateGOFileSimpleFormat(string GOFile, string GOFileSimpleFormat);
     static void generateGene2GoSimpleFormat();

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -22,6 +22,7 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
     vector<vector<double> > edgeWeights(n, vector<double> (n, 0));
 #ifdef WEIGHTED
     throw runtime_error("Importance not implemented for weighted Graphs");
+    Matrix matrix(n);
 #else
     Matrix matrix(n);
 #endif

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -22,10 +22,8 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
     vector<vector<double> > edgeWeights(n, vector<double> (n, 0));
 #ifdef WEIGHTED
     throw runtime_error("Importance not implemented for weighted Graphs");
-    Matrix matrix(n);
-#else
-    Matrix matrix(n);
 #endif
+    Matrix matrix(n);
     G.getMatrix(matrix);
     for (uint i = 0; i < n; i++) {
         for (uint j = 0; j < n; j++) {

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -27,7 +27,7 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
     G.getMatrix(matrix);
     for (uint i = 0; i < n; i++) {
         for (uint j = 0; j < n; j++) {
-            if (matrix.get(i, j)) edgeWeights[i][j] = 1;
+            if (matrix[i][j]) edgeWeights[i][j] = 1;
         }
     }
     return edgeWeights;

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -23,7 +23,7 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
 #ifdef WEIGHTED
     throw runtime_error("Importance not implemented for weighted Graphs");
 #endif
-    Matrix matrix(n);
+    Matrix<WEIGHTED_VALUE> matrix(n);
     G.getMatrix(matrix);
     for (uint i = 0; i < n; i++) {
         for (uint j = 0; j < n; j++) {

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -23,7 +23,7 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
 #ifdef WEIGHTED
     throw runtime_error("Importance not implemented for weighted Graphs");
 #endif
-    Matrix<WEIGHTED_VALUE> matrix(n);
+    Matrix<MATRIX_UNIT> matrix(n);
     G.getMatrix(matrix);
     for (uint i = 0; i < n; i++) {
         for (uint j = 0; j < n; j++) {

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -22,14 +22,13 @@ vector<vector<double> > Importance::initEdgeWeights(const Graph& G) {
     vector<vector<double> > edgeWeights(n, vector<double> (n, 0));
 #ifdef WEIGHTED
     throw runtime_error("Importance not implemented for weighted Graphs");
-    vector<vector<ushort> > adjMatrix(n, vector<ushort> (n));
 #else
-    vector<vector<bool> > adjMatrix(n, vector<bool> (n));
+    Matrix matrix(n);
 #endif
-    G.getAdjMatrix(adjMatrix);
+    G.getMatrix(matrix);
     for (uint i = 0; i < n; i++) {
         for (uint j = 0; j < n; j++) {
-            if (adjMatrix[i][j]) edgeWeights[i][j] = 1;
+            if (matrix.get(i, j)) edgeWeights[i][j] = 1;
         }
     }
     return edgeWeights;

--- a/src/measures/localMeasures/Importance.hpp
+++ b/src/measures/localMeasures/Importance.hpp
@@ -24,8 +24,8 @@ private:
     static vector<double> getImportances(const Graph& G);
 
     static vector<vector<double> > initEdgeWeights(const Graph& G);
-    static vector<ushort> getNodesSortedByDegree(const vector<vector<ushort> >& adjLists);
-    static void removeFromAdjList(vector<ushort>& list, ushort u);
+    static vector<uint> getNodesSortedByDegree(const vector<vector<uint> >& adjLists);
+    static void removeFromAdjList(vector<uint>& list, uint u);
     static void normalizeImportances(vector<double>& v);
 
     static bool hasNodesWithEnoughDegree(const Graph& G);

--- a/src/measures/localMeasures/LocalMeasure.cpp
+++ b/src/measures/localMeasures/LocalMeasure.cpp
@@ -47,8 +47,8 @@ void LocalMeasure::loadBinSimMatrix(string simMatrixFileName) {
 }
 
 void LocalMeasure::writeSimsWithNames(string outfile) {
-    unordered_map<ushort,string> mapG1 = G1->getIndexToNodeNameMap();
-    unordered_map<ushort,string> mapG2 = G2->getIndexToNodeNameMap();
+    unordered_map<uint,string> mapG1 = G1->getIndexToNodeNameMap();
+    unordered_map<uint,string> mapG2 = G2->getIndexToNodeNameMap();
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
     ofstream fout(outfile);

--- a/src/measures/localMeasures/NodeCount.cpp
+++ b/src/measures/localMeasures/NodeCount.cpp
@@ -20,17 +20,17 @@ void NodeCount::initSimMatrix() {
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
     uint k = distWeights.size();
-    vector<vector<ushort> > densities1 (n1, vector<ushort> (k+1));
-    vector<vector<ushort> > densities2 (n2, vector<ushort> (k+1));
-    for (ushort i = 0; i < n1; i++) {
+    vector<vector<uint> > densities1 (n1, vector<uint> (k+1));
+    vector<vector<uint> > densities2 (n2, vector<uint> (k+1));
+    for (uint i = 0; i < n1; i++) {
         densities1[i] = G1->numNodesAround(i, k);
-        for (ushort j = 1; j < k; j++) {
+        for (uint j = 1; j < k; j++) {
             densities1[i][j] += densities1[i][j-1];
         } 
     }
-    for (ushort i = 0; i < n2; i++) {
+    for (uint i = 0; i < n2; i++) {
         densities2[i] = G2->numNodesAround(i, k);
-        for (ushort j = 1; j < k; j++) {
+        for (uint j = 1; j < k; j++) {
             densities2[i][j] += densities2[i][j-1];
         }
     }

--- a/src/measures/localMeasures/NodeDensity.cpp
+++ b/src/measures/localMeasures/NodeDensity.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-NodeDensity::NodeDensity(Graph* G1, Graph* G2, ushort maxDist) : LocalMeasure(G1, G2, "noded") {
+NodeDensity::NodeDensity(Graph* G1, Graph* G2, uint maxDist) : LocalMeasure(G1, G2, "noded") {
     string fileName = autogenMatricesFolder+G1->getName()+"_"+
         G2->getName()+"_noded";
     fileName += ".bin";
@@ -15,23 +15,23 @@ NodeDensity::NodeDensity(Graph* G1, Graph* G2, ushort maxDist) : LocalMeasure(G1
     loadBinSimMatrix(fileName);
 }
 
-double NodeDensity::calcNodeDensity (vector<vector<ushort> > adjList, ushort originNode, ushort numNodes, ushort maxDist) {
-    ushort UNINTIALIZED_DISTANCE = numNodes;
-    vector<ushort> distanceFromOrigin(numNodes,UNINTIALIZED_DISTANCE);
-    queue <ushort> Q;
+double NodeDensity::calcNodeDensity (vector<vector<uint> > adjList, uint originNode, uint numNodes, uint maxDist) {
+    uint UNINTIALIZED_DISTANCE = numNodes;
+    vector<uint> distanceFromOrigin(numNodes,UNINTIALIZED_DISTANCE);
+    queue <uint> Q;
 
-    ushort numNodesWithinMaxDistance = 0;
+    uint numNodesWithinMaxDistance = 0;
     distanceFromOrigin[originNode] = 0;
     Q.push(originNode);
 
     while(not Q.empty()) {
-        ushort currentNode = Q.front();
+        uint currentNode = Q.front();
         Q.pop();
-        ushort dist = distanceFromOrigin[currentNode];
+        uint dist = distanceFromOrigin[currentNode];
         if(dist == maxDist) break;
         numNodesWithinMaxDistance++;
 
-        for(ushort neighbor : adjList[currentNode]) {
+        for(uint neighbor : adjList[currentNode]) {
             if(distanceFromOrigin[neighbor] == UNINTIALIZED_DISTANCE) {
                 distanceFromOrigin[neighbor] = dist + 1;
                 Q.push(neighbor);
@@ -42,8 +42,8 @@ double NodeDensity::calcNodeDensity (vector<vector<ushort> > adjList, ushort ori
     return numNodesWithinMaxDistance/(double)numNodes;
 }
 
-vector<double> NodeDensity::generateVector(Graph* g, ushort maxDist) {
-    vector<vector<ushort> > adjList;
+vector<double> NodeDensity::generateVector(Graph* g, uint maxDist) {
+    vector<vector<uint> > adjList;
     g->getAdjLists(adjList);
     vector<double> noded(g->getNumNodes());
     for(uint i = 0; i < g->getNumNodes(); ++i) {

--- a/src/measures/localMeasures/NodeDensity.hpp
+++ b/src/measures/localMeasures/NodeDensity.hpp
@@ -4,17 +4,17 @@
 
 class NodeDensity: public LocalMeasure {
 public:
-    NodeDensity(Graph* G1, Graph* G2, ushort maxDist);
+    NodeDensity(Graph* G1, Graph* G2, uint maxDist);
     virtual ~NodeDensity();
 private:
     void initSimMatrix();
     float compare(double n1, double n2);
-    double calcNodeDensity(vector<vector<ushort> > adjList, ushort originNode, ushort numNodes, ushort maxDist);
-    vector<double> generateVector(Graph* g, ushort maxDist);
+    double calcNodeDensity(vector<vector<uint> > adjList, uint originNode, uint numNodes, uint maxDist);
+    vector<double> generateVector(Graph* g, uint maxDist);
     vector<double> noded1;
     vector<double> noded2;
-    vector<vector<ushort> > nodedList; //edges in no particular order
-    ushort maxDist;
+    vector<vector<uint> > nodedList; //edges in no particular order
+    uint maxDist;
 };
 
 #endif

--- a/src/measures/localMeasures/Sequence.cpp
+++ b/src/measures/localMeasures/Sequence.cpp
@@ -17,8 +17,8 @@ void Sequence::generateBitscoresFile(string bitscoresFile) {
     cout << "Generating " << bitscoresFile << " ... ";
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
-    unordered_map<ushort,string> g1IndexToNodeMap = G1->getIndexToNodeNameMap();
-    unordered_map<ushort,string> g2IndexToNodeMap = G2->getIndexToNodeNameMap();
+    unordered_map<uint,string> g1IndexToNodeMap = G1->getIndexToNodeNameMap();
+    unordered_map<uint,string> g2IndexToNodeMap = G2->getIndexToNodeNameMap();
     ofstream outfile(bitscoresFile);
     for (uint i = 0; i < n1; i++) {
         for (uint j = 0; j < n2; j++) {
@@ -67,8 +67,8 @@ void Sequence::initSimMatrix() {
     uint n2 = G2->getNumNodes();
     sims = vector<vector<float> > (n1, vector<float> (n2, 0));
 
-    unordered_map<string,ushort> g1NodeToIndexMap = G1->getNodeNameToIndexMap();
-    unordered_map<string,ushort> g2NodeToIndexMap = G2->getNodeNameToIndexMap();
+    unordered_map<string,uint> g1NodeToIndexMap = G1->getNodeNameToIndexMap();
+    unordered_map<string,uint> g2NodeToIndexMap = G2->getNodeNameToIndexMap();
 
     string blastFile = "sequence/scores/"+g1Name+"_"+g2Name+"_blast.out";
     if (not fileExists(blastFile)) {
@@ -84,8 +84,8 @@ void Sequence::initSimMatrix() {
         iss >> node1 >> node2;
         if (g1NeedNameMap) node1 = g1NameMap[node1];
         if (g2NeedNameMap) node2 = g2NameMap[node2];
-        ushort index1 = g1NodeToIndexMap.at(node1);
-        ushort index2 = g2NodeToIndexMap.at(node2);
+        uint index1 = g1NodeToIndexMap.at(node1);
+        uint index2 = g2NodeToIndexMap.at(node2);
         //uses bitscores, which is the last column
         //there are other possibilities, such as
         //-log of e-values (second-to-last value), also used in l-graal

--- a/src/methods/Dijkstra.cpp
+++ b/src/methods/Dijkstra.cpp
@@ -28,7 +28,7 @@ Dijkstra::Dijkstra(Graph* G1, Graph* G2, MeasureCombination* MC, double d) :
   G1->getAdjLists(G1AdjLists);
   G2->getAdjLists(G2AdjLists);
 
-  A = vector<ushort> (n1);
+  A = vector<uint> (n1);
 
   sims = MC->getAggregatedLocalSims();
 
@@ -76,7 +76,7 @@ void Dijkstra::make_seed_queue(){
  * This function uses the same exclusion set for all priority queues.
  */
 
-std::pair <ushort, ushort> Dijkstra::best_pair(SkipList & pq) throw(QueueEmptyException){
+std::pair <uint, uint> Dijkstra::best_pair(SkipList & pq) throw(QueueEmptyException){
   return pq.pop_reservoir();
 }
 
@@ -84,7 +84,7 @@ std::pair <ushort, ushort> Dijkstra::best_pair(SkipList & pq) throw(QueueEmptyEx
  * side effects: this function adds a node to the respective exclusion sets
  * of each graph and adds the pair to the output set.  
  */
-void Dijkstra::update_neighbors(std::pair <ushort, ushort> & seed_pair){
+void Dijkstra::update_neighbors(std::pair <uint, uint> & seed_pair){
   //exclude the seed nodes from future consideration
   G1_exclude.insert(seed_pair.first);
   G2_exclude.insert(seed_pair.second);
@@ -94,8 +94,8 @@ void Dijkstra::update_neighbors(std::pair <ushort, ushort> & seed_pair){
   std::cout << "nodes aligned" << nodes_aligned << "\r" << std::flush; //<< std::endl;
 
   //set difference
-  vector<ushort> G1_neighbors = exclude_nodes(G1AdjLists[seed_pair.first], G1_exclude);
-  vector<ushort> G2_neighbors = exclude_nodes(G2AdjLists[seed_pair.second], G2_exclude);
+  vector<uint> G1_neighbors = exclude_nodes(G1AdjLists[seed_pair.first], G1_exclude);
+  vector<uint> G2_neighbors = exclude_nodes(G2AdjLists[seed_pair.second], G2_exclude);
 
   //if there are no neighbors, we can skip the matrix search 
   if(G1_neighbors.empty() || G2_neighbors.empty()){
@@ -106,12 +106,12 @@ void Dijkstra::update_neighbors(std::pair <ushort, ushort> & seed_pair){
   best_neighbors(seed_pair, G1_neighbors, G2_neighbors);
 }
 
-void Dijkstra::best_neighbors(std::pair <ushort, ushort> & seed_pair, vector<ushort> & G1_neighbors, vector<ushort> & G2_neighbors){
+void Dijkstra::best_neighbors(std::pair <uint, uint> & seed_pair, vector<uint> & G1_neighbors, vector<uint> & G2_neighbors){
   vector<vector<double> > small_matrix (G1_neighbors.size(), vector<double> (G2_neighbors.size()));
     
   /*
-    for(std::vector<ushort>::iterator G1_iter = G1_neighbors.begin(); G1_iter != G1_neighbors.end(); ++G1_iter){
-    for(std::vector<ushort>::iterator G2_iter = G2_neighbors.begin(); G2_iter != G2_neighbors.end(); ++G2_iter){
+    for(std::vector<uint>::iterator G1_iter = G1_neighbors.begin(); G1_iter != G1_neighbors.end(); ++G1_iter){
+    for(std::vector<uint>::iterator G2_iter = G2_neighbors.begin(); G2_iter != G2_neighbors.end(); ++G2_iter){
     //make a similarity matrix of neighbors
     //small_matrix[*G1_iter][*G2_iter] = sims[*G1_iter][*G2_iter];
     }
@@ -147,11 +147,11 @@ void Dijkstra::best_neighbors(std::pair <ushort, ushort> & seed_pair, vector<ush
  * It returns a vector containing the adjacent nodes 
  * which are not already aligned.  
  */
-vector<ushort> Dijkstra::exclude_nodes(vector<ushort> & v_in, std::unordered_set<ushort> & exclusion_set){
-  vector<ushort> v_out;
+vector<uint> Dijkstra::exclude_nodes(vector<uint> & v_in, std::unordered_set<uint> & exclusion_set){
+  vector<uint> v_out;
   v_out.reserve(v_in.size()); //minimize reallocations by reserving space in advance
   //|v_out| <= |v_in|
-  for(std::vector<ushort>::iterator it = v_in.begin(); it != v_in.end(); ++it){
+  for(std::vector<uint>::iterator it = v_in.begin(); it != v_in.end(); ++it){
     if(exclusion_set.find(*it) == exclusion_set.end()){
       v_out.push_back(*it);
     }
@@ -176,7 +176,7 @@ Alignment Dijkstra::run() {
     try{
       //std::cout << "seed phase" << std::endl;
       //seed phase
-      std::pair <ushort, ushort> seed_pair = best_pair(seed_queue); //seed_mat.pop_uniform();
+      std::pair <uint, uint> seed_pair = best_pair(seed_queue); //seed_mat.pop_uniform();
       update_neighbors(seed_pair);
     }catch (QueueEmptyException & e){
       //can't recover from this
@@ -192,7 +192,7 @@ Alignment Dijkstra::run() {
       //std::cout << "extend phase" << std::endl;
       start = get_time::now();
       try{
-    std::pair <ushort, ushort> neighbor_pair = best_pair(neighbor_queue);
+    std::pair <uint, uint> neighbor_pair = best_pair(neighbor_queue);
     update_neighbors(neighbor_pair);
       }catch (QueueEmptyException & e){
     //no more neighbors, get another seed

--- a/src/methods/Dijkstra.hpp
+++ b/src/methods/Dijkstra.hpp
@@ -43,10 +43,10 @@ private:
 
   //vector<vector<bool> > G1AdjMatrix;
   //vector<vector<bool> > G2AdjMatrix;
-  vector<vector<ushort> > G1AdjLists;
-  vector<vector<ushort> > G2AdjLists;
+  vector<vector<uint> > G1AdjLists;
+  vector<vector<uint> > G2AdjLists;
 
-  vector<ushort> A;
+  vector<uint> A;
 
   vector<vector<float> > sims;
 
@@ -56,9 +56,9 @@ private:
   string outputAName;
   unsigned int max_nodes;
     
-  std::unordered_set<ushort> G1_exclude;
-  std::unordered_set<ushort> G2_exclude;    
-  //std::unordered_set<ushort> current_neighbors;
+  std::unordered_set<uint> G1_exclude;
+  std::unordered_set<uint> G2_exclude;    
+  //std::unordered_set<uint> current_neighbors;
 
   double delta;
   static constexpr double EPSILON = 0.0000001;
@@ -70,11 +70,11 @@ private:
   /* Member functions */
     
   void make_seed_queue();
-  std::pair <ushort, ushort> get_seed(Graph* G1, Graph* G2);
-  std::pair <ushort, ushort> best_pair(SkipList & pq) throw(QueueEmptyException);
-  void update_neighbors(std::pair <ushort, ushort> & seed_pair);
-  void best_neighbors(std::pair <ushort, ushort> & seed_pair, vector<ushort> & G1_neighbors, vector<ushort> & G2_neighbors);
-  vector<ushort> exclude_nodes(vector<ushort> & v_in, std::unordered_set<ushort> & exclusion_set);
+  std::pair <uint, uint> get_seed(Graph* G1, Graph* G2);
+  std::pair <uint, uint> best_pair(SkipList & pq) throw(QueueEmptyException);
+  void update_neighbors(std::pair <uint, uint> & seed_pair);
+  void best_neighbors(std::pair <uint, uint> & seed_pair, vector<uint> & G1_neighbors, vector<uint> & G2_neighbors);
+  vector<uint> exclude_nodes(vector<uint> & v_in, std::unordered_set<uint> & exclusion_set);
 
 };
 

--- a/src/methods/GreedyLCCS.cpp
+++ b/src/methods/GreedyLCCS.cpp
@@ -21,26 +21,26 @@ GreedyLCCS::GreedyLCCS(Graph* G1, Graph* G2, string startAName):
 Alignment GreedyLCCS::run() {
     uint n1 = G1->getNumNodes();
     Alignment A = *startA;
-    vector<vector<ushort> > G1AdjLists(n1, vector<ushort> (0));
+    vector<vector<uint> > G1AdjLists(n1, vector<uint> (0));
     G1->getAdjLists(G1AdjLists);
-    vector<vector<ushort> > G2AdjLists;
+    vector<vector<uint> > G2AdjLists;
     G2->getAdjLists(G2AdjLists);
 
     //init set of already mapped nodes in G1
     Graph cs = A.commonSubgraph(*G1, *G2);
-    vector<ushort> aux = cs.getConnectedComponents()[0];
-    unordered_set<ushort> doneNodesG1(aux.begin(), aux.end());
+    vector<uint> aux = cs.getConnectedComponents()[0];
+    unordered_set<uint> doneNodesG1(aux.begin(), aux.end());
     
     //init set of already mapped nodes in G2
     for (uint i = 0; i < aux.size(); i++) aux[i] = A[aux[i]];
-    unordered_set<ushort> doneNodesG2(aux.begin(), aux.end());
+    unordered_set<uint> doneNodesG2(aux.begin(), aux.end());
 
     //init neighbors of done nodes in G1
-    unordered_set<ushort> neighbors;
+    unordered_set<uint> neighbors;
     for (uint i = 0; i < n1; i++) {
         if (not doneNodesG1.count(i)) {
             for (uint j = 0; j < G1AdjLists[i].size(); j++) {
-                ushort neighbor = G1AdjLists[i][j];
+                uint neighbor = G1AdjLists[i][j];
                 if (doneNodesG1.count(neighbor)) {
                     neighbors.insert(i);
                     break;
@@ -49,25 +49,25 @@ Alignment GreedyLCCS::run() {
         }
     }
 
-    unordered_set<ushort> checkedNeighbors;
+    unordered_set<uint> checkedNeighbors;
 
     while (not neighbors.empty()) {
         //choose neighbor
-        ushort node = *neighbors.begin();
+        uint node = *neighbors.begin();
         neighbors.erase(neighbors.begin());
         bool done = false;
         for (uint i = 0; not done and i < G1AdjLists[node].size(); i++) {
-            ushort adjNode = G1AdjLists[node][i];
+            uint adjNode = G1AdjLists[node][i];
             if (doneNodesG1.count(adjNode)) {
-                ushort adjNodeImage = A[adjNode];
+                uint adjNodeImage = A[adjNode];
                 for (uint j = 0; not done and j < G2AdjLists[adjNodeImage].size(); j++) {
-                    ushort adjNodeImageAdjNode = G2AdjLists[adjNodeImage][j];
+                    uint adjNodeImageAdjNode = G2AdjLists[adjNodeImage][j];
                     if (not doneNodesG2.count(adjNodeImageAdjNode)) {
                         doneNodesG1.insert(node);
                         doneNodesG2.insert(adjNodeImageAdjNode);
                         A[node] = adjNodeImageAdjNode;
                         for (uint k = 0; k < G1AdjLists[node].size(); k++) {
-                            ushort neighbor = G1AdjLists[node][k];
+                            uint neighbor = G1AdjLists[node][k];
                             if (not doneNodesG1.count(neighbor)) {
                                 neighbors.insert(neighbor);
                                 if (checkedNeighbors.count(neighbor)) {

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -158,8 +158,8 @@ Alignment HillClimbing::run() {
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source].size(); j++) {
                     uint neighbor = G1AdjLists[source][j];
-                    newAligEdges -= G2Matrix.get(oldTarget, A[neighbor]);
-                    newAligEdges += G2Matrix.get(newTarget, A[neighbor]);
+                    newAligEdges -= G2Matrix[oldTarget][A[neighbor]];
+                    newAligEdges += G2Matrix[newTarget][A[neighbor]];
                 }
 
                 int newG2InducedEdges = g2InducedEdges;
@@ -173,7 +173,7 @@ Alignment HillClimbing::run() {
                         newG2InducedEdges += assignedNodesG2[neighbor];
                     }
                     //address case changing between adjacent nodes:
-                    newG2InducedEdges -= G2Matrix.get(oldTarget, newTarget);
+                    newG2InducedEdges -= G2Matrix[oldTarget][newTarget];
                 }
 
                 double newLocalScoreSum = localScoreSum +
@@ -184,11 +184,11 @@ Alignment HillClimbing::run() {
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
                         uint neighbor = G1AdjLists[source][j];
-                        if (G2Matrix.get(oldTarget, A[neighbor])) {
+                        if (G2Matrix[oldTarget][A[neighbor]]) {
                             newWecSum -= (*wecSimMatrix)[source][oldTarget];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2Matrix.get(newTarget, A[neighbor])) {
+                        if (G2Matrix[newTarget][A[neighbor]]) {
                             newWecSum += (*wecSimMatrix)[source][newTarget];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
@@ -222,19 +222,19 @@ Alignment HillClimbing::run() {
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
                     uint neighbor = G1AdjLists[source1][j];
-                    newAligEdges -= G2Matrix.get(target1, A[neighbor]);
-                    newAligEdges += G2Matrix.get(target2, A[neighbor]);
+                    newAligEdges -= G2Matrix[target1][A[neighbor]];
+                    newAligEdges += G2Matrix[target2][A[neighbor]];
                 }
                 for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
                     uint neighbor = G1AdjLists[source2][j];
-                    newAligEdges -= G2Matrix.get(target2, A[neighbor]);
-                    newAligEdges += G2Matrix.get(target1, A[neighbor]);
+                    newAligEdges -= G2Matrix[target2][A[neighbor]];
+                    newAligEdges += G2Matrix[target1][A[neighbor]];
                 }
                 //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-                newAligEdges += (-1 << 1) & (G1Matrix.get(source1, source2) + G2Matrix.get(target1, target2));
+                newAligEdges += (-1 << 1) & (G1Matrix[source1][source2] + G2Matrix[target1][target2]);
 #else
-                newAligEdges += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
+                newAligEdges += 2*(G1Matrix[source1][source2] & G2Matrix[target1][target2]);
 #endif
                 double newLocalScoreSum = localScoreSum +
                     localsCombined[source1][target2] -
@@ -246,31 +246,31 @@ Alignment HillClimbing::run() {
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
                         uint neighbor = G1AdjLists[source1][j];
-                        if (G2Matrix.get(target1, A[neighbor])) {
+                        if (G2Matrix[target1][A[neighbor]]) {
                             newWecSum -= (*wecSimMatrix)[source1][target1];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2Matrix.get(target2, A[neighbor])) {
+                        if (G2Matrix[target2][A[neighbor]]) {
                             newWecSum += (*wecSimMatrix)[source1][target2];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
                     }
                     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
                         uint neighbor = G1AdjLists[source2][j];
-                        if (G2Matrix.get(target2, A[neighbor])) {
+                        if (G2Matrix[target2][A[neighbor]]) {
                             newWecSum -= (*wecSimMatrix)[source2][target2];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2Matrix.get(target1, A[neighbor])) {
+                        if (G2Matrix[target1][A[neighbor]]) {
                             newWecSum += (*wecSimMatrix)[source2][target1];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
                     }
                     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-                    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) { 
+                    if (G1Matrix[source1][source2] > 0 and G2Matrix[target1][target2] > 0) { 
 #else
-                    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
+                    if (G1Matrix[source1][source2] and G2Matrix[target1][target2]) {
 #endif
                         //not sure about this -- but seems fine
                         newWecSum += 2*(*wecSimMatrix)[source1][target1];

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -66,22 +66,22 @@ Alignment HillClimbing::run() {
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
 
-    vector<ushort> A(startA.getMapping());
+    vector<uint> A(startA.getMapping());
     Matrix G1Matrix;
     Matrix G2Matrix;
 
     G1->getMatrix(G1Matrix);
     G2->getMatrix(G2Matrix);
-    vector<vector<ushort> > G1AdjLists;
+    vector<vector<uint> > G1AdjLists;
     G1->getAdjLists(G1AdjLists);
-    vector<vector<ushort> > G2AdjLists;
+    vector<vector<uint> > G2AdjLists;
     G2->getAdjLists(G2AdjLists);
 
     vector<bool> assignedNodesG2(n2, false);
     for (uint i = 0; i < n1; i++) {
         assignedNodesG2[A[i]] = true;
     }
-    vector<ushort> unassignedNodesG2(n2-n1);
+    vector<uint> unassignedNodesG2(n2-n1);
     int j = 0;
     for (uint i = 0; i < n2; i++) {
         if (not assignedNodesG2[i]) {
@@ -141,23 +141,23 @@ Alignment HillClimbing::run() {
 
         //dummy initializations:
         bool useChangeOperator = false;
-        ushort bestSource = 0;
+        uint bestSource = 0;
         uint bestNewTargetIndex = 0;
         int bestNewAligEdges = 0;
         int bestNewG2InducedEdges = 0;
         double bestNewLocalScoreSum = 0;
         double bestNewWecSum = 0;
-        ushort bestSource1 = 0, bestSource2 = 0;
+        uint bestSource1 = 0, bestSource2 = 0;
 
         //traverse all change neighbors
-        for (ushort source = 0; source < n1; source++) {
+        for (uint source = 0; source < n1; source++) {
             for (uint newTargetIndex = 0; newTargetIndex < n2-n1; newTargetIndex++) {
-                ushort oldTarget = A[source];
-                ushort newTarget = unassignedNodesG2[newTargetIndex];
+                uint oldTarget = A[source];
+                uint newTarget = unassignedNodesG2[newTargetIndex];
 
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source].size(); j++) {
-                    ushort neighbor = G1AdjLists[source][j];
+                    uint neighbor = G1AdjLists[source][j];
                     newAligEdges -= G2Matrix.get(oldTarget, A[neighbor]);
                     newAligEdges += G2Matrix.get(newTarget, A[neighbor]);
                 }
@@ -165,11 +165,11 @@ Alignment HillClimbing::run() {
                 int newG2InducedEdges = g2InducedEdges;
                 if (needG2InducedEdges) {
                     for (uint j = 0; j < G2AdjLists[oldTarget].size(); j++) {
-                        ushort neighbor = G2AdjLists[oldTarget][j];
+                        uint neighbor = G2AdjLists[oldTarget][j];
                         newG2InducedEdges -= assignedNodesG2[neighbor];
                     }
                     for (uint j = 0; j < G2AdjLists[newTarget].size(); j++) {
-                        ushort neighbor = G2AdjLists[newTarget][j];
+                        uint neighbor = G2AdjLists[newTarget][j];
                         newG2InducedEdges += assignedNodesG2[neighbor];
                     }
                     //address case changing between adjacent nodes:
@@ -183,7 +183,7 @@ Alignment HillClimbing::run() {
                 double newWecSum = wecSum;
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
-                        ushort neighbor = G1AdjLists[source][j];
+                        uint neighbor = G1AdjLists[source][j];
                         if (G2Matrix.get(oldTarget, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source][oldTarget];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
@@ -215,18 +215,18 @@ Alignment HillClimbing::run() {
         }
 
         //traverse all swap neighbors
-        for (ushort source1 = 0; source1 < n1; source1++) {
-            for (ushort source2 = source1+1; source2 < n1; source2++) {
-                ushort target1 = A[source1], target2 = A[source2];
+        for (uint source1 = 0; source1 < n1; source1++) {
+            for (uint source2 = source1+1; source2 < n1; source2++) {
+                uint target1 = A[source1], target2 = A[source2];
 
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
-                    ushort neighbor = G1AdjLists[source1][j];
+                    uint neighbor = G1AdjLists[source1][j];
                     newAligEdges -= G2Matrix.get(target1, A[neighbor]);
                     newAligEdges += G2Matrix.get(target2, A[neighbor]);
                 }
                 for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
-                    ushort neighbor = G1AdjLists[source2][j];
+                    uint neighbor = G1AdjLists[source2][j];
                     newAligEdges -= G2Matrix.get(target2, A[neighbor]);
                     newAligEdges += G2Matrix.get(target1, A[neighbor]);
                 }
@@ -245,7 +245,7 @@ Alignment HillClimbing::run() {
                 double newWecSum = wecSum;
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
-                        ushort neighbor = G1AdjLists[source1][j];
+                        uint neighbor = G1AdjLists[source1][j];
                         if (G2Matrix.get(target1, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source1][target1];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
@@ -256,7 +256,7 @@ Alignment HillClimbing::run() {
                         }
                     }
                     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
-                        ushort neighbor = G1AdjLists[source2][j];
+                        uint neighbor = G1AdjLists[source2][j];
                         if (G2Matrix.get(target2, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source2][target2];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
@@ -308,8 +308,8 @@ Alignment HillClimbing::run() {
         wecSum = bestNewWecSum;
 
         if (useChangeOperator) {
-            ushort newTarget = unassignedNodesG2[bestNewTargetIndex];
-            ushort oldTarget = A[bestSource];
+            uint newTarget = unassignedNodesG2[bestNewTargetIndex];
+            uint oldTarget = A[bestSource];
             A[bestSource] = newTarget;
             unassignedNodesG2[bestNewTargetIndex] = oldTarget;
             assignedNodesG2[oldTarget] = false;
@@ -317,7 +317,7 @@ Alignment HillClimbing::run() {
             g2InducedEdges = bestNewG2InducedEdges;
         }
         else {
-            ushort target1 = A[bestSource1], target2 = A[bestSource2];
+            uint target1 = A[bestSource1], target2 = A[bestSource2];
             A[bestSource1] = target2;
             A[bestSource2] = target1;
         }

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -67,8 +67,8 @@ Alignment HillClimbing::run() {
     uint n2 = G2->getNumNodes();
 
     vector<uint> A(startA.getMapping());
-    Matrix<WEIGHTED_VALUE> G1Matrix;
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G1Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
 
     G1->getMatrix(G1Matrix);
     G2->getMatrix(G2Matrix);

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -232,7 +232,7 @@ Alignment HillClimbing::run() {
                 }
                 //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-                newAligEdges += (-1 << 1) & (G1Matrix[source1][source2] + G2Matrix[target1][target2]);
+                newAligEdges += (-1 << 1) & (G1Matrix.get(source1, source2) + G2Matrix.get(target1, target2));
 #else
                 newAligEdges += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
 #endif

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -67,16 +67,11 @@ Alignment HillClimbing::run() {
     uint n2 = G2->getNumNodes();
 
     vector<ushort> A(startA.getMapping());
-#ifdef WEIGHTED
-    vector<vector<ushort> > G1AdjMatrix;
-    vector<vector<ushort> > G2AdjMatrix;
-#else
-    vector<vector<bool> > G1AdjMatrix;
-    vector<vector<bool> > G2AdjMatrix;
-#endif
+    Matrix G1Matrix;
+    Matrix G2Matrix;
 
-    G1->getAdjMatrix(G1AdjMatrix);
-    G2->getAdjMatrix(G2AdjMatrix);
+    G1->getMatrix(G1Matrix);
+    G2->getMatrix(G2Matrix);
     vector<vector<ushort> > G1AdjLists;
     G1->getAdjLists(G1AdjLists);
     vector<vector<ushort> > G2AdjLists;
@@ -163,8 +158,8 @@ Alignment HillClimbing::run() {
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source].size(); j++) {
                     ushort neighbor = G1AdjLists[source][j];
-                    newAligEdges -= G2AdjMatrix[oldTarget][A[neighbor]];
-                    newAligEdges += G2AdjMatrix[newTarget][A[neighbor]];
+                    newAligEdges -= G2Matrix.get(oldTarget, A[neighbor]);
+                    newAligEdges += G2Matrix.get(newTarget, A[neighbor]);
                 }
 
                 int newG2InducedEdges = g2InducedEdges;
@@ -178,7 +173,7 @@ Alignment HillClimbing::run() {
                         newG2InducedEdges += assignedNodesG2[neighbor];
                     }
                     //address case changing between adjacent nodes:
-                    newG2InducedEdges -= G2AdjMatrix[oldTarget][newTarget];
+                    newG2InducedEdges -= G2Matrix.get(oldTarget, newTarget);
                 }
 
                 double newLocalScoreSum = localScoreSum +
@@ -189,11 +184,11 @@ Alignment HillClimbing::run() {
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
                         ushort neighbor = G1AdjLists[source][j];
-                        if (G2AdjMatrix[oldTarget][A[neighbor]]) {
+                        if (G2Matrix.get(oldTarget, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source][oldTarget];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2AdjMatrix[newTarget][A[neighbor]]) {
+                        if (G2Matrix.get(newTarget, A[neighbor])) {
                             newWecSum += (*wecSimMatrix)[source][newTarget];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
@@ -227,19 +222,19 @@ Alignment HillClimbing::run() {
                 int newAligEdges = aligEdges;
                 for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
                     ushort neighbor = G1AdjLists[source1][j];
-                    newAligEdges -= G2AdjMatrix[target1][A[neighbor]];
-                    newAligEdges += G2AdjMatrix[target2][A[neighbor]];
+                    newAligEdges -= G2Matrix.get(target1, A[neighbor]);
+                    newAligEdges += G2Matrix.get(target2, A[neighbor]);
                 }
                 for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
                     ushort neighbor = G1AdjLists[source2][j];
-                    newAligEdges -= G2AdjMatrix[target2][A[neighbor]];
-                    newAligEdges += G2AdjMatrix[target1][A[neighbor]];
+                    newAligEdges -= G2Matrix.get(target2, A[neighbor]);
+                    newAligEdges += G2Matrix.get(target1, A[neighbor]);
                 }
                 //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-                newAligEdges += (-1 << 1) & (G1AdjMatrix[source1][source2] + G2AdjMatrix[target1][target2]);
+                newAligEdges += (-1 << 1) & (G1Matrix[source1][source2] + G2Matrix[target1][target2]);
 #else
-                newAligEdges += 2*(G1AdjMatrix[source1][source2] & G2AdjMatrix[target1][target2]);
+                newAligEdges += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
 #endif
                 double newLocalScoreSum = localScoreSum +
                     localsCombined[source1][target2] -
@@ -251,31 +246,31 @@ Alignment HillClimbing::run() {
                 if (wecWeight > 0) {
                     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
                         ushort neighbor = G1AdjLists[source1][j];
-                        if (G2AdjMatrix[target1][A[neighbor]]) {
+                        if (G2Matrix.get(target1, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source1][target1];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2AdjMatrix[target2][A[neighbor]]) {
+                        if (G2Matrix.get(target2, A[neighbor])) {
                             newWecSum += (*wecSimMatrix)[source1][target2];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
                     }
                     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
                         ushort neighbor = G1AdjLists[source2][j];
-                        if (G2AdjMatrix[target2][A[neighbor]]) {
+                        if (G2Matrix.get(target2, A[neighbor])) {
                             newWecSum -= (*wecSimMatrix)[source2][target2];
                             newWecSum -= (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
-                        if (G2AdjMatrix[target1][A[neighbor]]) {
+                        if (G2Matrix.get(target1, A[neighbor])) {
                             newWecSum += (*wecSimMatrix)[source2][target1];
                             newWecSum += (*wecSimMatrix)[neighbor][A[neighbor]];
                         }
                     }
                     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-                    if (G1AdjMatrix[source1][source2] > 0 and G2AdjMatrix[target1][target2] > 0) { 
+                    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) { 
 #else
-                    if (G1AdjMatrix[source1][source2] and G2AdjMatrix[target1][target2]) {
+                    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
 #endif
                         //not sure about this -- but seems fine
                         newWecSum += 2*(*wecSimMatrix)[source1][target1];

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -67,8 +67,8 @@ Alignment HillClimbing::run() {
     uint n2 = G2->getNumNodes();
 
     vector<uint> A(startA.getMapping());
-    Matrix G1Matrix;
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G1Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
 
     G1->getMatrix(G1Matrix);
     G2->getMatrix(G2Matrix);

--- a/src/methods/Method.cpp
+++ b/src/methods/Method.cpp
@@ -46,9 +46,9 @@ void  Method::checkLockingBeforeReport(Alignment A){
     if(G1->getLockedCount() == 0)
         return;
 
-    unordered_map<ushort,string> g1_NameMap = G1->getIndexToNodeNameMap();
-    unordered_map<string,ushort> g2_IndexMap = G2->getNodeNameToIndexMap();
-    unordered_map<ushort,string> g2_NameMap = G2->getIndexToNodeNameMap();
+    unordered_map<uint,string> g1_NameMap = G1->getIndexToNodeNameMap();
+    unordered_map<string,uint> g2_IndexMap = G2->getNodeNameToIndexMap();
+    unordered_map<uint,string> g2_NameMap = G2->getIndexToNodeNameMap();
 
     uint n1 = G1->getNumNodes();
     for(uint i=0; i< n1 ; i++){
@@ -69,8 +69,8 @@ void Method::checkNodeTypesBeforeReport(Alignment A){
     if(!G1->hasNodeTypes())
         return;
 
-    unordered_map<ushort,string> g1_NameMap = G1->getIndexToNodeNameMap();
-    unordered_map<ushort,string> g2_NameMap = G2->getIndexToNodeNameMap();
+    unordered_map<uint,string> g1_NameMap = G1->getIndexToNodeNameMap();
+    unordered_map<uint,string> g2_NameMap = G2->getIndexToNodeNameMap();
 
     uint n1 = G1->getNumNodes();
     for(uint i=0; i< n1 ; i++){
@@ -103,8 +103,8 @@ void Method::setLockFile(string fileName){
 }
 
 
-unordered_map<ushort, ushort> Method::getReverseMap(const unordered_map<ushort,ushort> reverse) const {
-    unordered_map<ushort,ushort> res;
+unordered_map<uint, uint> Method::getReverseMap(const unordered_map<uint,uint> reverse) const {
+    unordered_map<uint,uint> res;
     for (const auto &nameIndexPair : reverse ) {
         res[nameIndexPair.second] = nameIndexPair.first;
     }

--- a/src/methods/Method.hpp
+++ b/src/methods/Method.hpp
@@ -23,7 +23,7 @@ public:
     void checkLockingBeforeReport(Alignment A);
     void checkNodeTypesBeforeReport(Alignment A);
 
-    unordered_map<ushort,ushort> getReverseMap(const unordered_map<ushort,ushort> reverse) const;
+    unordered_map<uint,uint> getReverseMap(const unordered_map<uint,uint> reverse) const;
 
 protected:
     Graph* G1;

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -221,9 +221,9 @@ SANA::SANA(Graph* G1, Graph* G2,
         wecSims                          = (*wecSimsP);
     }
 #ifdef CORES
-    coreFreq        = vector<vector<ulong> > (n1, vector<ulong>(n2, 0));
+    coreFreq = Matrix<ulong>(n1, n2);
     coreCount       = vector<ulong>(n1, 0);
-    weightedCoreFreq= vector<vector<double> > (n1, vector<double>(n2, 0));
+    weightedCoreFreq = Matrix<double>(n1, n2);
     totalCoreWeight = vector<double>(n1, 0);
 #endif
     //to evaluate local measures incrementally
@@ -1723,7 +1723,7 @@ Alignment SANA::runRestartPhases() {
 vector<ulong> SANA::getCoreCount() {
     return coreCount;
 }
-vector<vector<ulong>> SANA::getCoreFreq() {
+Matrix<ulong> SANA::getCoreFreq() {
     return coreFreq;
 }
 #endif

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -191,7 +191,7 @@ SANA::SANA(Graph* G1, Graph* G2,
         needNC      = true;
     } catch(...) {
         ncWeight = 0;
-        trueA    = {static_cast<ushort>(G2->getNumNodes()), 1};
+        trueA    = {static_cast<uint>(G2->getNumNodes()), 1};
     }
 
     try {
@@ -252,10 +252,10 @@ SANA::SANA(Graph* G1, Graph* G2,
     running the algorithm
     */
     assignedNodesG2       = new vector<bool> (n2);
-    unassignedNodesG2     = new vector<ushort> (n2-n1);
-    unassignedgenesG2     = new vector<ushort> (G2->geneCount - G1->geneCount);
-    unassignedmiRNAsG2    = new vector<ushort> (G2->miRNACount - G1->miRNACount);
-    A                     = new vector<ushort> (n1);
+    unassignedNodesG2     = new vector<uint> (n2-n1);
+    unassignedgenesG2     = new vector<uint> (G2->geneCount - G1->geneCount);
+    unassignedmiRNAsG2    = new vector<uint> (G2->miRNACount - G1->miRNACount);
+    A                     = new vector<uint> (n1);
     avgEnergyInc          = -0.00001; //to track progress
     this->addHillClimbing = addHillClimbing;
 }
@@ -312,10 +312,10 @@ Alignment SANA::run() {
 #ifndef CORES
 #error must have CORES macro defined to print them
 #endif
-	unordered_map<ushort,string> G1Index2Name = G1->getIndexToNodeNameMap();
-	unordered_map<ushort,string> G2Index2Name = G2->getIndexToNodeNameMap();
+	unordered_map<uint,string> G1Index2Name = G1->getIndexToNodeNameMap();
+	unordered_map<uint,string> G2Index2Name = G2->getIndexToNodeNameMap();
 	printf("######## core frequencies#########\n");
-	for(ushort i=0; i<n1; i++) for(ushort j=0; j<n2; j++) if(coreFreq[i][j]>0)
+	for(uint i=0; i<n1; i++) for(uint j=0; j<n2; j++) if(coreFreq[i][j]>0)
 	    printf("%s %s  %lu / %lu = %.16f weighted %.16f / %.16f = %.16f\n", G1Index2Name[i].c_str(), G2Index2Name[j].c_str(),
 		coreFreq[i][j], coreCount[i],
 		coreFreq[i][j]/(double)coreCount[i],
@@ -341,7 +341,7 @@ double mecC(PARAMS) { return double(aligEdges) / (g1WeightedEdges + g2WeightedEd
 double sesC(PARAMS) { return squaredAligEdges; }
 #endif
 
-unordered_set<vector<ushort>*>* SANA::paretoRun() {
+unordered_set<vector<uint>*>* SANA::paretoRun() {
     measureCalculation["ec"] = ecC;
     measureCalculation["s3"] = s3C;
     measureCalculation["ics"] = icsC;
@@ -365,11 +365,11 @@ unordered_set<vector<ushort>*>* SANA::paretoRun() {
 }
 
 // Used for method #2 of locking
-inline ushort SANA::G1RandomUnlockedNode_Fast() {
+inline uint SANA::G1RandomUnlockedNode_Fast() {
     return unLockedNodesG1[G1RandomUnlockedNodeDist(gen)];
 }
 
-inline ushort SANA::G1RandomUnlockedNode(){
+inline uint SANA::G1RandomUnlockedNode(){
     #ifdef REINDEX
         return G1RandomUnlockedNodeDist(gen);
     #else
@@ -379,7 +379,7 @@ inline ushort SANA::G1RandomUnlockedNode(){
 
 // Gives a random unlocked nodes with the same type as source1
 // Only called from performswap
-inline ushort SANA::G1RandomUnlockedNode(uint source1){
+inline uint SANA::G1RandomUnlockedNode(uint source1){
     if(!nodesHaveType){
         return SANA::G1RandomUnlockedNode();
     }
@@ -406,7 +406,7 @@ inline ushort SANA::G1RandomUnlockedNode(uint source1){
 }
 
 // Return index of the unassigned node in the unassginedNodesG2 (or unassignedgenesG2, ...)
-inline ushort SANA::G2RandomUnlockedNode(uint target1){
+inline uint SANA::G2RandomUnlockedNode(uint target1){
     if(!nodesHaveType){
         return G2RandomUnlockedNode_Fast();
     } else {
@@ -419,7 +419,7 @@ inline ushort SANA::G2RandomUnlockedNode(uint target1){
             int index = G2RandomUnassignedmiRNADist(gen);
             return index;
         }
-        // ushort node;
+        // uint node;
         // do {
         //     node = G2RandomUnlockedNode_Fast(); // gives back unlocked G2 node
         // } while(G2->nodeTypes[target1] != G2->nodeTypes[(*unassignedNodesG2)[node]]);
@@ -427,7 +427,7 @@ inline ushort SANA::G2RandomUnlockedNode(uint target1){
     }
 }
 
-inline ushort SANA::G2RandomUnlockedNode_Fast(){
+inline uint SANA::G2RandomUnlockedNode_Fast(){
     return G2RandomUnassignedNode(gen);
 }
 
@@ -496,15 +496,15 @@ double SANA::trueAcceptingProbability(){
 void SANA::initDataStructures(const Alignment& startA) {
     nodesHaveType = G1->hasNodeTypes();
 
-    A = new vector<ushort>(startA.getMapping());
+    A = new vector<uint>(startA.getMapping());
 
     assignedNodesG2 = new vector<bool> (n2, false);
     for (uint i = 0; i < n1; i++) {
         (*assignedNodesG2)[(*A)[i]] = true;
     }
-    unassignedNodesG2        = new vector<ushort> (n2-n1);
-    unassignedgenesG2        = new vector<ushort> ();
-    unassignedmiRNAsG2       = new vector<ushort> ();
+    unassignedNodesG2        = new vector<uint> (n2-n1);
+    unassignedgenesG2        = new vector<uint> ();
+    unassignedmiRNAsG2       = new vector<uint> ();
     
     if(nodesHaveType){
         cerr << "Seperating unassigned genes and miRNAs in G2" << endl;
@@ -524,7 +524,7 @@ void SANA::initDataStructures(const Alignment& startA) {
     }
     //  Init unlockedNodesG1
     uint unlockedG1            = n1 - G1->getLockedCount();
-    unLockedNodesG1            = vector<ushort> (unlockedG1);
+    unLockedNodesG1            = vector<uint> (unlockedG1);
     uint index                 = 0;
     for (uint i = 0; i < n1; i++){
         if(not G1->isLocked(i)){
@@ -666,7 +666,7 @@ Alignment SANA::simpleRun(const Alignment& startA, long long int maxExecutionIte
         return *A; //dummy return to shut compiler warning
 }
 
-unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, double maxExecutionSeconds,
+unordered_set<vector<uint>*>* SANA::simpleParetoRun(const Alignment& startA, double maxExecutionSeconds,
         long long int& iter) {
 
     initDataStructures(startA);
@@ -699,7 +699,7 @@ unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, d
 
     return storedAlignments;
 }
-unordered_set<vector<ushort>*>* SANA::simpleParetoRun(const Alignment& startA, long long int maxExecutionIterations,
+unordered_set<vector<uint>*>* SANA::simpleParetoRun(const Alignment& startA, long long int maxExecutionIterations,
         long long int& iter) {
 
     initDataStructures(startA);
@@ -857,18 +857,18 @@ void SANA::prepareMeasureDataByAlignment() {
 
     assignedNodesG2 = new vector<bool>(*storedAssignedNodesG2[A]);
     if(!nodesHaveType)
-        unassignedNodesG2 = new vector<ushort>(*storedUnassignedNodesG2[A]);
+        unassignedNodesG2 = new vector<uint>(*storedUnassignedNodesG2[A]);
     else {
-        unassignedmiRNAsG2 = new vector<ushort>(*storedUnassignedmiRNAsG2[A]);
-        unassignedgenesG2 = new vector<ushort>(*storedUnassignedgenesG2[A]);
+        unassignedmiRNAsG2 = new vector<uint>(*storedUnassignedmiRNAsG2[A]);
+        unassignedgenesG2 = new vector<uint>(*storedUnassignedgenesG2[A]);
     }
 
-    A = new vector<ushort>(*A);
+    A = new vector<uint>(*A);
 }
 
 void SANA::insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addScores) {
     bool inserted = false;
-    vector<vector<ushort>*> toRemove = paretoFront.addAlignmentScores(A, addScores, inserted);
+    vector<vector<uint>*> toRemove = paretoFront.addAlignmentScores(A, addScores, inserted);
     if (inserted) {
         for (unsigned int i = 0; i < toRemove.size(); i++)
             removeAlignmentData(toRemove[i]);
@@ -905,20 +905,20 @@ void SANA::insertCurrentAlignmentAndData() {
     /*------------------------>*/storedCurrentScore[A]     = currentScore;
 }
 
-void SANA::removeAlignmentData(vector<ushort>* toRemove) {
+void SANA::removeAlignmentData(vector<uint>* toRemove) {
     storedAlignments->erase(toRemove);
 
     vector<bool>* removeAssignedNodesG2 = storedAssignedNodesG2[toRemove];
     storedAssignedNodesG2.erase(toRemove);
     delete removeAssignedNodesG2;
     if(!nodesHaveType) {
-        vector<ushort>* removeUnassignedNodesG2 = storedUnassignedNodesG2[toRemove];
+        vector<uint>* removeUnassignedNodesG2 = storedUnassignedNodesG2[toRemove];
         storedUnassignedNodesG2.erase(toRemove);
         delete removeUnassignedNodesG2;
     }
     else {
-        vector<ushort>* removeUnassignedmiRNAsG2 = storedUnassignedmiRNAsG2[toRemove];
-        vector<ushort>* removeUnassignedgenesG2 = storedUnassignedgenesG2[toRemove];
+        vector<uint>* removeUnassignedmiRNAsG2 = storedUnassignedmiRNAsG2[toRemove];
+        vector<uint>* removeUnassignedgenesG2 = storedUnassignedgenesG2[toRemove];
         storedUnassignedmiRNAsG2.erase(toRemove);
         storedUnassignedgenesG2.erase(toRemove);
         delete removeUnassignedmiRNAsG2;
@@ -974,12 +974,12 @@ void SANA::SANAIteration() {
 }
 
 void SANA::performChange(int type) {
-    ushort source       = G1RandomUnlockedNode();
-    ushort oldTarget    = (*A)[source];
+    uint source       = G1RandomUnlockedNode();
+    uint oldTarget    = (*A)[source];
     
     uint newTargetIndex = G2RandomUnlockedNode(oldTarget);
 
-    ushort newTarget = -1;
+    uint newTarget = -1;
     bool isGene = false;
     if(!nodesHaveType)
         newTarget    = (*unassignedNodesG2)[newTargetIndex];
@@ -1073,9 +1073,9 @@ void SANA::performChange(int type) {
 }
 
 void SANA::performSwap(int type) {
-    ushort source1 = G1RandomUnlockedNode();
-    ushort source2 = G1RandomUnlockedNode(source1);
-    ushort target1 = (*A)[source1], target2 = (*A)[source2];
+    uint source1 = G1RandomUnlockedNode();
+    uint source2 = G1RandomUnlockedNode(source1);
+    uint target1 = (*A)[source1], target2 = (*A)[source2];
 
     int newAligEdges           = (needAligEdges or needSec) ?  aligEdges + aligEdgesIncSwapOp(source1, source2, target1, target2) : -1;
     int newTCSum               = (needTC) ?  TCSum + TCIncSwapOp(source1, source2, target1, target2) : -1;
@@ -1328,10 +1328,10 @@ bool SANA::scoreComparison(double newAligEdges, double newInducedEdges, double n
     return makeChange;
 }
 
-int SANA::aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int SANA::aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0;
     const uint n = G1AdjLists[source].size();
-    ushort neighbor;
+    uint neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
         res -= G2Matrix.get(oldTarget, (*A)[neighbor]);
@@ -1340,10 +1340,10 @@ int SANA::aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget
     return res;
 }
 
-int SANA::aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+int SANA::aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     int res = 0;
     const uint n = G1AdjLists[source1].size();
-    ushort neighbor;
+    uint neighbor;
     uint i = 0;
     for (; i < n; ++i) {
         neighbor = G1AdjLists[source1][i];
@@ -1375,13 +1375,13 @@ static int _edgeVal;
 // it should be edgeVal^2 - (edgeVal+1)^2 which is (2e + 1), but for some reason I had to make
 // it 2*(e+1).  That seemed to work better.  So yeah... big ugly hack.
 #define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, (*A)[j])), 2*((_edgeVal<1000?_edgeVal:0) + 1))
-int SANA::squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int SANA::squaredAligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0, diff;
-    ushort neighbor;
+    uint neighbor;
     const uint n = G1AdjLists[source].size();
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
-        // Account for ushort edges? Or assume smaller graph is edge value 1?
+        // Account for uint edges? Or assume smaller graph is edge value 1?
         diff = SQRDIFF(oldTarget, neighbor);
         assert(fabs(diff)<1100);
         res -= diff>0?diff:0;
@@ -1392,9 +1392,9 @@ int SANA::squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort ne
     return res;
 }
 
-int SANA::squaredAligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+int SANA::squaredAligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     int res = 0, diff;
-    ushort neighbor;
+    uint neighbor;
     const uint n = G1AdjLists[source1].size();
     uint i = 0;
     for (; i < n; ++i) {
@@ -1425,10 +1425,10 @@ int SANA::squaredAligEdgesIncSwapOp(ushort source1, ushort source2, ushort targe
     return res;
 }
 
-int SANA::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int SANA::inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0;
     const uint n = G2AdjLists[oldTarget].size();
-    ushort neighbor;
+    uint neighbor;
     uint i = 0;
     for (; i < n; ++i) {
         neighbor = G2AdjLists[oldTarget][i];
@@ -1444,18 +1444,18 @@ int SANA::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTar
     return res;
 }
 
-double SANA::localScoreSumIncChangeOp(vector<vector<float> > const & sim, ushort const & source, ushort const & oldTarget, ushort const & newTarget) {
+double SANA::localScoreSumIncChangeOp(vector<vector<float> > const & sim, uint const & source, uint const & oldTarget, uint const & newTarget) {
     return sim[source][newTarget] - sim[source][oldTarget];
 }
 
-double SANA::localScoreSumIncSwapOp(vector<vector<float> > const & sim, ushort const & source1, ushort const & source2, ushort const & target1, ushort const & target2) {
+double SANA::localScoreSumIncSwapOp(vector<vector<float> > const & sim, uint const & source1, uint const & source2, uint const & target1, uint const & target2) {
     return sim[source1][target2] - sim[source1][target1] + sim[source2][target1] - sim[source2][target2];
 }
 
-double SANA::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+double SANA::WECIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     double res = 0;
     const uint n = G1AdjLists[source].size();
-    ushort neighbor;
+    uint neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source][j];
         if (G2Matrix.get(oldTarget, (*A)[neighbor])) {
@@ -1470,10 +1470,10 @@ double SANA::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
     return res;
 }
 
-double SANA::WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+double SANA::WECIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     double res = 0;
     const uint n = G1AdjLists[source1].size();
-    ushort neighbor;
+    uint neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source1][j];
         if (G2Matrix.get(target1, (*A)[neighbor])) {
@@ -1509,13 +1509,13 @@ double SANA::WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort
     return res;
 }
 
-double SANA::EWECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget){
+double SANA::EWECIncChangeOp(uint source, uint oldTarget, uint newTarget){
     double score = 0;
     score = (EWECSimCombo(source, newTarget)) - (EWECSimCombo(source, oldTarget));
     return score;
 }
 
-double SANA::EWECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2){
+double SANA::EWECIncSwapOp(uint source1, uint source2, uint target1, uint target2){
     double score = 0;
     score = (EWECSimCombo(source1, target2)) + (EWECSimCombo(source2, target1)) - (EWECSimCombo(source1, target1)) - (EWECSimCombo(source2, target2));
     if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)){
@@ -1524,10 +1524,10 @@ double SANA::EWECIncSwapOp(ushort source1, ushort source2, ushort target1, ushor
     return score;
 }
 
-double SANA::EWECSimCombo(ushort source, ushort target){
+double SANA::EWECSimCombo(uint source, uint target){
     double score = 0;
     const uint n = G1AdjLists[source].size();
-    ushort neighbor;
+    uint neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
         if (G2Matrix.get(target, (*A)[neighbor])) {
@@ -1539,10 +1539,10 @@ double SANA::EWECSimCombo(ushort source, ushort target){
     return score/(2*g1Edges);
 }
 
-double SANA::TCIncChangeOp(ushort source, ushort oldTarget, ushort newTarget){
+double SANA::TCIncChangeOp(uint source, uint oldTarget, uint newTarget){
     double deltaTriangles = 0;
     const uint n = G1AdjLists[source].size();
-    ushort neighbor1, neighbor2;
+    uint neighbor1, neighbor2;
     for(uint i = 0; i < n; ++i){
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source][i];
@@ -1564,10 +1564,10 @@ double SANA::TCIncChangeOp(ushort source, ushort oldTarget, ushort newTarget){
     return ((double)deltaTriangles/maxTriangles);
 }
 
-double SANA::TCIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2){
+double SANA::TCIncSwapOp(uint source1, uint source2, uint target1, uint target2){
     double deltaTriangles = 0;
     const uint n = G1AdjLists[source1].size();
-    ushort neighbor1, neighbor2;
+    uint neighbor1, neighbor2;
     for(uint i = 0; i < n; ++i){
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source1][i];
@@ -1613,14 +1613,14 @@ double SANA::TCIncSwapOp(ushort source1, ushort source2, ushort target1, ushort 
     return ((double)deltaTriangles/maxTriangles);
 }
 
-int SANA::ncIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int SANA::ncIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int change = 0;
     if (trueA[source] == oldTarget) change -= 1;
     if (trueA[source] == newTarget) change += 1;
     return change;
 }
 
-int SANA::ncIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+int SANA::ncIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     int change = 0;
     if(trueA[source1] == target1) change -= 1;
     if(trueA[source2] == target2) change -= 1;
@@ -2350,8 +2350,8 @@ void SANA::setDynamicTDecay() {
 #ifdef WEIGHTED
 void SANA::prune(string& startAligName) {
     std::cerr << "Starting to prune using " <<  startAligName << std::endl;
-    int n = G1->getNumNodes();
-    vector<ushort> alignment;
+    uint n = G1->getNumNodes();
+    vector<uint> alignment;
     
     stringstream errorMsg;
     string format = startAligName.substr(startAligName.size()-6);
@@ -2369,9 +2369,9 @@ void SANA::prune(string& startAligName) {
 #endif        
 
 
-    unordered_map<ushort, ushort> reIndexedMap;    
+    unordered_map<uint, uint> reIndexedMap;    
     // This is when no reIndexing is done, just to simplify the code
-    for(int i=0;i<n;i++)
+    for(uint i=0;i<n;i++)
         reIndexedMap[i] = i;
 
 #ifdef REINDEX
@@ -2384,20 +2384,20 @@ void SANA::prune(string& startAligName) {
     alignment = align.getMapping();
             
     std::cerr << alignment.size() << " " << n << std::endl;
-    if ((int)alignment.size() != n) {
+    if ((uint)alignment.size() != n) {
         errorMsg << "Alignment size (" << alignment.size() << ") less than number of nodes (" << n <<")";
         throw runtime_error(errorMsg.str().c_str());
     }
-    set<pair<int,int>> removedEdges;
-    for (int i = 0; i < n; ++i) {
-        int g1_node1 = reIndexedMap[i];
-        int shadow_node = alignment[g1_node1];
-        int m = G1AdjLists[i].size();
-        for (int j = 0; j < m; ++j) {
+    set<pair<uint,uint>> removedEdges;
+    for (uint i = 0; i < n; ++i) {
+        uint g1_node1 = reIndexedMap[i];
+        uint shadow_node = alignment[g1_node1];
+        uint m = G1AdjLists[i].size();
+        for (uint j = 0; j < m; ++j) {
             if (G1AdjLists[i][j] < i)
                 continue;
-            int g1_node2 = reIndexedMap[G1AdjLists[i][j]];
-            int shadow_end = alignment[g1_node2];
+            uint g1_node2 = reIndexedMap[G1AdjLists[i][j]];
+            uint shadow_end = alignment[g1_node2];
 
             assert(G1Matrix.get(g1_node1, g1_node2) == 0 || G2Matrix.get(shadow_node, shadow_end) > 0);
             assert(G1Matrix.get(g1_node2, g1_node1) ==0 || G2Matrix.get(shadow_end, shadow_node) > 0);
@@ -2405,16 +2405,16 @@ void SANA::prune(string& startAligName) {
             G2Matrix.set(G2Matrix.get(shadow_node, shadow_end) - G1Matrix.get(g1_node1, g1_node2), shadow_node, shadow_end);
             G2Matrix.set(G2Matrix.get(shadow_end, shadow_node) - G1Matrix.get(g1_node1, g1_node2), shadow_end, shadow_node);
             if (G2Matrix.get(shadow_node, shadow_end) == 0) {
-                    removedEdges.insert(pair<int,int>(shadow_node,shadow_end));
+                    removedEdges.insert(pair<uint,uint>(shadow_node,shadow_end));
             }
         }
     }
-    vector<vector<ushort> > t_edgeList;
-    vector<vector<ushort> > G2EdgeList;
+    vector<vector<uint> > t_edgeList;
+    vector<vector<uint> > G2EdgeList;
     G2->getEdgeList(G2EdgeList);
     for (auto c : G2EdgeList) {
-        if (removedEdges.find(pair<int,int>(c[0],c[1])) != removedEdges.end() or
-                removedEdges.find(pair<int,int>(c[1],c[0])) != removedEdges.end()) {
+        if (removedEdges.find(pair<uint,uint>(c[0],c[1])) != removedEdges.end() or
+                removedEdges.find(pair<uint,uint>(c[1],c[0])) != removedEdges.end()) {
             continue;
         }
         t_edgeList.push_back(c);

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -99,8 +99,8 @@ SANA::SANA(Graph* G1, Graph* G2,
     paretoInitial   = MC->getParetoInitial();
     paretoCapacity  = MC->getParetoCapacity();
 
-    G1->getAdjMatrix(G1AdjMatrix);
-    G2->getAdjMatrix(G2AdjMatrix);
+    G1->getMatrix(G1Matrix);
+    G2->getMatrix(G2Matrix);
     G1->getAdjLists(G1AdjLists);
 #ifdef WEIGHTED
     if (startAligName != "") {
@@ -857,7 +857,7 @@ void SANA::performChange(int type) {
         double foo = eval(*A);
         if(fabs(foo - newCurrentScore)>20){
             cout << "\nChange: nCS " << newCurrentScore << " (nSAE) " << newSquaredAligEdges << " eval " << foo << " nCS - eval " << newCurrentScore-foo;
-            //cout << "source " << source << " oldTarget " << oldTarget << " newTarget " << newTarget << " adj? " << G2AdjMatrix[oldTarget][newTarget] << endl;
+            //cout << "source " << source << " oldTarget " << oldTarget << " newTarget " << newTarget << " adj? " << G2Matrix[oldTarget][newTarget] << endl;
             newCurrentScore = newSquaredAligEdges = foo;
         } else cout << "c";
         }
@@ -919,7 +919,7 @@ void SANA::performSwap(int type) {
         if (randomReal(gen) <= 1) {
             double foo = eval(*A);
             if (fabs(foo - newCurrentScore) > 20) {
-                cout << "\nSwap: nCS " << newCurrentScore << " eval " << foo << " nCS - eval " << newCurrentScore - foo << " adj? " << (G1AdjMatrix[source1][source2] & G2AdjMatrix[target1][target2]);
+                cout << "\nSwap: nCS " << newCurrentScore << " eval " << foo << " nCS - eval " << newCurrentScore - foo << " adj? " << (G1Matrix[source1][source2] & G2Matrix[target1][target2]);
                 newCurrentScore = newSquaredAligEdges = foo;
             }
             else cout << "s";
@@ -1145,8 +1145,8 @@ int SANA::aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget
     ushort neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
-        res -= G2AdjMatrix[oldTarget][(*A)[neighbor]];
-        res += G2AdjMatrix[newTarget][(*A)[neighbor]];
+        res -= G2Matrix.get(oldTarget, (*A)[neighbor]);
+        res += G2Matrix.get(newTarget, (*A)[neighbor]);
     }
     return res;
 }
@@ -1158,20 +1158,20 @@ int SANA::aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ush
     uint i = 0;
     for (; i < n; ++i) {
         neighbor = G1AdjLists[source1][i];
-        res -= G2AdjMatrix[target1][(*A)[neighbor]];
-        res += G2AdjMatrix[target2][(*A)[neighbor]];
+        res -= G2Matrix.get(target1, (*A)[neighbor]);
+        res += G2Matrix.get(target2, (*A)[neighbor]);
     }
     const uint m = G1AdjLists[source2].size();
     for (i = 0; i < m; ++i) {
         neighbor = G1AdjLists[source2][i];
-        res -= G2AdjMatrix[target2][(*A)[neighbor]];
-        res += G2AdjMatrix[target1][(*A)[neighbor]];
+        res -= G2Matrix.get(target2, (*A)[neighbor]);
+        res += G2Matrix.get(target1, (*A)[neighbor]);
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-    res += (-1 << 1) & (G1AdjMatrix[source1][source2] + G2AdjMatrix[target1][target2]);
+    res += (-1 << 1) & (G1Matrix.get(source1, source2) + G2Matrix.get(target1, target2));
 #else
-    res += 2*(G1AdjMatrix[source1][source2] & G2AdjMatrix[target1][target2]);
+    res += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
 #endif
     return res;
 }
@@ -1185,7 +1185,7 @@ static int _edgeVal;
 // between the value of this ladder and the ladder with one edge added or removed.  Mathematically
 // it should be edgeVal^2 - (edgeVal+1)^2 which is (2e + 1), but for some reason I had to make
 // it 2*(e+1).  That seemed to work better.  So yeah... big ugly hack.
-#define SQRDIFF(i,j) ((_edgeVal=G2AdjMatrix[i][(*A)[j]]), 2*((_edgeVal<1000?_edgeVal:0) + 1))
+#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, (*A)[j])), 2*((_edgeVal<1000?_edgeVal:0) + 1))
 int SANA::squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
     int res = 0, diff;
     ushort neighbor;
@@ -1229,7 +1229,7 @@ int SANA::squaredAligEdgesIncSwapOp(ushort source1, ushort source2, ushort targe
     }
     // How to do for squared?
     // address case swapping between adjacent nodes with adjacent images:
-    if(G1AdjMatrix[source1][source2] and G2AdjMatrix[target1][target2])
+    if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2))
     {
         res += 2 * SQRDIFF(target1,target2);
     }
@@ -1251,7 +1251,7 @@ int SANA::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTar
         res += (*assignedNodesG2)[neighbor];
     }
     //address case changing between adjacent nodes:
-    res -= G2AdjMatrix[oldTarget][newTarget];
+    res -= G2Matrix.get(oldTarget, newTarget);
     return res;
 }
 
@@ -1269,11 +1269,11 @@ double SANA::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
     ushort neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source][j];
-        if (G2AdjMatrix[oldTarget][(*A)[neighbor]]) {
+        if (G2Matrix.get(oldTarget, (*A)[neighbor])) {
             res -= wecSims[source][oldTarget];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2AdjMatrix[newTarget][(*A)[neighbor]]) {
+        if (G2Matrix.get(newTarget, (*A)[neighbor])) {
             res += wecSims[source][newTarget];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
@@ -1287,11 +1287,11 @@ double SANA::WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort
     ushort neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source1][j];
-        if (G2AdjMatrix[target1][(*A)[neighbor]]) {
+        if (G2Matrix.get(target1, (*A)[neighbor])) {
             res -= wecSims[source1][target1];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2AdjMatrix[target2][(*A)[neighbor]]) {
+        if (G2Matrix.get(target2, (*A)[neighbor])) {
             res += wecSims[source1][target2];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
@@ -1299,20 +1299,20 @@ double SANA::WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort
     const uint m = G1AdjLists[source2].size();
     for (uint j = 0; j < m; ++j) {
         neighbor = G1AdjLists[source2][j];
-        if (G2AdjMatrix[target2][(*A)[neighbor]]) {
+        if (G2Matrix.get(target2, (*A)[neighbor])) {
             res -= wecSims[source2][target2];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2AdjMatrix[target1][(*A)[neighbor]]) {
+        if (G2Matrix.get(target1, (*A)[neighbor])) {
             res += wecSims[source2][target1];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-    if (G1AdjMatrix[source1][source2] > 0 and G2AdjMatrix[target1][target2] > 0) {
+    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) {
 #else
-    if (G1AdjMatrix[source1][source2] and G2AdjMatrix[target1][target2]) {
+    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
 #endif
         res += 2*wecSims[source1][target1];
         res += 2*wecSims[source2][target2];
@@ -1329,7 +1329,7 @@ double SANA::EWECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget){
 double SANA::EWECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2){
     double score = 0;
     score = (EWECSimCombo(source1, target2)) + (EWECSimCombo(source2, target1)) - (EWECSimCombo(source1, target1)) - (EWECSimCombo(source2, target2));
-    if(G1AdjMatrix[source1][source2] and G2AdjMatrix[target1][target2]){
+    if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)){
         score += ewec->getScore(ewec->getColIndex(target1, target2), ewec->getRowIndex(source1, source2))/(g1Edges); //correcting for missed edges when swapping 2 adjacent pairs
     }
     return score;
@@ -1341,7 +1341,7 @@ double SANA::EWECSimCombo(ushort source, ushort target){
     ushort neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
-        if (G2AdjMatrix[target][(*A)[neighbor]]) {
+        if (G2Matrix.get(target, (*A)[neighbor])) {
             int e1 = ewec->getRowIndex(source, neighbor);
             int e2 = ewec->getColIndex(target, (*A)[neighbor]);
             score+=ewec->getScore(e2,e1);
@@ -1358,14 +1358,14 @@ double SANA::TCIncChangeOp(ushort source, ushort oldTarget, ushort newTarget){
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source][i];
             neighbor2 = G1AdjLists[source][j];
-            if(G1AdjMatrix[neighbor1][neighbor2]){
+            if(G1Matrix.get(neighbor1, neighbor2)){
                 //G1 has a triangle
-                if(G2AdjMatrix[oldTarget][(*A)[neighbor1]] and G2AdjMatrix[oldTarget][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]]){
+                if(G2Matrix.get(oldTarget, (*A)[neighbor1]) and G2Matrix.get(oldTarget, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if(G2AdjMatrix[newTarget][(*A)[neighbor1]] and G2AdjMatrix[newTarget][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]]){
+                if(G2Matrix.get(newTarget, (*A)[neighbor1]) and G2Matrix.get(newTarget, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -1383,16 +1383,16 @@ double SANA::TCIncSwapOp(ushort source1, ushort source2, ushort target1, ushort 
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source1][i];
             neighbor2 = G1AdjLists[source1][j];
-            if(G1AdjMatrix[neighbor1][neighbor2]){
+            if(G1Matrix.get(neighbor1, neighbor2)){
                 //G1 has a triangle
-                if(G2AdjMatrix[target1][(*A)[neighbor1]] and G2AdjMatrix[target1][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]]){
+                if(G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if((G2AdjMatrix[target2][(*A)[neighbor1]] and G2AdjMatrix[target2][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]])
-                   || (neighbor1 == source2 and G2AdjMatrix[target2][target1] and G2AdjMatrix[target2][(*A)[neighbor2]] and G2AdjMatrix[target1][(*A)[neighbor2]])
-                   || (neighbor2 == source2 and G2AdjMatrix[target2][(*A)[neighbor1]] and G2AdjMatrix[target2][target1] and G2AdjMatrix[(*A)[neighbor1]][target1])){
+                if((G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2]))
+                || (neighbor1 == source2 and G2Matrix.get(target2, target1) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get(target1, (*A)[neighbor2]))
+                || (neighbor2 == source2 and G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, target1) and G2Matrix.get((*A)[neighbor1], target1))) {
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -1404,16 +1404,16 @@ double SANA::TCIncSwapOp(ushort source1, ushort source2, ushort target1, ushort 
         for(uint j = i+1; j < m; ++j){
             neighbor1 = G1AdjLists[source2][i];
             neighbor2 = G1AdjLists[source2][j];
-            if(G1AdjMatrix[neighbor1][neighbor2]){
+            if(G1Matrix.get(neighbor1, neighbor2)){
                 //G1 has a triangle
-                if(G2AdjMatrix[target2][(*A)[neighbor1]] and G2AdjMatrix[target2][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]]){
+                if(G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if((G2AdjMatrix[target1][(*A)[neighbor1]] and G2AdjMatrix[target1][(*A)[neighbor2]] and G2AdjMatrix[(*A)[neighbor1]][(*A)[neighbor2]])
-                   || (neighbor1 == source1 and G2AdjMatrix[target1][target2] and G2AdjMatrix[target1][(*A)[neighbor2]] and G2AdjMatrix[target2][(*A)[neighbor2]])
-                   || (neighbor2 == source1 and G2AdjMatrix[target1][(*A)[neighbor1]] and G2AdjMatrix[target1][target2] and G2AdjMatrix[(*A)[neighbor1]][target2])){
+                if((G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2]))
+                   || (neighbor1 == source1 and G2Matrix.get(target1, target2) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get(target2, (*A)[neighbor2]))
+                   || (neighbor2 == source1 and G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, target2) and G2Matrix.get((*A)[neighbor1], target2))){
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -2194,12 +2194,12 @@ void SANA::prune(string& startAligName) {
             int g1_node2 = reIndexedMap[G1AdjLists[i][j]];
             int shadow_end = alignment[g1_node2];
 
-            assert(G1AdjMatrix[g1_node1][g1_node2] == 0 || G2AdjMatrix[shadow_node][shadow_end] > 0);
-            assert(G1AdjMatrix[g1_node2][g1_node1] ==0 || G2AdjMatrix[shadow_end][shadow_node] > 0);
+            assert(G1Matrix[g1_node1][g1_node2] == 0 || G2Matrix[shadow_node][shadow_end] > 0);
+            assert(G1Matrix[g1_node2][g1_node1] ==0 || G2Matrix[shadow_end][shadow_node] > 0);
 
-            G2AdjMatrix[shadow_node][shadow_end] -= G1AdjMatrix[g1_node1][g1_node2];
-            G2AdjMatrix[shadow_end][shadow_node] -= G1AdjMatrix[g1_node1][g1_node2];
-            if (G2AdjMatrix[shadow_node][shadow_end] == 0) {
+            G2Matrix[shadow_node][shadow_end] -= G1Matrix[g1_node1][g1_node2];
+            G2Matrix[shadow_end][shadow_node] -= G1Matrix[g1_node1][g1_node2];
+            if (G2Matrix[shadow_node][shadow_end] == 0) {
                     removedEdges.insert(pair<int,int>(shadow_node,shadow_end));
             }
         }
@@ -2214,7 +2214,7 @@ void SANA::prune(string& startAligName) {
         }
         t_edgeList.push_back(c);
     }
-    G2->setAdjMatrix(G2AdjMatrix);
+    G2->setMatrix(G2Matrix);
     G2->getAdjLists(G2AdjLists);
     G2->setEdgeList(t_edgeList);
 }

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -2194,12 +2194,12 @@ void SANA::prune(string& startAligName) {
             int g1_node2 = reIndexedMap[G1AdjLists[i][j]];
             int shadow_end = alignment[g1_node2];
 
-            assert(G1Matrix[g1_node1][g1_node2] == 0 || G2Matrix[shadow_node][shadow_end] > 0);
-            assert(G1Matrix[g1_node2][g1_node1] ==0 || G2Matrix[shadow_end][shadow_node] > 0);
+            assert(G1Matrix.get(g1_node1, g1_node2) == 0 || G2Matrix.get(shadow_node, shadow_end) > 0);
+            assert(G1Matrix.get(g1_node2, g1_node1) ==0 || G2Matrix.get(shadow_end, shadow_node) > 0);
 
-            G2Matrix[shadow_node][shadow_end] -= G1Matrix[g1_node1][g1_node2];
-            G2Matrix[shadow_end][shadow_node] -= G1Matrix[g1_node1][g1_node2];
-            if (G2Matrix[shadow_node][shadow_end] == 0) {
+            G2Matrix.set(G2Matrix.get(shadow_node, shadow_end) - G1Matrix.get(g1_node1, g1_node2), shadow_node, shadow_end);
+            G2Matrix.set(G2Matrix.get(shadow_end, shadow_node) - G1Matrix.get(g1_node1, g1_node2), shadow_end, shadow_node);
+            if (G2Matrix.get(shadow_node, shadow_end) == 0) {
                     removedEdges.insert(pair<int,int>(shadow_node,shadow_end));
             }
         }

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -1334,8 +1334,8 @@ int SANA::aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     uint neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
-        res -= G2Matrix.get(oldTarget, (*A)[neighbor]);
-        res += G2Matrix.get(newTarget, (*A)[neighbor]);
+        res -= G2Matrix[oldTarget][(*A)[neighbor]];
+        res += G2Matrix[newTarget][(*A)[neighbor]];
     }
     return res;
 }
@@ -1347,20 +1347,20 @@ int SANA::aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint targ
     uint i = 0;
     for (; i < n; ++i) {
         neighbor = G1AdjLists[source1][i];
-        res -= G2Matrix.get(target1, (*A)[neighbor]);
-        res += G2Matrix.get(target2, (*A)[neighbor]);
+        res -= G2Matrix[target1][(*A)[neighbor]];
+        res += G2Matrix[target2][(*A)[neighbor]];
     }
     const uint m = G1AdjLists[source2].size();
     for (i = 0; i < m; ++i) {
         neighbor = G1AdjLists[source2][i];
-        res -= G2Matrix.get(target2, (*A)[neighbor]);
-        res += G2Matrix.get(target1, (*A)[neighbor]);
+        res -= G2Matrix[target2][(*A)[neighbor]];
+        res += G2Matrix[target1][(*A)[neighbor]];
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-    res += (-1 << 1) & (G1Matrix.get(source1, source2) + G2Matrix.get(target1, target2));
+    res += (-1 << 1) & (G1Matrix[source1][source2] + G2Matrix[target1][target2]);
 #else
-    res += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
+    res += 2*(G1Matrix[source1][source2] & G2Matrix[target1][target2]);
 #endif
     return res;
 }
@@ -1374,7 +1374,7 @@ static int _edgeVal;
 // between the value of this ladder and the ladder with one edge added or removed.  Mathematically
 // it should be edgeVal^2 - (edgeVal+1)^2 which is (2e + 1), but for some reason I had to make
 // it 2*(e+1).  That seemed to work better.  So yeah... big ugly hack.
-#define SQRDIFF(i,j) ((_edgeVal=G2Matrix.get(i, (*A)[j])), 2*((_edgeVal<1000?_edgeVal:0) + 1))
+#define SQRDIFF(i,j) ((_edgeVal=G2Matrix[i][(*A)[j]]), 2*((_edgeVal<1000?_edgeVal:0) + 1))
 int SANA::squaredAligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0, diff;
     uint neighbor;
@@ -1418,7 +1418,7 @@ int SANA::squaredAligEdgesIncSwapOp(uint source1, uint source2, uint target1, ui
     }
     // How to do for squared?
     // address case swapping between adjacent nodes with adjacent images:
-    if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2))
+    if(G1Matrix[source1][source2] and G2Matrix[target1][target2])
     {
         res += 2 * SQRDIFF(target1,source2);
     }
@@ -1440,7 +1440,7 @@ int SANA::inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
         res += (*assignedNodesG2)[neighbor];
     }
     //address case changing between adjacent nodes:
-    res -= G2Matrix.get(oldTarget, newTarget);
+    res -= G2Matrix[oldTarget][newTarget];
     return res;
 }
 
@@ -1458,11 +1458,11 @@ double SANA::WECIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     uint neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source][j];
-        if (G2Matrix.get(oldTarget, (*A)[neighbor])) {
+        if (G2Matrix[oldTarget][(*A)[neighbor]]) {
             res -= wecSims[source][oldTarget];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2Matrix.get(newTarget, (*A)[neighbor])) {
+        if (G2Matrix[newTarget][(*A)[neighbor]]) {
             res += wecSims[source][newTarget];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
@@ -1476,11 +1476,11 @@ double SANA::WECIncSwapOp(uint source1, uint source2, uint target1, uint target2
     uint neighbor;
     for (uint j = 0; j < n; ++j) {
         neighbor = G1AdjLists[source1][j];
-        if (G2Matrix.get(target1, (*A)[neighbor])) {
+        if (G2Matrix[target1][(*A)[neighbor]]) {
             res -= wecSims[source1][target1];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2Matrix.get(target2, (*A)[neighbor])) {
+        if (G2Matrix[target2][(*A)[neighbor]]) {
             res += wecSims[source1][target2];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
@@ -1488,20 +1488,20 @@ double SANA::WECIncSwapOp(uint source1, uint source2, uint target1, uint target2
     const uint m = G1AdjLists[source2].size();
     for (uint j = 0; j < m; ++j) {
         neighbor = G1AdjLists[source2][j];
-        if (G2Matrix.get(target2, (*A)[neighbor])) {
+        if (G2Matrix[target2][(*A)[neighbor]]) {
             res -= wecSims[source2][target2];
             res -= wecSims[neighbor][(*A)[neighbor]];
         }
-        if (G2Matrix.get(target1, (*A)[neighbor])) {
+        if (G2Matrix[target1][(*A)[neighbor]]) {
             res += wecSims[source2][target1];
             res += wecSims[neighbor][(*A)[neighbor]];
         }
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
-    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) {
+    if (G1Matrix[source1][source2] > 0 and G2Matrix[target1][target2] > 0) {
 #else
-    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
+    if (G1Matrix[source1][source2] and G2Matrix[target1][target2]) {
 #endif
         res += 2*wecSims[source1][target1];
         res += 2*wecSims[source2][target2];
@@ -1518,7 +1518,7 @@ double SANA::EWECIncChangeOp(uint source, uint oldTarget, uint newTarget){
 double SANA::EWECIncSwapOp(uint source1, uint source2, uint target1, uint target2){
     double score = 0;
     score = (EWECSimCombo(source1, target2)) + (EWECSimCombo(source2, target1)) - (EWECSimCombo(source1, target1)) - (EWECSimCombo(source2, target2));
-    if(G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)){
+    if(G1Matrix[source1][source2] and G2Matrix[target1][target2]){
         score += ewec->getScore(ewec->getColIndex(target1, target2), ewec->getRowIndex(source1, source2))/(g1Edges); //correcting for missed edges when swapping 2 adjacent pairs
     }
     return score;
@@ -1530,7 +1530,7 @@ double SANA::EWECSimCombo(uint source, uint target){
     uint neighbor;
     for (uint i = 0; i < n; ++i) {
         neighbor = G1AdjLists[source][i];
-        if (G2Matrix.get(target, (*A)[neighbor])) {
+        if (G2Matrix[target][(*A)[neighbor]]) {
             int e1 = ewec->getRowIndex(source, neighbor);
             int e2 = ewec->getColIndex(target, (*A)[neighbor]);
             score+=ewec->getScore(e2,e1);
@@ -1547,14 +1547,14 @@ double SANA::TCIncChangeOp(uint source, uint oldTarget, uint newTarget){
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source][i];
             neighbor2 = G1AdjLists[source][j];
-            if(G1Matrix.get(neighbor1, neighbor2)){
+            if(G1Matrix[neighbor1][neighbor2]){
                 //G1 has a triangle
-                if(G2Matrix.get(oldTarget, (*A)[neighbor1]) and G2Matrix.get(oldTarget, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
+                if(G2Matrix[oldTarget][(*A)[neighbor1]] and G2Matrix[oldTarget][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]]){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if(G2Matrix.get(newTarget, (*A)[neighbor1]) and G2Matrix.get(newTarget, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
+                if(G2Matrix[newTarget][(*A)[neighbor1]] and G2Matrix[newTarget][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]]){
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -1572,16 +1572,16 @@ double SANA::TCIncSwapOp(uint source1, uint source2, uint target1, uint target2)
         for(uint j = i+1; j < n; ++j){
             neighbor1 = G1AdjLists[source1][i];
             neighbor2 = G1AdjLists[source1][j];
-            if(G1Matrix.get(neighbor1, neighbor2)){
+            if(G1Matrix[neighbor1][neighbor2]){
                 //G1 has a triangle
-                if(G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
+                if(G2Matrix[target1][(*A)[neighbor1]] and G2Matrix[target1][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]]){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if((G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2]))
-                || (neighbor1 == source2 and G2Matrix.get(target2, target1) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get(target1, (*A)[neighbor2]))
-                || (neighbor2 == source2 and G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, target1) and G2Matrix.get((*A)[neighbor1], target1))) {
+                if((G2Matrix[target2][(*A)[neighbor1]] and G2Matrix[target2][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]])
+                || (neighbor1 == source2 and G2Matrix[target2][target1] and G2Matrix[target2][(*A)[neighbor2]] and G2Matrix[target1][(*A)[neighbor2]])
+                || (neighbor2 == source2 and G2Matrix[target2][(*A)[neighbor1]] and G2Matrix[target2][target1] and G2Matrix[(*A)[neighbor1]][target1])) {
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -1593,16 +1593,16 @@ double SANA::TCIncSwapOp(uint source1, uint source2, uint target1, uint target2)
         for(uint j = i+1; j < m; ++j){
             neighbor1 = G1AdjLists[source2][i];
             neighbor2 = G1AdjLists[source2][j];
-            if(G1Matrix.get(neighbor1, neighbor2)){
+            if(G1Matrix[neighbor1][neighbor2]){
                 //G1 has a triangle
-                if(G2Matrix.get(target2, (*A)[neighbor1]) and G2Matrix.get(target2, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2])){
+                if(G2Matrix[target2][(*A)[neighbor1]] and G2Matrix[target2][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]]){
                     //G2 HAD a triangle
                     deltaTriangles -= 1;
                 }
 
-                if((G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get((*A)[neighbor1], (*A)[neighbor2]))
-                   || (neighbor1 == source1 and G2Matrix.get(target1, target2) and G2Matrix.get(target1, (*A)[neighbor2]) and G2Matrix.get(target2, (*A)[neighbor2]))
-                   || (neighbor2 == source1 and G2Matrix.get(target1, (*A)[neighbor1]) and G2Matrix.get(target1, target2) and G2Matrix.get((*A)[neighbor1], target2))){
+                if((G2Matrix[target1][(*A)[neighbor1]] and G2Matrix[target1][(*A)[neighbor2]] and G2Matrix[(*A)[neighbor1]][(*A)[neighbor2]])
+                   || (neighbor1 == source1 and G2Matrix[target1][target2] and G2Matrix[target1][(*A)[neighbor2]] and G2Matrix[target2][(*A)[neighbor2]])
+                   || (neighbor2 == source1 and G2Matrix[target1][(*A)[neighbor1]] and G2Matrix[target1][target2] and G2Matrix[(*A)[neighbor1]][target2])){
                     //G2 GAINS a triangle
                     deltaTriangles += 1;
                 }
@@ -2399,13 +2399,13 @@ void SANA::prune(string& startAligName) {
             uint g1_node2 = reIndexedMap[G1AdjLists[i][j]];
             uint shadow_end = alignment[g1_node2];
 
-            assert(G1Matrix.get(g1_node1, g1_node2) == 0 || G2Matrix.get(shadow_node, shadow_end) > 0);
-            assert(G1Matrix.get(g1_node2, g1_node1) ==0 || G2Matrix.get(shadow_end, shadow_node) > 0);
+            assert(G1Matrix[g1_node1][g1_node2] == 0 || G2Matrix[shadow_node][shadow_end] > 0);
+            assert(G1Matrix[g1_node2][g1_node1] == 0 || G2Matrix[shadow_end][shadow_node] > 0);
 
-            G2Matrix.set(G2Matrix.get(shadow_node, shadow_end) - G1Matrix.get(g1_node1, g1_node2), shadow_node, shadow_end);
-            G2Matrix.set(G2Matrix.get(shadow_end, shadow_node) - G1Matrix.get(g1_node1, g1_node2), shadow_end, shadow_node);
-            if (G2Matrix.get(shadow_node, shadow_end) == 0) {
-                    removedEdges.insert(pair<uint,uint>(shadow_node,shadow_end));
+            G2Matrix[shadow_node][shadow_end] -= G1Matrix[g1_node1][g1_node2];
+            G2Matrix[shadow_end][shadow_node] -= G1Matrix[g1_node1][g1_node2];
+            if (G2Matrix[shadow_node][shadow_end] == 0) {
+                removedEdges.insert(pair<uint,uint>(shadow_node,shadow_end));
             }
         }
     }

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -83,13 +83,8 @@ private:
     double g2WeightedEdges;
 #endif
     double g2Edges; //stored as double because it appears in division
-#ifdef WEIGHTED
-    vector<vector<ushort> > G1AdjMatrix;
-    vector<vector<ushort> > G2AdjMatrix;
-#else
-    vector<vector<bool> > G1AdjMatrix;
-    vector<vector<bool> > G2AdjMatrix;
-#endif
+    Matrix G1Matrix;
+    Matrix G2Matrix;
     vector<vector<ushort> > G1AdjLists;
     vector<vector<ushort> > G2AdjLists;
 

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -97,8 +97,8 @@ private:
     double g2WeightedEdges;
 #endif
     double g2Edges; //stored as double because it appears in division
-    Matrix G1Matrix;
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G1Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
     vector<vector<uint> > G1AdjLists;
     vector<vector<uint> > G2AdjLists;
 

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -97,8 +97,8 @@ private:
     double g2WeightedEdges;
 #endif
     double g2Edges; //stored as double because it appears in division
-    Matrix<WEIGHTED_VALUE> G1Matrix;
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G1Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
     vector<vector<uint> > G1AdjLists;
     vector<vector<uint> > G2AdjLists;
 

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -29,7 +29,7 @@ public:
     ~SANA(){}
 
     Alignment run();
-    unordered_set<vector<ushort>*>* paretoRun();
+    unordered_set<vector<uint>*>* paretoRun();
     void describeParameters(ostream& stream);
     string fileNameSuffix(const Alignment& A);
 
@@ -99,11 +99,11 @@ private:
     double g2Edges; //stored as double because it appears in division
     Matrix G1Matrix;
     Matrix G2Matrix;
-    vector<vector<ushort> > G1AdjLists;
-    vector<vector<ushort> > G2AdjLists;
+    vector<vector<uint> > G1AdjLists;
+    vector<vector<uint> > G2AdjLists;
 
     void initTau(void);
-    vector<ushort> unLockedNodesG1;
+    vector<uint> unLockedNodesG1;
     bool nodesHaveType = false;
     //random number generation
     mt19937 gen;
@@ -117,11 +117,11 @@ private:
     uniform_int_distribution<> G2RandomUnassignedmiRNADist;
 
 
-    ushort G1RandomUnlockedNode();
-    ushort G1RandomUnlockedNode(uint source1); // used in nodes-have-type because
-    ushort G1RandomUnlockedNode_Fast();
-    ushort G2RandomUnlockedNode(uint target1);
-    ushort G2RandomUnlockedNode_Fast();
+    uint G1RandomUnlockedNode();
+    uint G1RandomUnlockedNode(uint source1); // used in nodes-have-type because
+    uint G1RandomUnlockedNode_Fast();
+    uint G2RandomUnlockedNode(uint target1);
+    uint G2RandomUnlockedNode_Fast();
 
     //temperature schedule
     double TInitial;
@@ -160,10 +160,10 @@ private:
     //data structures for the solution space search
     double changeProbability[2];
     vector<bool> *assignedNodesG2;
-    vector<ushort> *unassignedNodesG2;
-    vector<ushort> *unassignedmiRNAsG2;
-    vector<ushort> *unassignedgenesG2;
-    vector<ushort>* A;
+    vector<uint> *unassignedNodesG2;
+    vector<uint> *unassignedmiRNAsG2;
+    vector<uint> *unassignedgenesG2;
+    vector<uint>* A;
     //initializes all the necessary data structures for a new run
     void initDataStructures(const Alignment& startA);
 
@@ -213,14 +213,14 @@ private:
     //to evaluate EC incrementally
     bool needAligEdges;
     int aligEdges;
-    int aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    int aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    int aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    int aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
     // to evaluate SES incrementally
     bool needSquaredAligEdges;
     int squaredAligEdges;
-    int squaredAligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    int squaredAligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    int squaredAligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    int squaredAligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
     //to evaluate EC incrementally
     bool needSec;
@@ -229,34 +229,34 @@ private:
     //to evaluate S3 incrementally
     bool needInducedEdges;
     int inducedEdges;
-    int inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
+    int inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget);
 
     bool needTC;
     double TCSum;
-    double TCIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    double TCIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    double TCIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    double TCIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
     //to evaluate nc incrementally
     bool needNC;
     int ncSum;
-    vector<ushort> trueA;
-    int ncIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    int ncIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    vector<uint> trueA;
+    int ncIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    int ncIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
     //to evaluate wec incrementally
     bool needWec;
     double wecSum;
     vector<vector<float> > wecSims;
-    double WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    double WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    double WECIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    double WECIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
     //to evaluate ewec incrementally
     bool needEwec;
     ExternalWeightedEdgeConservation* ewec;
     double ewecSum;
-    double EWECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    double EWECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
-    double EWECSimCombo(ushort source, ushort target);
+    double EWECIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    double EWECIncSwapOp(uint source1, uint source2, uint target1, uint target2);
+    double EWECSimCombo(uint source, uint target);
 
     //to evaluate local measures incrementally
     bool needLocal;
@@ -270,8 +270,8 @@ private:
     vector<double> totalCoreWeight; // sum of all pBads, for each node in G1.
 #endif
     map<string, vector<vector<float> > > localSimMatrixMap;
-    double localScoreSumIncChangeOp(vector<vector<float> > const & sim, ushort const & source, ushort const & oldTarget, ushort const & newTarget);
-    double localScoreSumIncSwapOp(vector<vector<float> > const & sim, ushort const & source1, ushort const & source2, ushort const & target1, ushort const & target2);
+    double localScoreSumIncChangeOp(vector<vector<float> > const & sim, uint const & source, uint const & oldTarget, uint const & newTarget);
+    double localScoreSumIncSwapOp(vector<vector<float> > const & sim, uint const & source1, uint const & source2, uint const & target1, uint const & target2);
 
 
 
@@ -289,9 +289,9 @@ private:
         long long int& iter);
     Alignment simpleRun(const Alignment& startA, double maxExecutionSeconds, long long int maxExecutionIterations,
         long long int& iter);
-    unordered_set<vector<ushort>*>* simpleParetoRun(const Alignment& A, double maxExecutionSeconds,
+    unordered_set<vector<uint>*>* simpleParetoRun(const Alignment& A, double maxExecutionSeconds,
         long long int& iter);
-    unordered_set<vector<ushort>*>* simpleParetoRun(const Alignment& A, long long int maxExecutionIterations,
+    unordered_set<vector<uint>*>* simpleParetoRun(const Alignment& A, long long int maxExecutionIterations,
         long long int& iter);
 
     double currentScore;
@@ -326,7 +326,7 @@ private:
     void insertCurrentAndPrepareNewMeasureDataByAlignment(vector<double> &addScores);
     vector<double> translateScoresToVector();
     void insertCurrentAlignmentAndData();
-    void removeAlignmentData(vector<ushort>* toRemove);
+    void removeAlignmentData(vector<uint>* toRemove);
     void initializeParetoFront();
     vector<double> getMeasureScores(double newAligEdges, double newInducedEdges, double newTCSum,
                                      double newLocalScoreSum, double newWecSum, double newNcSum,
@@ -338,25 +338,25 @@ private:
     vector<double> currentScores;
     ParetoFront paretoFront;
     vector<bool>* newAN = new vector<bool>(0);
-    vector<ushort>* newUAN = new vector<ushort>(0);
-    vector<ushort>* newUmiRNA = new vector<ushort>(0);
-    vector<ushort>* newUG = new vector<ushort>(0);
+    vector<uint>* newUAN = new vector<uint>(0);
+    vector<uint>* newUmiRNA = new vector<uint>(0);
+    vector<uint>* newUG = new vector<uint>(0);
     unordered_map<string, int> scoreNamesToIndexes;
-    unordered_set<vector<ushort>*>* storedAlignments = new unordered_set<vector<ushort>*>;
-    unordered_map<vector<ushort>*, vector<bool>*> storedAssignedNodesG2;
-    unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedNodesG2;
-    unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedmiRNAsG2;
-    unordered_map<vector<ushort>*, vector<ushort>*> storedUnassignedgenesG2;
-    unordered_map<vector<ushort>*, int> storedAligEdges;
-    unordered_map<vector<ushort>*, int> storedSquaredAligEdges;
-    unordered_map<vector<ushort>*, int> storedInducedEdges;
-    unordered_map<vector<ushort>*, double> storedLocalScoreSum;
-    unordered_map<vector<ushort>*, double> storedWecSum;
-    unordered_map<vector<ushort>*, double> storedEwecSum;
-    unordered_map<vector<ushort>*, int> storedNcSum;
-    unordered_map<vector<ushort>*, double> storedTCSum;
-    unordered_map<vector<ushort>*, double> storedCurrentScore;
-    unordered_map<vector<ushort>*, map<string, double>*> storedLocalScoreSumMap;
+    unordered_set<vector<uint>*>* storedAlignments = new unordered_set<vector<uint>*>;
+    unordered_map<vector<uint>*, vector<bool>*> storedAssignedNodesG2;
+    unordered_map<vector<uint>*, vector<uint>*> storedUnassignedNodesG2;
+    unordered_map<vector<uint>*, vector<uint>*> storedUnassignedmiRNAsG2;
+    unordered_map<vector<uint>*, vector<uint>*> storedUnassignedgenesG2;
+    unordered_map<vector<uint>*, int> storedAligEdges;
+    unordered_map<vector<uint>*, int> storedSquaredAligEdges;
+    unordered_map<vector<uint>*, int> storedInducedEdges;
+    unordered_map<vector<uint>*, double> storedLocalScoreSum;
+    unordered_map<vector<uint>*, double> storedWecSum;
+    unordered_map<vector<uint>*, double> storedEwecSum;
+    unordered_map<vector<uint>*, int> storedNcSum;
+    unordered_map<vector<uint>*, double> storedTCSum;
+    unordered_map<vector<uint>*, double> storedCurrentScore;
+    unordered_map<vector<uint>*, map<string, double>*> storedLocalScoreSumMap;
     typedef double (*calc)(PARAMS);
     unordered_map<string, calc> measureCalculation;
 };

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -71,7 +71,7 @@ public:
     string startAligName = "";
     void prune(string& startAligName);
 #ifdef CORES
-    vector<vector<ulong>> getCoreFreq();
+    Matrix<ulong> getCoreFreq();
     vector<ulong> getCoreCount();
 #endif
     //to compute TDecay automatically
@@ -264,9 +264,9 @@ private:
     map<string, double>* localScoreSumMap = new map<string, double>;
     vector<vector<float> > sims;
 #ifdef CORES
-    vector<vector<ulong> > coreFreq;
+    Matrix<ulong> coreFreq;
     vector<ulong> coreCount; // number of times this node in g1 was sampled.
-    vector<vector<double> > weightedCoreFreq; // weighted by pBad below
+    Matrix<double> weightedCoreFreq; // weighted by pBad below
     vector<double> totalCoreWeight; // sum of all pBads, for each node in G1.
 #endif
     map<string, vector<vector<float> > > localSimMatrixMap;

--- a/src/methods/TabuSearch.cpp
+++ b/src/methods/TabuSearch.cpp
@@ -107,8 +107,8 @@ TabuSearch::TabuSearch(Graph* G1, Graph* G2,
     //stack. it is initialized properly before
     //running the algorithm
     assignedNodesG2 = vector<bool> (n2);
-    unassignedNodesG2 = vector<ushort> (n2-n1);
-    A = vector<ushort> (n1);
+    unassignedNodesG2 = vector<uint> (n2-n1);
+    A = vector<uint> (n1);
 
     assert((nodeTabus and n1 > maxTabus) or (not nodeTabus and n1*n2 > maxTabus));
 }
@@ -142,7 +142,7 @@ void TabuSearch::initDataStructures(const Alignment& startA) {
         assignedNodesG2[A[i]] = true;
     }
 
-    unassignedNodesG2 = vector<ushort> (n2-n1);
+    unassignedNodesG2 = vector<uint> (n2-n1);
     int j = 0;
     for (uint i = 0; i < n2; i++) {
         if (not assignedNodesG2[i]) {
@@ -216,11 +216,11 @@ Alignment TabuSearch::simpleRun(const Alignment& startA, double maxExecutionSeco
     return bestA; //dummy return to shut compiler warning
 }
 
-bool TabuSearch::isTabu(ushort node) {
+bool TabuSearch::isTabu(uint node) {
     return tabusHash.count(node) != 0;
 }
 
-void TabuSearch::addTabu(ushort node) {
+void TabuSearch::addTabu(uint node) {
   if (tabus.size() == maxTabus) {
     if (tabus.size() == 0) return;
     tabusHash.erase(tabus.back());
@@ -232,13 +232,13 @@ void TabuSearch::addTabu(ushort node) {
 
 //if tabus are mappings, the first 16 bits are the node in G1
 //and the last 16 bits are the node in G2
-bool TabuSearch::isTabu(ushort node1, ushort node2) {
+bool TabuSearch::isTabu(uint node1, uint node2) {
     uint tabuId = node1;
     tabuId = (tabuId << 16) | node2;
     return tabusHash.count(tabuId) != 0;
 }
 
-void TabuSearch::addTabu(ushort node1, ushort node2) {
+void TabuSearch::addTabu(uint node1, uint node2) {
     if (tabus.size() == maxTabus) {
         if (tabus.size() == 0) return;
         tabusHash.erase(tabus.back());
@@ -252,16 +252,16 @@ void TabuSearch::addTabu(ushort node1, ushort node2) {
 
 void TabuSearch::TabuSearchIteration() {
     nScore = -1;
-    ushort numAdmiNeighborsFound = 0;
+    uint numAdmiNeighborsFound = 0;
     while (numAdmiNeighborsFound < nNeighbors) {
         if (randomReal(gen) <= changeProbability) {
-            ushort source = G1RandomNode(gen);
+            uint source = G1RandomNode(gen);
             if (isTabu(source)) continue;
             ++numAdmiNeighborsFound;
             performChange(source);
         }
         else {
-            ushort source1 = G1RandomNode(gen), source2 = G1RandomNode(gen);
+            uint source1 = G1RandomNode(gen), source2 = G1RandomNode(gen);
             if (isTabu(source1) or isTabu(source2)) continue;
             ++numAdmiNeighborsFound;
             performSwap(source1, source2);
@@ -276,18 +276,18 @@ void TabuSearch::TabuSearchIteration() {
 
 void TabuSearch::TabuSearchIterationMappingTabus() {
     nScore = -1;
-    ushort numAdmiNeighborsFound = 0;
+    uint numAdmiNeighborsFound = 0;
     while (numAdmiNeighborsFound < nNeighbors) {
         if (randomReal(gen) <= changeProbability) {
-            ushort source = G1RandomNode(gen);
+            uint source = G1RandomNode(gen);
             uint newTargetIndex = G2RandomUnassignedNode(gen);
-            ushort newTarget = unassignedNodesG2[newTargetIndex];
+            uint newTarget = unassignedNodesG2[newTargetIndex];
             if (isTabu(source, newTarget)) continue;
             ++numAdmiNeighborsFound;
             performChange(source, newTargetIndex);
         }
         else {
-            ushort source1 = G1RandomNode(gen), source2 = G1RandomNode(gen);
+            uint source1 = G1RandomNode(gen), source2 = G1RandomNode(gen);
             if (isTabu(source1, A[source2]) or isTabu(source2, A[source1])) continue;
             ++numAdmiNeighborsFound;
             performSwap(source1, source2);
@@ -331,14 +331,14 @@ void TabuSearch::moveToBestAdmiNeighbor() {
     }
 }
 
-void TabuSearch::performChange(ushort source) {
+void TabuSearch::performChange(uint source) {
     uint newTargetIndex = G2RandomUnassignedNode(gen);
     performChange(source, newTargetIndex);
 }
 
-void TabuSearch::performChange(ushort source, uint newTargetIndex) {
-    ushort oldTarget = A[source];
-    ushort newTarget = unassignedNodesG2[newTargetIndex];
+void TabuSearch::performChange(uint source, uint newTargetIndex) {
+    uint oldTarget = A[source];
+    uint newTarget = unassignedNodesG2[newTargetIndex];
 
     int newAligEdges = -1; //dummy initialization to shut compiler warnings
     if (needAligEdges) {
@@ -380,8 +380,8 @@ void TabuSearch::performChange(ushort source, uint newTargetIndex) {
     }
 }
 
-void TabuSearch::performSwap(ushort source1, ushort source2) {
-    ushort target1 = A[source1], target2 = A[source2];
+void TabuSearch::performSwap(uint source1, uint source2) {
+    uint target1 = A[source1], target2 = A[source2];
 
     int newAligEdges = -1; //dummy initialization to shut compiler warnings
     if (needAligEdges) {
@@ -417,25 +417,25 @@ void TabuSearch::performSwap(ushort source1, ushort source2) {
     }
 }
 
-int TabuSearch::aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int TabuSearch::aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source].size(); i++) {
-        ushort neighbor = G1AdjLists[source][i];
+        uint neighbor = G1AdjLists[source][i];
         res -= G2Matrix.get(oldTarget, A[neighbor]);
         res += G2Matrix.get(newTarget, A[neighbor]);
     }
     return res;
 }
 
-int TabuSearch::aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+int TabuSearch::aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source1].size(); i++) {
-        ushort neighbor = G1AdjLists[source1][i];
+        uint neighbor = G1AdjLists[source1][i];
         res -= G2Matrix.get(target1, A[neighbor]);
         res += G2Matrix.get(target2, A[neighbor]);
     }
     for (uint i = 0; i < G1AdjLists[source2].size(); i++) {
-        ushort neighbor = G1AdjLists[source2][i];
+        uint neighbor = G1AdjLists[source2][i];
         res -= G2Matrix.get(target2, A[neighbor]);
         res += G2Matrix.get(target1, A[neighbor]);
     }
@@ -449,14 +449,14 @@ int TabuSearch::aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target
     return res;
 }
 
-int TabuSearch::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+int TabuSearch::inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     int res = 0;
     for (uint i = 0; i < G2AdjLists[oldTarget].size(); i++) {
-        ushort neighbor = G2AdjLists[oldTarget][i];
+        uint neighbor = G2AdjLists[oldTarget][i];
         res -= assignedNodesG2[neighbor];
     }
     for (uint i = 0; i < G2AdjLists[newTarget].size(); i++) {
-        ushort neighbor = G2AdjLists[newTarget][i];
+        uint neighbor = G2AdjLists[newTarget][i];
         res += assignedNodesG2[neighbor];
     }
     //address case changing between adjacent nodes:
@@ -464,21 +464,21 @@ int TabuSearch::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort 
     return res;
 }
 
-double TabuSearch::localScoreSumIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+double TabuSearch::localScoreSumIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     return sims[source][newTarget] - sims[source][oldTarget];
 }
 
-double TabuSearch::localScoreSumIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+double TabuSearch::localScoreSumIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     return sims[source1][target2] -
            sims[source1][target1] +
            sims[source2][target1] -
            sims[source2][target2];
 }
 
-double TabuSearch::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget) {
+double TabuSearch::WECIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
-        ushort neighbor = G1AdjLists[source][j];
+        uint neighbor = G1AdjLists[source][j];
         if (G2Matrix.get(oldTarget, A[neighbor])) {
             res -= wecSims[source][oldTarget];
             res -= wecSims[neighbor][A[neighbor]];
@@ -491,10 +491,10 @@ double TabuSearch::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTar
     return res;
 }
 
-double TabuSearch::WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2) {
+double TabuSearch::WECIncSwapOp(uint source1, uint source2, uint target1, uint target2) {
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
-        ushort neighbor = G1AdjLists[source1][j];
+        uint neighbor = G1AdjLists[source1][j];
         if (G2Matrix.get(target1, A[neighbor])) {
             res -= wecSims[source1][target1];
             res -= wecSims[neighbor][A[neighbor]];
@@ -505,7 +505,7 @@ double TabuSearch::WECIncSwapOp(ushort source1, ushort source2, ushort target1, 
         }
     }
     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
-        ushort neighbor = G1AdjLists[source2][j];
+        uint neighbor = G1AdjLists[source2][j];
         if (G2Matrix.get(target2, A[neighbor])) {
             res -= wecSims[source2][target2];
             res -= wecSims[neighbor][A[neighbor]];

--- a/src/methods/TabuSearch.cpp
+++ b/src/methods/TabuSearch.cpp
@@ -421,8 +421,8 @@ int TabuSearch::aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source].size(); i++) {
         uint neighbor = G1AdjLists[source][i];
-        res -= G2Matrix.get(oldTarget, A[neighbor]);
-        res += G2Matrix.get(newTarget, A[neighbor]);
+        res -= G2Matrix[oldTarget][A[neighbor]];
+        res += G2Matrix[newTarget][A[neighbor]];
     }
     return res;
 }
@@ -431,20 +431,20 @@ int TabuSearch::aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uin
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source1].size(); i++) {
         uint neighbor = G1AdjLists[source1][i];
-        res -= G2Matrix.get(target1, A[neighbor]);
-        res += G2Matrix.get(target2, A[neighbor]);
+        res -= G2Matrix[target1][A[neighbor]];
+        res += G2Matrix[target2][A[neighbor]];
     }
     for (uint i = 0; i < G1AdjLists[source2].size(); i++) {
         uint neighbor = G1AdjLists[source2][i];
-        res -= G2Matrix.get(target2, A[neighbor]);
-        res += G2Matrix.get(target1, A[neighbor]);
+        res -= G2Matrix[target2][A[neighbor]];
+        res += G2Matrix[target1][A[neighbor]];
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
     throw runtime_error("TabuSearch not implemented for weighted Graphs");
-    res += 2*(G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0); 
+    res += 2*(G1Matrix[source1][source2] > 0 and G2Matrix[target1][target2] > 0); 
 #else
-    res += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
+    res += 2*(G1Matrix[source1][source2] & G2Matrix[target1][target2]);
 #endif
     return res;
 }
@@ -460,7 +460,7 @@ int TabuSearch::inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTar
         res += assignedNodesG2[neighbor];
     }
     //address case changing between adjacent nodes:
-    res -= G2Matrix.get(oldTarget, newTarget);
+    res -= G2Matrix[oldTarget][newTarget];
     return res;
 }
 
@@ -479,11 +479,11 @@ double TabuSearch::WECIncChangeOp(uint source, uint oldTarget, uint newTarget) {
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
         uint neighbor = G1AdjLists[source][j];
-        if (G2Matrix.get(oldTarget, A[neighbor])) {
+        if (G2Matrix[oldTarget][A[neighbor]]) {
             res -= wecSims[source][oldTarget];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2Matrix.get(newTarget, A[neighbor])) {
+        if (G2Matrix[newTarget][A[neighbor]]) {
             res += wecSims[source][newTarget];
             res += wecSims[neighbor][A[neighbor]];
         }
@@ -495,22 +495,22 @@ double TabuSearch::WECIncSwapOp(uint source1, uint source2, uint target1, uint t
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
         uint neighbor = G1AdjLists[source1][j];
-        if (G2Matrix.get(target1, A[neighbor])) {
+        if (G2Matrix[target1][A[neighbor]]) {
             res -= wecSims[source1][target1];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2Matrix.get(target2, A[neighbor])) {
+        if (G2Matrix[target2][A[neighbor]]) {
             res += wecSims[source1][target2];
             res += wecSims[neighbor][A[neighbor]];
         }
     }
     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
         uint neighbor = G1AdjLists[source2][j];
-        if (G2Matrix.get(target2, A[neighbor])) {
+        if (G2Matrix[target2][A[neighbor]]) {
             res -= wecSims[source2][target2];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2Matrix.get(target1, A[neighbor])) {
+        if (G2Matrix[target1][A[neighbor]]) {
             res += wecSims[source2][target1];
             res += wecSims[neighbor][A[neighbor]];
         }
@@ -518,9 +518,9 @@ double TabuSearch::WECIncSwapOp(uint source1, uint source2, uint target1, uint t
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
     throw runtime_error("TabuSearch not implemented for weighted Graphs");
-    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) {
+    if (G1Matrix[source1][source2] > 0 and G2Matrix[target1][target2] > 0) {
 #else
-    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
+    if (G1Matrix[source1][source2] and G2Matrix[target1][target2]) {
 #endif
         res += 2*wecSims[source1][target1];
         res += 2*wecSims[source2][target2];

--- a/src/methods/TabuSearch.cpp
+++ b/src/methods/TabuSearch.cpp
@@ -37,8 +37,8 @@ TabuSearch::TabuSearch(Graph* G1, Graph* G2,
     n1 = G1->getNumNodes();
     n2 = G2->getNumNodes();
     g1Edges = G1->getNumEdges();
-    G1->getAdjMatrix(G1AdjMatrix);
-    G2->getAdjMatrix(G2AdjMatrix);
+    G1->getMatrix(G1Matrix);
+    G2->getMatrix(G2Matrix);
     G1->getAdjLists(G1AdjLists);
     G2->getAdjLists(G2AdjLists);
 
@@ -421,8 +421,8 @@ int TabuSearch::aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort new
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source].size(); i++) {
         ushort neighbor = G1AdjLists[source][i];
-        res -= G2AdjMatrix[oldTarget][A[neighbor]];
-        res += G2AdjMatrix[newTarget][A[neighbor]];
+        res -= G2Matrix.get(oldTarget, A[neighbor]);
+        res += G2Matrix.get(newTarget, A[neighbor]);
     }
     return res;
 }
@@ -431,20 +431,20 @@ int TabuSearch::aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target
     int res = 0;
     for (uint i = 0; i < G1AdjLists[source1].size(); i++) {
         ushort neighbor = G1AdjLists[source1][i];
-        res -= G2AdjMatrix[target1][A[neighbor]];
-        res += G2AdjMatrix[target2][A[neighbor]];
+        res -= G2Matrix.get(target1, A[neighbor]);
+        res += G2Matrix.get(target2, A[neighbor]);
     }
     for (uint i = 0; i < G1AdjLists[source2].size(); i++) {
         ushort neighbor = G1AdjLists[source2][i];
-        res -= G2AdjMatrix[target2][A[neighbor]];
-        res += G2AdjMatrix[target1][A[neighbor]];
+        res -= G2Matrix.get(target2, A[neighbor]);
+        res += G2Matrix.get(target1, A[neighbor]);
     }
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
     throw runtime_error("TabuSearch not implemented for weighted Graphs");
-    res += 2*(G1AdjMatrix[source1][source2] > 0 and G2AdjMatrix[target1][target2] > 0); 
+    res += 2*(G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0); 
 #else
-    res += 2*(G1AdjMatrix[source1][source2] & G2AdjMatrix[target1][target2]);
+    res += 2*(G1Matrix.get(source1, source2) & G2Matrix.get(target1, target2));
 #endif
     return res;
 }
@@ -460,7 +460,7 @@ int TabuSearch::inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort 
         res += assignedNodesG2[neighbor];
     }
     //address case changing between adjacent nodes:
-    res -= G2AdjMatrix[oldTarget][newTarget];
+    res -= G2Matrix.get(oldTarget, newTarget);
     return res;
 }
 
@@ -479,11 +479,11 @@ double TabuSearch::WECIncChangeOp(ushort source, ushort oldTarget, ushort newTar
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source].size(); j++) {
         ushort neighbor = G1AdjLists[source][j];
-        if (G2AdjMatrix[oldTarget][A[neighbor]]) {
+        if (G2Matrix.get(oldTarget, A[neighbor])) {
             res -= wecSims[source][oldTarget];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2AdjMatrix[newTarget][A[neighbor]]) {
+        if (G2Matrix.get(newTarget, A[neighbor])) {
             res += wecSims[source][newTarget];
             res += wecSims[neighbor][A[neighbor]];
         }
@@ -495,22 +495,22 @@ double TabuSearch::WECIncSwapOp(ushort source1, ushort source2, ushort target1, 
     double res = 0;
     for (uint j = 0; j < G1AdjLists[source1].size(); j++) {
         ushort neighbor = G1AdjLists[source1][j];
-        if (G2AdjMatrix[target1][A[neighbor]]) {
+        if (G2Matrix.get(target1, A[neighbor])) {
             res -= wecSims[source1][target1];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2AdjMatrix[target2][A[neighbor]]) {
+        if (G2Matrix.get(target2, A[neighbor])) {
             res += wecSims[source1][target2];
             res += wecSims[neighbor][A[neighbor]];
         }
     }
     for (uint j = 0; j < G1AdjLists[source2].size(); j++) {
         ushort neighbor = G1AdjLists[source2][j];
-        if (G2AdjMatrix[target2][A[neighbor]]) {
+        if (G2Matrix.get(target2, A[neighbor])) {
             res -= wecSims[source2][target2];
             res -= wecSims[neighbor][A[neighbor]];
         }
-        if (G2AdjMatrix[target1][A[neighbor]]) {
+        if (G2Matrix.get(target1, A[neighbor])) {
             res += wecSims[source2][target1];
             res += wecSims[neighbor][A[neighbor]];
         }
@@ -518,9 +518,9 @@ double TabuSearch::WECIncSwapOp(ushort source1, ushort source2, ushort target1, 
     //address case swapping between adjacent nodes with adjacent images:
 #ifdef WEIGHTED
     throw runtime_error("TabuSearch not implemented for weighted Graphs");
-    if (G1AdjMatrix[source1][source2] > 0 and G2AdjMatrix[target1][target2] > 0) {
+    if (G1Matrix.get(source1, source2) > 0 and G2Matrix.get(target1, target2) > 0) {
 #else
-    if (G1AdjMatrix[source1][source2] and G2AdjMatrix[target1][target2]) {
+    if (G1Matrix.get(source1, source2) and G2Matrix.get(target1, target2)) {
 #endif
         res += 2*wecSims[source1][target1];
         res += 2*wecSims[source2][target2];

--- a/src/methods/TabuSearch.hpp
+++ b/src/methods/TabuSearch.hpp
@@ -29,8 +29,8 @@ private:
     double g1Edges; //stored as double because it appears in division
     Matrix G1Matrix;
     Matrix G2Matrix;
-    vector<vector<ushort> > G1AdjLists;
-    vector<vector<ushort> > G2AdjLists;
+    vector<vector<uint> > G1AdjLists;
+    vector<vector<uint> > G2AdjLists;
 
 
     //random number generation
@@ -46,8 +46,8 @@ private:
     //data structures for the solution space search
     double changeProbability;
     vector<bool> assignedNodesG2;
-    vector<ushort> unassignedNodesG2;
-    vector<ushort> A;
+    vector<uint> unassignedNodesG2;
+    vector<uint> A;
     //initializes all the necessary datastructures for a new run
     void initDataStructures(const Alignment& startA);
 
@@ -64,30 +64,30 @@ private:
     //to evaluate EC incrementally
     bool needAligEdges;
     int aligEdges;
-    int aligEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    int aligEdgesIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    int aligEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    int aligEdgesIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
 
     //to evaluate S3 incrementally
     bool needInducedEdges;
     int inducedEdges;
-    int inducedEdgesIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
+    int inducedEdgesIncChangeOp(uint source, uint oldTarget, uint newTarget);
 
 
     //to evaluate wec incrementally
     bool needWec;
     double wecSum;
     vector<vector<float> > wecSims;
-    double WECIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    double WECIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    double WECIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    double WECIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
 
     //to evaluate local measures incrementally
     bool needLocal;
     double localScoreSum;
     vector<vector<float> > sims;
-    double localScoreSumIncChangeOp(ushort source, ushort oldTarget, ushort newTarget);
-    double localScoreSumIncSwapOp(ushort source1, ushort source2, ushort target1, ushort target2);
+    double localScoreSumIncChangeOp(uint source, uint oldTarget, uint newTarget);
+    double localScoreSumIncSwapOp(uint source1, uint source2, uint target1, uint target2);
 
 
     //other execution options
@@ -101,9 +101,9 @@ private:
     double energyInc;
     void TabuSearchIteration();
     void TabuSearchIterationMappingTabus();
-    void performChange(ushort source);
-    void performChange(ushort source, uint newTargetIndex);
-    void performSwap(ushort source1, ushort source2);
+    void performChange(uint source);
+    void performChange(uint source, uint newTargetIndex);
+    void performSwap(uint source1, uint source2);
 
     //others
     Timer timer;
@@ -111,7 +111,7 @@ private:
 
     //tabu search-specific data structures
     //best-known solution
-    vector<ushort> bestA;
+    vector<uint> bestA;
     double bestScore;
 
 
@@ -127,10 +127,10 @@ private:
     deque<uint> tabus;
     unordered_set<uint> tabusHash;
 
-    bool isTabu(ushort node);
-    void addTabu(ushort node);
-    bool isTabu(ushort node1, ushort node2);
-    void addTabu(ushort node1, ushort node2);
+    bool isTabu(uint node);
+    void addTabu(uint node);
+    bool isTabu(uint node1, uint node2);
+    void addTabu(uint node1, uint node2);
 
 
     double nScore;
@@ -139,17 +139,17 @@ private:
     void moveToBestAdmiNeighbor();
 
     bool isChangeNeighbor;
-    ushort nSource;
-    ushort nOldTarget;
-    ushort nNewTarget;
+    uint nSource;
+    uint nOldTarget;
+    uint nNewTarget;
     uint nNewTargetIndex;
     int nAligEdges;
     int nInducedEdges;
     double nLocalScoreSum;
     double nWecSum;
 
-    ushort nSource1, nSource2;
-    ushort nTarget1, nTarget2;
+    uint nSource1, nSource2;
+    uint nTarget1, nTarget2;
 
 
 

--- a/src/methods/TabuSearch.hpp
+++ b/src/methods/TabuSearch.hpp
@@ -27,13 +27,8 @@ private:
     uint n1;
     uint n2;
     double g1Edges; //stored as double because it appears in division
-#ifdef WEIGHTED
-    vector<vector<ushort> > G1AdjMatrix;
-    vector<vector<ushort> > G2AdjMatrix;
-#else
-    vector<vector<bool> > G1AdjMatrix;
-    vector<vector<bool> > G2AdjMatrix;
-#endif
+    Matrix G1Matrix;
+    Matrix G2Matrix;
     vector<vector<ushort> > G1AdjLists;
     vector<vector<ushort> > G2AdjLists;
 

--- a/src/methods/TabuSearch.hpp
+++ b/src/methods/TabuSearch.hpp
@@ -27,8 +27,8 @@ private:
     uint n1;
     uint n2;
     double g1Edges; //stored as double because it appears in division
-    Matrix G1Matrix;
-    Matrix G2Matrix;
+    Matrix<WEIGHTED_VALUE> G1Matrix;
+    Matrix<WEIGHTED_VALUE> G2Matrix;
     vector<vector<uint> > G1AdjLists;
     vector<vector<uint> > G2AdjLists;
 

--- a/src/methods/TabuSearch.hpp
+++ b/src/methods/TabuSearch.hpp
@@ -27,8 +27,8 @@ private:
     uint n1;
     uint n2;
     double g1Edges; //stored as double because it appears in division
-    Matrix<WEIGHTED_VALUE> G1Matrix;
-    Matrix<WEIGHTED_VALUE> G2Matrix;
+    Matrix<MATRIX_UNIT> G1Matrix;
+    Matrix<MATRIX_UNIT> G2Matrix;
     vector<vector<uint> > G1AdjLists;
     vector<vector<uint> > G2AdjLists;
 

--- a/src/methods/WeightedAlignmentVoter.cpp
+++ b/src/methods/WeightedAlignmentVoter.cpp
@@ -10,15 +10,15 @@ WeightedAlignmentVoter::WeightedAlignmentVoter(Graph* G1, Graph* G2, LocalMeasur
 
 }
 
-ushort WeightedAlignmentVoter::addBestPair(const vector<vector<double> >& simMatrix, vector<bool>& alreadyAlignedG1, vector<bool>& alreadyAlignedG2) {
-    int n1 = simMatrix.size();
-    int n2 = simMatrix[0].size();
-    ushort bestNodeG1 = -1;
-    ushort bestNodeG2 = -1;
+uint WeightedAlignmentVoter::addBestPair(const vector<vector<double> >& simMatrix, vector<bool>& alreadyAlignedG1, vector<bool>& alreadyAlignedG2) {
+    uint n1 = simMatrix.size();
+    uint n2 = simMatrix[0].size();
+    uint bestNodeG1 = -1;
+    uint bestNodeG2 = -1;
     double bestScore = -1;
-    for (ushort i = 0; i < n1; i++) {
+    for (uint i = 0; i < n1; i++) {
         if (not alreadyAlignedG1[i]) {
-            for (ushort j = 0; j < n2; j++) {
+            for (uint j = 0; j < n2; j++) {
                 if (not alreadyAlignedG2[j]) {
                     if (simMatrix[i][j] > bestScore) {
                         bestNodeG1 = i;
@@ -35,13 +35,13 @@ ushort WeightedAlignmentVoter::addBestPair(const vector<vector<double> >& simMat
     return bestNodeG1;
 }
 
-void WeightedAlignmentVoter::updateNeighbors(const vector<bool>& alreadyAlignedG1, const vector<bool>& alreadyAlignedG2, ushort node, const vector<vector<double> >& nodeSimMatrix, vector<vector<double> >& simMatrix) {
-    vector<vector<ushort> > adjListsG1, adjListsG2;
+void WeightedAlignmentVoter::updateNeighbors(const vector<bool>& alreadyAlignedG1, const vector<bool>& alreadyAlignedG2, uint node, const vector<vector<double> >& nodeSimMatrix, vector<vector<double> >& simMatrix) {
+    vector<vector<uint> > adjListsG1, adjListsG2;
     G1->getAdjLists(adjListsG1);
     G2->getAdjLists(adjListsG2);
-    for (ushort neighborG1 : adjListsG1[node]) {
+    for (uint neighborG1 : adjListsG1[node]) {
         if (not alreadyAlignedG1[neighborG1]) {
-            for (ushort neighborG2 : adjListsG2[A[node]]) {
+            for (uint neighborG2 : adjListsG2[A[node]]) {
                 if (not alreadyAlignedG2[neighborG2]) {
                     simMatrix[neighborG1][neighborG2] +=
                         nodeSimMatrix[neighborG1][neighborG2] +
@@ -63,11 +63,11 @@ Alignment WeightedAlignmentVoter::run() {
             simMatrix[i][j] = nodeSimMatrix[i][j];
         }
     }
-    A = vector<ushort> (n1);
+    A = vector<uint> (n1);
     vector<bool> alreadyAlignedG1(n1, false);
     vector<bool> alreadyAlignedG2(n2, false);
     for (int i = 0; i < n1; i++) {
-        ushort newNode = addBestPair(simMatrix, alreadyAlignedG1, alreadyAlignedG2);
+        uint newNode = addBestPair(simMatrix, alreadyAlignedG1, alreadyAlignedG2);
         updateNeighbors(alreadyAlignedG1, alreadyAlignedG2, newNode, nodeSimMatrix, simMatrix);
     }
     return A;

--- a/src/methods/WeightedAlignmentVoter.hpp
+++ b/src/methods/WeightedAlignmentVoter.hpp
@@ -13,9 +13,9 @@ public:
     string fileNameSuffix(const Alignment& A);
 private:
     LocalMeasure* nodeSim;
-    vector<ushort> A;
-    void updateNeighbors(const vector<bool>& alreadyAlignedG1, const vector<bool>& alreadyAlignedG2, ushort node, const vector<vector<double> >& nodeSimMatrix, vector<vector<double> >& simMatrix);
-    ushort addBestPair(const vector<vector<double> >& simMatrix, vector<bool>& alreadyAlignedG1, vector<bool>& alreadyAlignedG2);
+    vector<uint> A;
+    void updateNeighbors(const vector<bool>& alreadyAlignedG1, const vector<bool>& alreadyAlignedG2, uint node, const vector<vector<double> >& nodeSimMatrix, vector<vector<double> >& simMatrix);
+    uint addBestPair(const vector<vector<double> >& simMatrix, vector<bool>& alreadyAlignedG1, vector<bool>& alreadyAlignedG2);
 };
 
 #endif

--- a/src/methods/wrappers/GREATWrapper.cpp
+++ b/src/methods/wrappers/GREATWrapper.cpp
@@ -45,7 +45,7 @@ string GREATWrapper::generateAlignment() {
 Alignment GREATWrapper::loadAlignment(Graph* G1, Graph* G2, string fileName) {
     //TODO replace
     exit(-1);
-    vector<ushort> mapping(G1->getNumNodes(), G2->getNumNodes());
+    vector<uint> mapping(G1->getNumNodes(), G2->getNumNodes());
     return Alignment(mapping);
 }
 

--- a/src/methods/wrappers/HubAlignWrapper.cpp
+++ b/src/methods/wrappers/HubAlignWrapper.cpp
@@ -31,9 +31,9 @@ void HubAlignWrapper::generateEdgeListFile(int graphNum) {
     if (graphNum == 1) G = G1;
     else G = G2;
 
-    vector<vector<ushort> > edgeList;
+    vector<vector<uint> > edgeList;
     G->getEdgeList(edgeList);
-    unordered_map<ushort,string> names = G->getIndexToNodeNameMap();
+    unordered_map<uint,string> names = G->getIndexToNodeNameMap();
     uint m = G->getNumEdges();
     vector<vector<string> > edgeListNames(m, vector<string> (2));
     for (uint i = 0; i < m; i++) {

--- a/src/methods/wrappers/MIGRAALWrapper.cpp
+++ b/src/methods/wrappers/MIGRAALWrapper.cpp
@@ -33,9 +33,9 @@ string MIGRAALWrapper::generateAlignment() {
 
 Alignment MIGRAALWrapper::loadAlignment(Graph* G1, Graph* G2, string fileName) {
     vector<string> words = fileToStrings(fileName);
-    vector<ushort> mapping(G1->getNumNodes(), G2->getNumNodes());
-    unordered_map<string, ushort> g1nodeMap = G1->getNodeNameToIndexMap();
-    unordered_map<string, ushort> g2nodeMap = G2->getNodeNameToIndexMap();
+    vector<uint> mapping(G1->getNumNodes(), G2->getNumNodes());
+    unordered_map<string, uint> g1nodeMap = G1->getNodeNameToIndexMap();
+    unordered_map<string, uint> g2nodeMap = G2->getNodeNameToIndexMap();
 
     for (uint i = 0; i < words.size(); i+=2) {
         string node1 = words[i];

--- a/src/methods/wrappers/MagnaWrapper.cpp
+++ b/src/methods/wrappers/MagnaWrapper.cpp
@@ -31,9 +31,9 @@ string MagnaWrapper::generateAlignment() {
 
 Alignment MagnaWrapper::loadAlignment(Graph* G1, Graph* G2, string fileName) {
     vector<string> words = fileToStrings(MAGNADIR + "/" + fileName, false);
-    vector<ushort> mapping(G1->getNumNodes(), G2->getNumNodes());
-    unordered_map<string,ushort> node1Map = G1->getNodeNameToIndexMap();
-    unordered_map<string,ushort> node2Map = G2->getNodeNameToIndexMap();
+    vector<uint> mapping(G1->getNumNodes(), G2->getNumNodes());
+    unordered_map<string,uint> node1Map = G1->getNodeNameToIndexMap();
+    unordered_map<string,uint> node2Map = G2->getNodeNameToIndexMap();
 
     for (uint i = 0; i < words.size(); i+=2) {
         string node1 = words[i];

--- a/src/methods/wrappers/NETALWrapper.cpp
+++ b/src/methods/wrappers/NETALWrapper.cpp
@@ -44,7 +44,7 @@ Alignment NETALWrapper::loadAlignment(Graph* G1, Graph* G2, string fileName) {
     string word;
     int n1= G1->getNumNodes();
     int n2= G2->getNumNodes();
-    vector<ushort> mapping(n1, n2);
+    vector<uint> mapping(n1, n2);
 
     for (uint i = 0; i < lines.size(); ++i) {
         istringstream line(lines[i]);

--- a/src/modes/ParetoMode.cpp
+++ b/src/modes/ParetoMode.cpp
@@ -68,7 +68,7 @@ vector<Alignment> ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2
     cout << "Start execution of " << method->getName() << " in Pareto Mode." << endl;
     Timer T;
     T.start();
-    unordered_set<vector<unsigned short>*> *A = static_cast<SANA*>(method)->paretoRun();
+    unordered_set<vector<uint>*> *A = static_cast<SANA*>(method)->paretoRun();
     
     vector<Alignment> alignments;
     for(auto i = A->begin(); i != A->end(); i++)
@@ -79,7 +79,7 @@ vector<Alignment> ParetoMode::runParetoMode(Method *method, Graph *G1, Graph *G2
 
     // Re Index back to normal (Method #3 of locking)
 
-    // Needs to be reimplemented with unordered_set<vector<unsigned short>>*
+    // Needs to be reimplemented with unordered_set<vector<uint>>*
     
     for(unsigned int i = 0; i < alignments.size(); i++) {
         if(G1->hasNodeTypes()){
@@ -114,7 +114,7 @@ void ParetoMode::printAlignments(vector<Alignment>& alignments, const string &fi
     output.close();
 }
 
-typedef unordered_map<ushort,string> NodeIndexMap;
+typedef unordered_map<uint,string> NodeIndexMap;
 void ParetoMode::printEdgeLists(Graph* G1, Graph* G2, vector<Alignment>& alignments, const string &fileName) {
     string outputFileName = fileName;
     if(outputFileName.find(".out") != string::npos && outputFileName.rfind(".out") + 4 == outputFileName.size())

--- a/src/modes/SimilarityMode.cpp
+++ b/src/modes/SimilarityMode.cpp
@@ -45,8 +45,8 @@ void SimilarityMode::saveSimilarityMatrix(vector<vector <float> > sim, Graph &G1
             }
         break;
         case 1:
-            unordered_map<ushort,string> g1Map = G1.getIndexToNodeNameMap();
-            unordered_map<ushort,string>  g2Map = G2.getIndexToNodeNameMap();
+            unordered_map<uint,string> g1Map = G1.getIndexToNodeNameMap();
+            unordered_map<uint,string>  g2Map = G2.getIndexToNodeNameMap();
             for(uint i = 0; i < sim.size(); ++i) {
                 for(uint j = 0; j < sim[i].size(); ++j) {
                     outfile << g1Map[i] << " " << g2Map[j] << " " << sim[i][j] << endl;

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -70,7 +70,7 @@ void makeReport(const Graph& G1, Graph& G2, const Alignment& A,
       table[1][6] = to_string(M.eval("ics",A)); table[1][7] = to_string(M.eval("s3",A));
 
       for (int i = 0; i < tableRows-2; i++) {
-    const vector<ushort>& nodes = CS.getConnectedComponents()[i];
+    const vector<uint>& nodes = CS.getConnectedComponents()[i];
     Graph H = CS.nodeInducedSubgraph(nodes);
     Alignment newA(nodes);
     newA.compose(A);

--- a/src/utils/Matrix.cpp
+++ b/src/utils/Matrix.cpp
@@ -1,26 +1,3 @@
 #include "Matrix.hpp"
 
-Matrix::Matrix() {
-}
 
-Matrix::Matrix(const Matrix & matrix) {
-    data = matrix.data;
-}
-
-Matrix::Matrix(uint numberOfNodes) {
-#ifdef SPARSE
-    data = MATRIX_DATA_STRUCTURE(numberOfNodes);
-#else
-    data = MATRIX_DATA_STRUCTURE(numberOfNodes, 
-           vector<VALUE_UNIT>(numberOfNodes, VALUE_UNIT()));
-#endif        
-}
-
-Matrix & Matrix::operator = (const Matrix & matrix) {
-    data = matrix.data;
-    return *this;
-}
-
-uint Matrix::size() const {
-    return data.size();
-}

--- a/src/utils/Matrix.cpp
+++ b/src/utils/Matrix.cpp
@@ -1,0 +1,26 @@
+#include "Matrix.hpp"
+
+Matrix::Matrix() {
+}
+
+Matrix::Matrix(const Matrix & matrix) {
+    data = matrix.data;
+}
+
+Matrix::Matrix(uint numberOfNodes) {
+#ifdef SPARSE
+    data = MATRIX_DATA_STRUCTURE(numberOfNodes);
+#else
+    data = MATRIX_DATA_STRUCTURE(numberOfNodes, 
+           vector<VALUE_UNIT>(numberOfNodes, VALUE_UNIT()));
+#endif        
+}
+
+Matrix & Matrix::operator = (const Matrix & matrix) {
+    data = matrix.data;
+    return *this;
+}
+
+uint Matrix::size() const {
+    return data.size();
+}

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -14,28 +14,26 @@ using namespace std;
 #endif
     
 #ifdef SPARSE
-    #define MATRIX_DATA_STRUCTURE SparseMatrix<WEIGHTED_VALUE>
+    #define MATRIX_DATA_STRUCTURE SparseMatrix<T>
 #else
-    #define MATRIX_DATA_STRUCTURE vector<vector<WEIGHTED_VALUE> >
+    #define MATRIX_DATA_STRUCTURE vector<vector<T> >
 #endif
 
-
+template <typename T>
 class Matrix {
 public:
-
     Matrix();
     Matrix(const Matrix & matrix);
     Matrix(uint numberOfNodes);
 
     Matrix & operator = (const Matrix & matrix);
 
-
-    WEIGHTED_VALUE get(uint node1, uint node2) const;
-    void set(WEIGHTED_VALUE value, uint node1, uint node2);
+    T get(uint node1, uint node2) const;
+    void set(T value, uint node1, uint node2);
 
     uint size() const;
 
-    void connect(WEIGHTED_VALUE value, uint node1, uint node2);
+    void connect(T value, uint node1, uint node2);
     bool isConnected(uint node1, uint node2) const;
 
     template <class Archive>
@@ -53,7 +51,8 @@ private:
  * the header files.
  */
 
-inline WEIGHTED_VALUE Matrix::get(uint node1, uint node2) const {
+template <typename T>
+inline T Matrix<T>::get(uint node1, uint node2) const {
 #ifdef SPARSE
     return data.get(node1, node2);
 #else
@@ -61,7 +60,8 @@ inline WEIGHTED_VALUE Matrix::get(uint node1, uint node2) const {
 #endif
 }
 
-inline void Matrix::set(WEIGHTED_VALUE value, uint node1, uint node2) {
+template <typename T>
+inline void Matrix<T>::set(T value, uint node1, uint node2) {
 #ifdef SPARSE
     if (data.get(node1, node2) || data.get(node2, node1)) {
         return ;
@@ -75,7 +75,8 @@ inline void Matrix::set(WEIGHTED_VALUE value, uint node1, uint node2) {
 #endif
 }
 
-inline void Matrix::connect(WEIGHTED_VALUE value, uint node1, uint node2) {
+template <typename T>
+inline void Matrix<T>::connect(T value, uint node1, uint node2) {
 #ifdef SPARSE
     data.set(value, node1, node2);
     data.set(value, node2, node1);
@@ -85,11 +86,42 @@ inline void Matrix::connect(WEIGHTED_VALUE value, uint node1, uint node2) {
 #endif       
 }
 
-inline bool Matrix::isConnected(uint node1, uint node2) const {
+template <typename T>
+inline bool Matrix<T>::isConnected(uint node1, uint node2) const {
 #ifdef SPARSE
     return data.get(node1, node2) && data.get(node2, node1);
 #else
     return data[node1][node2] && data[node2][node1];
 #endif
+}
+
+template <typename T>
+Matrix<T>::Matrix() {
+}
+
+template <typename T>
+Matrix<T>::Matrix(const Matrix & matrix) {
+    data = matrix.data;
+}
+
+template <typename T>
+Matrix<T>::Matrix(uint numberOfNodes) {
+#ifdef SPARSE
+    data = MATRIX_DATA_STRUCTURE(numberOfNodes);
+#else
+    data = MATRIX_DATA_STRUCTURE(numberOfNodes, 
+           vector<T>(numberOfNodes, T()));
+#endif        
+}
+
+template <typename T>
+Matrix<T> & Matrix<T>::operator = (const Matrix & matrix) {
+    data = matrix.data;
+    return *this;
+}
+
+template <typename T>
+uint Matrix<T>::size() const {
+    return data.size();
 }
 #endif

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -8,9 +8,9 @@
 using namespace std;
 
 #ifdef WEIGHTED
-    #define WEIGHTED_VALUE ushort
+    #define MATRIX_UNIT ushort
 #else
-    #define WEIGHTED_VALUE bool
+    #define MATRIX_UNIT bool
 #endif
     
 #ifdef SPARSE

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -8,15 +8,15 @@
 using namespace std;
 
 #ifdef WEIGHTED
-    #define VALUE_UNIT ushort
+    #define WEIGHTED_VALUE ushort
 #else
-    #define VALUE_UNIT bool
+    #define WEIGHTED_VALUE bool
 #endif
     
 #ifdef SPARSE
-    #define MATRIX_DATA_STRUCTURE SparseMatrix<VALUE_UNIT>
+    #define MATRIX_DATA_STRUCTURE SparseMatrix<WEIGHTED_VALUE>
 #else
-    #define MATRIX_DATA_STRUCTURE vector<vector<VALUE_UNIT> >
+    #define MATRIX_DATA_STRUCTURE vector<vector<WEIGHTED_VALUE> >
 #endif
 
 
@@ -30,12 +30,12 @@ public:
     Matrix & operator = (const Matrix & matrix);
 
 
-    VALUE_UNIT get(uint node1, uint node2) const;
-    void set(VALUE_UNIT value, uint node1, uint node2);
+    WEIGHTED_VALUE get(uint node1, uint node2) const;
+    void set(WEIGHTED_VALUE value, uint node1, uint node2);
 
     uint size() const;
 
-    void connect(VALUE_UNIT value, uint node1, uint node2);
+    void connect(WEIGHTED_VALUE value, uint node1, uint node2);
     bool isConnected(uint node1, uint node2) const;
 
     template <class Archive>
@@ -53,7 +53,7 @@ private:
  * the header files.
  */
 
-inline VALUE_UNIT Matrix::get(uint node1, uint node2) const {
+inline WEIGHTED_VALUE Matrix::get(uint node1, uint node2) const {
 #ifdef SPARSE
     return data.get(node1, node2);
 #else
@@ -61,7 +61,7 @@ inline VALUE_UNIT Matrix::get(uint node1, uint node2) const {
 #endif
 }
 
-inline void Matrix::set(VALUE_UNIT value, uint node1, uint node2) {
+inline void Matrix::set(WEIGHTED_VALUE value, uint node1, uint node2) {
 #ifdef SPARSE
     if (data.get(node1, node2) || data.get(node2, node1)) {
         return ;
@@ -75,7 +75,7 @@ inline void Matrix::set(VALUE_UNIT value, uint node1, uint node2) {
 #endif
 }
 
-inline void Matrix::connect(VALUE_UNIT value, uint node1, uint node2) {
+inline void Matrix::connect(WEIGHTED_VALUE value, uint node1, uint node2) {
 #ifdef SPARSE
     data.set(value, node1, node2);
     data.set(value, node2, node1);

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -14,8 +14,10 @@ using namespace std;
 #endif
     
 #ifdef SPARSE
+    #define INNER_CONTAINER unordered_map<uint, T> 
     #define MATRIX_DATA_STRUCTURE SparseMatrix<T>
 #else
+    #define INNER_CONTAINER vector<T> 
     #define MATRIX_DATA_STRUCTURE vector<vector<T> >
 #endif
 
@@ -25,8 +27,9 @@ public:
     Matrix();
     Matrix(const Matrix & matrix);
     Matrix(uint numberOfNodes);
-
+    Matrix(uint row, uint col);
     Matrix & operator = (const Matrix & matrix);
+    INNER_CONTAINER & operator [] (uint node1);
 
     T get(uint node1, uint node2) const;
     void set(T value, uint node1, uint node2);
@@ -50,6 +53,23 @@ private:
  * fail the speed test. And these inline functions must be defined in 
  * the header files.
  */
+
+
+template <typename T>
+inline INNER_CONTAINER & Matrix<T>::operator [] (uint node1) {
+    return data[node1];
+}
+
+
+template <typename T>
+Matrix<T>::Matrix(uint row, uint col) {
+#ifdef SPARSE
+    data = MATRIX_DATA_STRUCTURE(row);
+#else
+    data = MATRIX_DATA_STRUCTURE(row, 
+           vector<T>(col, T()));
+#endif
+}
 
 template <typename T>
 inline T Matrix<T>::get(uint node1, uint node2) const {

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -28,16 +28,12 @@ public:
     Matrix(const Matrix & matrix);
     Matrix(uint numberOfNodes);
     Matrix(uint row, uint col);
+
     Matrix & operator = (const Matrix & matrix);
     INNER_CONTAINER & operator [] (uint node1);
 
-    T get(uint node1, uint node2) const;
-    void set(T value, uint node1, uint node2);
-
+    const T get(uint node1, uint node2) const;
     uint size() const;
-
-    void connect(T value, uint node1, uint node2);
-    bool isConnected(uint node1, uint node2) const;
 
     template <class Archive>
     void serialize(Archive & archive) {
@@ -48,18 +44,11 @@ private:
    MATRIX_DATA_STRUCTURE data;
 };
 
-/*
- * The inline prefix is a must (mostly for get), otherwise it will 
- * fail the speed test. And these inline functions must be defined in 
- * the header files.
- */
-
 
 template <typename T>
 inline INNER_CONTAINER & Matrix<T>::operator [] (uint node1) {
     return data[node1];
 }
-
 
 template <typename T>
 Matrix<T>::Matrix(uint row, uint col) {
@@ -72,46 +61,11 @@ Matrix<T>::Matrix(uint row, uint col) {
 }
 
 template <typename T>
-inline T Matrix<T>::get(uint node1, uint node2) const {
+inline const T Matrix<T>::get(uint node1, uint node2) const {
 #ifdef SPARSE
     return data.get(node1, node2);
 #else
     return data[node1][node2];
-#endif
-}
-
-template <typename T>
-inline void Matrix<T>::set(T value, uint node1, uint node2) {
-#ifdef SPARSE
-    if (data.get(node1, node2) || data.get(node2, node1)) {
-        return ;
-    }
-    data.set(value, node1, node2);
-#else
-    if (data[node1][node2] || data[node2][node1]) {
-        return ;
-    }
-    data[node1][node2] = value;
-#endif
-}
-
-template <typename T>
-inline void Matrix<T>::connect(T value, uint node1, uint node2) {
-#ifdef SPARSE
-    data.set(value, node1, node2);
-    data.set(value, node2, node1);
-#else
-    data[node1][node2] = value;
-    data[node2][node1] = value;
-#endif       
-}
-
-template <typename T>
-inline bool Matrix<T>::isConnected(uint node1, uint node2) const {
-#ifdef SPARSE
-    return data.get(node1, node2) && data.get(node2, node1);
-#else
-    return data[node1][node2] && data[node2][node1];
 #endif
 }
 

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -1,0 +1,95 @@
+#ifndef MATRIX_HPP
+#define MATRIX_HPP
+
+#include "utils.hpp"
+#include "SparseMatrix.hpp"
+#include <vector>
+
+using namespace std;
+
+#ifdef WEIGHTED
+    #define VALUE_UNIT ushort
+#else
+    #define VALUE_UNIT bool
+#endif
+    
+#ifdef SPARSE
+    #define MATRIX_DATA_STRUCTURE SparseMatrix<VALUE_UNIT>
+#else
+    #define MATRIX_DATA_STRUCTURE vector<vector<VALUE_UNIT> >
+#endif
+
+
+class Matrix {
+public:
+
+    Matrix();
+    Matrix(const Matrix & matrix);
+    Matrix(uint numberOfNodes);
+
+    Matrix & operator = (const Matrix & matrix);
+
+
+    VALUE_UNIT get(uint node1, uint node2) const;
+    void set(VALUE_UNIT value, uint node1, uint node2);
+
+    uint size() const;
+
+    void connect(VALUE_UNIT value, uint node1, uint node2);
+    bool isConnected(uint node1, uint node2) const;
+
+    template <class Archive>
+    void serialize(Archive & archive) {
+        archive(CEREAL_NVP(data));
+    }
+
+private:
+   MATRIX_DATA_STRUCTURE data;
+};
+
+/*
+ * The inline prefix is a must (mostly for get), otherwise it will 
+ * fail the speed test. And these inline functions must be defined in 
+ * the header files.
+ */
+
+inline VALUE_UNIT Matrix::get(uint node1, uint node2) const {
+#ifdef SPARSE
+    return data.get(node1, node2);
+#else
+    return data[node1][node2];
+#endif
+}
+
+inline void Matrix::set(VALUE_UNIT value, uint node1, uint node2) {
+#ifdef SPARSE
+    if (data.get(node1, node2) || data.get(node2, node1)) {
+        return ;
+    }
+    data.set(value, node1, node2);
+#else
+    if (data[node1][node2] || data[node2][node1]) {
+        return ;
+    }
+    data[node1][node2] = value;
+#endif
+}
+
+inline void Matrix::connect(VALUE_UNIT value, uint node1, uint node2) {
+#ifdef SPARSE
+    data.set(value, node1, node2);
+    data.set(value, node2, node1);
+#else
+    data[node1][node2] = value;
+    data[node2][node1] = value;
+#endif       
+}
+
+inline bool Matrix::isConnected(uint node1, uint node2) const {
+#ifdef SPARSE
+    return data.get(node1, node2) && data.get(node2, node1);
+#else
+    return data[node1][node2] && data[node2][node1];
+#endif
+}
+#endif

--- a/src/utils/ParetoFront.hpp
+++ b/src/utils/ParetoFront.hpp
@@ -18,7 +18,7 @@ struct greaterThan {
         bool operator()(const double &a, const double &b) { return a > b; }
 };
 
-typedef vector<unsigned short>* alignmentPtr;
+typedef vector<uint>* alignmentPtr;
 typedef pair<multimap<double, alignmentPtr, greaterThan>::iterator, multimap<double, alignmentPtr, greaterThan>::iterator> multiValueIterator;
 typedef multimap<double, alignmentPtr, greaterThan>::iterator singleValueIterator;
 

--- a/src/utils/SeedMatrix.cpp
+++ b/src/utils/SeedMatrix.cpp
@@ -1,6 +1,6 @@
 #include "SeedMatrix.hpp"
 
-SeedMatrix::SeedMatrix(MeasureCombination * MC, double delta, bool isMaxHeap, std::unordered_set<ushort> & lex, std::unordered_set<ushort> & rex) :
+SeedMatrix::SeedMatrix(MeasureCombination * MC, double delta, bool isMaxHeap, std::unordered_set<uint> & lex, std::unordered_set<uint> & rex) :
   delta(delta), isMaxHeap(isMaxHeap),
   left_exclude(lex), right_exclude(rex)
 {
@@ -15,9 +15,9 @@ SeedMatrix::~SeedMatrix(){
 void SeedMatrix::init_column_vector(){
   std::cout << "init column vector" << std::endl;
   column_vector.reserve(sims.size());
-  for(ushort i = 0; i < sims.size(); ++i){
+  for(uint i = 0; i < sims.size(); ++i){
     float max = -1;
-    for(ushort j = 0; j < sims[i].size(); ++j){
+    for(uint j = 0; j < sims[i].size(); ++j){
       if(sims[i][j] > max){
     max = sims[i][j];
       }
@@ -44,7 +44,7 @@ void SeedMatrix::init_column_vector(){
   //this->debug();
 }
 
-std::pair<ushort,ushort> SeedMatrix::pop_uniform(){
+std::pair<uint,uint> SeedMatrix::pop_uniform(){
   if(column_vector.size() <= 0){
     return std::make_pair(0,0);
     //throw QueueEmptyException();
@@ -123,14 +123,14 @@ uint SeedMatrix::bin_search(vector<node_t> & vec, float val, uint i, uint j){
   return 0;
 }
 
-vector<node_t> * SeedMatrix::create_node(ushort node_num){
+vector<node_t> * SeedMatrix::create_node(uint node_num){
   std::cout << "create node " << node_num << std::endl;
   vector<float> & sim_row = sims[node_num];
   std::cout << "row size" << sim_row.size() << std::endl;
   vector<node_t> * out = new vector<node_t>();
   out->reserve(sim_row.size());
   std::cout << "out vector created" << std::endl;
-  for(ushort j = 0; j < sim_row.size(); ++j){
+  for(uint j = 0; j < sim_row.size(); ++j){
     node_t curr = {sim_row[j], j};
     //std::cout << "node " << j << curr.sim << std::endl;
     out->push_back(curr);

--- a/src/utils/SeedMatrix.hpp
+++ b/src/utils/SeedMatrix.hpp
@@ -19,7 +19,7 @@ using namespace std;
 class node_t {
 public:
   float sim;
-  ushort node;
+  uint node;
   //bool operator < (const node_t & left, const node_t & right){
   bool operator < (const node_t & right) const{
     return (this->sim < right.sim);
@@ -32,7 +32,7 @@ bool operator < (const node_t & left, const node_t & right){
 */
 class seed_t {
 public:
-  ushort left_node;
+  uint left_node;
   vector<node_t> * pairs;
   float top;
   uint start;
@@ -57,9 +57,9 @@ public:
 
 class SeedMatrix{
 public:
-  SeedMatrix(MeasureCombination * MC, double delta, bool isMaxHeap, std::unordered_set<ushort> & lex, std::unordered_set<ushort> & rex);
+  SeedMatrix(MeasureCombination * MC, double delta, bool isMaxHeap, std::unordered_set<uint> & lex, std::unordered_set<uint> & rex);
   ~SeedMatrix();
-  std::pair<ushort,ushort> pop_uniform();
+  std::pair<uint,uint> pop_uniform();
   void init_column_vector(vector<vector<float> > & sims);
   //void save();
   //void load();
@@ -75,7 +75,7 @@ private:
   bool isMaxHeap;
 
   void init_column_vector();
-  vector<node_t> * create_node(ushort node_num);
+  vector<node_t> * create_node(uint node_num);
   void delete_node(seed_t & selected);
   static uint bin_search(vector<node_t> & vec, float val, uint i, uint j);
   //void delete_row(int i);
@@ -85,8 +85,8 @@ private:
   vector<seed_t> column_vector;
 
   std::mt19937 rng;
-  std::unordered_set<ushort> & left_exclude;
-  std::unordered_set<ushort> & right_exclude;
+  std::unordered_set<uint> & left_exclude;
+  std::unordered_set<uint> & right_exclude;
 
 };
 

--- a/src/utils/SkipList.cpp
+++ b/src/utils/SkipList.cpp
@@ -11,7 +11,7 @@ SkipNode::SkipNode(){
   }
 }
 
-SkipNode::SkipNode(int h, float k, std::pair<ushort,ushort> v)
+SkipNode::SkipNode(int h, float k, std::pair<uint,uint> v)
   :height(h), key(k), value(v){
   for(int i = 0; i < MAX_LEVEL; ++i){
     forward[i] = NULL;
@@ -49,7 +49,7 @@ void SkipNode::debug(int limit){
   }
 }
 
-SkipList::SkipList(float delta, bool setMaxHeap, std::unordered_set<ushort> & lex, std::unordered_set<ushort> & rex)
+SkipList::SkipList(float delta, bool setMaxHeap, std::unordered_set<uint> & lex, std::unordered_set<uint> & rex)
   :_isMaxHeap(setMaxHeap), length(0), level(0), delta(delta + EPSILON),
    left_exclude(lex), right_exclude(rex)
 {
@@ -84,7 +84,7 @@ int SkipList::random_height(void){
   return (level<SkipNode::MAX_LEVEL) ? level : SkipNode::MAX_LEVEL;
 }
 
-void SkipList::insert(float similarity, std::pair<ushort,ushort> entry){
+void SkipList::insert(float similarity, std::pair<uint,uint> entry){
   auto start = std::chrono::steady_clock::now();
   similarity = _isMaxHeap ? (1 - similarity) : similarity;
     
@@ -190,9 +190,9 @@ uint SkipList::random_int(uint n){
  * this function cannot be recursive due to stack overflow 
  * for seeds > 2300
  */
-std::pair<ushort,ushort> SkipList::pop_reservoir(){
+std::pair<uint,uint> SkipList::pop_reservoir(){
   auto start = std::chrono::steady_clock::now();
-  std::pair<ushort,ushort> result;
+  std::pair<uint,uint> result;
   uint miss_counter = 0;
 
   if(this->empty()){
@@ -238,7 +238,7 @@ std::pair<ushort,ushort> SkipList::pop_reservoir(){
   return result;
 
 /*
-  std::pair<ushort,ushort> result;
+  std::pair<uint,uint> result;
   uint miss_counter = 0;
   do{
     if(this->empty()){
@@ -275,9 +275,9 @@ std::pair<ushort,ushort> SkipList::pop_reservoir(){
 */
 }
 
-std::pair<ushort,ushort> SkipList::pop_distr(){
+std::pair<uint,uint> SkipList::pop_distr(){
   std::cout << "pop distr" << this->length << std::endl;
-  std::pair<ushort,ushort> result;
+  std::pair<uint,uint> result;
   SkipNode * curr;
   SkipNode * choice = this->head.forward[0];
   do{
@@ -504,7 +504,7 @@ bool SkipList::deserialize(std::string fname){
     std::cout << "no file found" << std::endl;
     return false;
   }
-  ushort height = 1, n1 = 0, n2 = 0;
+  uint height = 1, n1 = 0, n2 = 0;
   float sim = 1;
   
   file >> this->length;
@@ -512,7 +512,7 @@ bool SkipList::deserialize(std::string fname){
   while(file >> sim >> n1 >> n2 >> height){
     //std::cout << "node" << sim << "\t" << n1 << " " << n2 << " " << height << std::endl; 
     SkipNode * curr = new SkipNode(height, sim, std::make_pair(n1, n2));
-    for(int i = 0; i < height; ++i){
+    for(uint i = 0; i < height; ++i){
       update[i]->forward[i] = curr;
       update[i] = curr;
     }
@@ -535,7 +535,7 @@ void SkipList::test(){
     //std::cout << "list contents " << std::endl;
     //list.head.debug(16);
     std::cout << "testing pop_uniform()" << std::endl;
-    std::pair<ushort,ushort> result1 = list.pop_uniform();
+    std::pair<uint,uint> result1 = list.pop_uniform();
     std::cout << "result is (" << result1.first << ", " << result1.second << ")" << std::endl;
     
     std::cout << "List should be empty " << list.empty() << std::endl;
@@ -613,7 +613,7 @@ void SkipList::test(){
     std::cout << "testing pop_uniform()" << std::endl;
     while(!list.empty()){
     //list.debug();
-    std::pair<ushort,ushort> result1 = list.pop_uniform();
+    std::pair<uint,uint> result1 = list.pop_uniform();
     std::cout << "(" << result1.first << ", " << result1.second << ")" << std::endl;
     }
     std::cout << "List should be empty " << list.empty() << std::endl;

--- a/src/utils/SkipList.hpp
+++ b/src/utils/SkipList.hpp
@@ -24,12 +24,12 @@ class SkipNode{
 public:
   int height;
   float key;
-  std::pair<ushort,ushort> value;
+  std::pair<uint,uint> value;
 
   static constexpr int MAX_LEVEL = 16;
     
   SkipNode();
-  SkipNode(int h, float k, std::pair<ushort,ushort> v);
+  SkipNode(int h, float k, std::pair<uint,uint> v);
   ~SkipNode();
   SkipNode * forward[MAX_LEVEL];
   void debug(int limit);
@@ -38,14 +38,14 @@ public:
 class SkipList{
 public:
   SkipList(float delta, bool setMaxHeap,
-       std::unordered_set<ushort> & lex, std::unordered_set<ushort> & rex);
+       std::unordered_set<uint> & lex, std::unordered_set<uint> & rex);
   ~SkipList();
     
 
-  void insert(float similarity, std::pair<ushort,ushort> entry);
+  void insert(float similarity, std::pair<uint,uint> entry);
   bool empty();
-  std::pair<ushort,ushort> pop_reservoir();
-  std::pair<ushort,ushort> pop_distr();
+  std::pair<uint,uint> pop_reservoir();
+  std::pair<uint,uint> pop_distr();
   bool isMaxHeap();
 
   void debug();
@@ -79,8 +79,8 @@ private:
   std::chrono::milliseconds pop_time;
   uint cumulative_miss;
   uint miss_counter;
-  std::unordered_set<ushort> & left_exclude;
-  std::unordered_set<ushort> & right_exclude;
+  std::unordered_set<uint> & left_exclude;
+  std::unordered_set<uint> & right_exclude;
   std::vector<std::uniform_int_distribution<int>> uni;
 };
 

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -72,11 +72,11 @@ public:
         SparseMatrix<T> result(size());
 
         T a;
-        for (uint j = 1; j <= size(); j++){
-            for (uint k = 1; k <= m.size(); k++){
+        for (uint j = 0; j < size(); j++){
+            for (uint k = 0; k < m.size(); k++){
                 a = 0;
                 if(m.get(k, j) != 0){
-                    for (uint i = 1; i <= size(); i++) {
+                    for (uint i = 0; i < size(); i++) {
                         if(get(i, k) != 0 && m.get(k, j) != 0){
                             a += get(i, k) * m.get(k, j);
                             result.set(a, i, j);

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -1,108 +1,13 @@
 #ifndef SPARSEMATRIX_H
 #define SPARSEMATRIX_H
 
+#include <unordered_map>
 #include <vector>
 #include <assert.h>
 #include <math.h>
 #include <iostream>
 
 using namespace std;
-
-class MySet {
-public:
-    typedef unsigned int SETTYPE;
-    static const unsigned int setBits = sizeof(SETTYPE)*8;
-
-    static int SIZE(unsigned int n)
-    { return (n+setBits-1)/setBits; }   /* number of array elements needed to store n bits */
-
-    MySet() {
-        n = 0;
-    }
-
-    MySet(unsigned int n):
-        array(SIZE(n)) {
-        this->n = n;
-    }
-
-    unsigned int size() const {
-        return n;
-    }
-
-    void init(unsigned int n) {
-        this->n = n;
-        array = vector<SETTYPE>(n);
-    }
-
-    void set(unsigned int element) {
-        assert(element < n);
-        array[element/setBits] |= (1UL << (element % setBits));
-    }
-
-    bool get(unsigned int element) const {
-        assert(element < n);
-        return array[element/setBits] & (1UL << (element % setBits)) ?
-                true : false;
-    }
-
-    template <class Archive>
-    void serialize(Archive & archive) {
-        archive(array, n);
-    }
-private:
-    unsigned int n;
-    vector<SETTYPE> array;
-};
-
-
-class SparseSet {
-public:
-    SparseSet() {
-        n = 0;
-        sqrt_n = 0;
-    }
-
-    SparseSet(unsigned long n):
-        sets(ceil(sqrt(n))) {
-        this->n = n;
-        sqrt_n = ceil(sqrt(n));
-    }
-    
-    unsigned long size() const {
-        return n;
-    }
-
-    void init(unsigned long n) {
-        sqrt_n = ceil(sqrt(n));
-        sets = vector<MySet>(sqrt_n);
-        this->n = n;
-    }
-
-    void set(unsigned long element) {
-        assert(element < n);
-        int which = element / sqrt_n;
-        if(sets[which].size() == 0) {
-            sets[which].init(sqrt_n);
-        }
-        sets[which].set(element - which * sqrt_n);
-    }
-
-    bool get(unsigned long element) const {
-        assert(element < n);
-        int which = element / sqrt_n;
-        return sets[which].size() != 0 && sets[which].get(element - which * sqrt_n);
-    }
-
-    template <class Archive>
-    void serialize(Archive & archive) {
-        archive(sets, n, sqrt_n);
-    }
-
-private:
-    unsigned long n;
-    unsigned int sqrt_n;
-    vector<MySet> sets;
-};
 
 template <typename T>
 class SparseMatrix {
@@ -125,24 +30,21 @@ public:
         return *this;
     }
 
-    T get(int node1, int node2) const {
-        if (v[node1].size() == 0) {
-            return false;
-        }
-
-        return v[node1].get(node2);
-    }
-
     unsigned long size() const {
         return n;
     }
 
-    void set(int value, int node1, int node2) {
-        if (v[node1].size() == 0) {
-            v[node1].init(n);
+    T get(unsigned long node1, unsigned long node2) const {
+        auto got = v[node1].find(node2);
+        if (got == v[node1].end()) {
+            return T();
+        } else {
+            return got->second;
         }
+    }
 
-        v[node1].set(node2);
+    void set(T value, unsigned long node1, unsigned long node2) {
+        v[node1][node2] = value;
     }
 
     template <class Archive>
@@ -166,11 +68,11 @@ public:
         SparseMatrix<T> result(size());
 
         T a;
-        for (int j = 1; j <= size(); j++){
-            for (int k = 1; k <= m.size(); k++){
+        for (unsigned long j = 1; j <= size(); j++){
+            for (unsigned long k = 1; k <= m.size(); k++){
                 a = 0;
                 if(m.get(k, j) != 0){
-                    for (int i = 1; i <= size(); i++) {
+                    for (unsigned long i = 1; i <= size(); i++) {
                         if(get(i, k) != 0 && m.get(k, j) != 0){
                             a += get(i, k) * m.get(k, j);
                             result.set(a, i, j);
@@ -184,7 +86,7 @@ public:
 
 private:
     unsigned long n;
-    vector<SparseSet> v;
+    vector<unordered_map<unsigned long, T>> v;
 };
 
 #endif

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -16,7 +16,7 @@ public:
         n = 0;
     }
 
-    SparseMatrix(unsigned long n): 
+    SparseMatrix(uint n): 
         v(n) {
         this->n = n; 
     }
@@ -30,11 +30,15 @@ public:
         return *this;
     }
 
-    unsigned long size() const {
+    unordered_map<uint, T> & operator [] (uint node1) {
+        return v[node1];
+    }
+
+    uint size() const {
         return n;
     }
 
-    T get(unsigned long node1, unsigned long node2) const {
+    T get(uint node1, uint node2) const {
         auto got = v[node1].find(node2);
         if (got == v[node1].end()) {
             return T();
@@ -43,7 +47,7 @@ public:
         }
     }
 
-    void set(T value, unsigned long node1, unsigned long node2) {
+    void set(T value, uint node1, uint node2) {
         v[node1][node2] = value;
     }
 
@@ -68,11 +72,11 @@ public:
         SparseMatrix<T> result(size());
 
         T a;
-        for (unsigned long j = 1; j <= size(); j++){
-            for (unsigned long k = 1; k <= m.size(); k++){
+        for (uint j = 1; j <= size(); j++){
+            for (uint k = 1; k <= m.size(); k++){
                 a = 0;
                 if(m.get(k, j) != 0){
-                    for (unsigned long i = 1; i <= size(); i++) {
+                    for (uint i = 1; i <= size(); i++) {
                         if(get(i, k) != 0 && m.get(k, j) != 0){
                             a += get(i, k) * m.get(k, j);
                             result.set(a, i, j);
@@ -85,8 +89,8 @@ public:
     }
 
 private:
-    unsigned long n;
-    vector<unordered_map<unsigned long, T>> v;
+    uint n;
+    vector<unordered_map<uint, T>> v;
 };
 
 #endif

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -45,8 +45,7 @@ public:
                 true : false;
     }
 
-
-		template <class Archive>
+    template <class Archive>
     void serialize(Archive & archive) {
         archive(array, n);
     }

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -1,0 +1,183 @@
+#ifndef SPARSEMATRIX_H
+#define SPARSEMATRIX_H
+
+#include <vector>
+#include <assert.h>
+#include <math.h>
+#include <iostream>
+
+using namespace std;
+
+class MySet {
+public:
+    typedef unsigned int SETTYPE;
+    static const unsigned int setBits = sizeof(SETTYPE)*8;
+
+    static int SIZE(unsigned int n)
+    { return (n+setBits-1)/setBits; }   /* number of array elements needed to store n bits */
+
+    MySet() {
+        n = 0;
+    }
+
+    MySet(unsigned int n):
+        array(SIZE(n)) {
+        this->n = n;
+    }
+
+    unsigned int size() const {
+        return n;
+    }
+
+    void init(unsigned int n) {
+        this->n = n;
+        array = vector<SETTYPE>(n);
+    }
+
+    void set(unsigned int element) {
+        assert(element < n);
+        array[element/setBits] |= (1UL << (element % setBits));
+    }
+
+    bool get(unsigned int element) const {
+        assert(element < n);
+        return array[element/setBits] & (1UL << (element % setBits)) ?
+                true : false;
+    }
+
+
+		template <class Archive>
+    void serialize(Archive & archive) {
+        archive(array, n);
+    }
+private:
+    unsigned int n;
+    vector<SETTYPE> array;
+};
+
+
+class SparseSet {
+public:
+    SparseSet() {
+        n = 0;
+        sqrt_n = 0;
+    }
+
+    SparseSet(unsigned long n):
+        sets(ceil(sqrt(n))) {
+        this->n = n;
+        sqrt_n = ceil(sqrt(n));
+    }
+    
+    unsigned long size() const {
+        return n;
+    }
+
+    void init(unsigned long n) {
+        sqrt_n = ceil(sqrt(n));
+        sets = vector<MySet>(sqrt_n);
+        this->n = n;
+    }
+
+    void set(unsigned long element) {
+        assert(element < n);
+        int which = element / sqrt_n;
+        if(sets[which].size() == 0) {
+            sets[which].init(sqrt_n);
+        }
+        sets[which].set(element - which * sqrt_n);
+    }
+
+    bool get(unsigned long element) const {
+        assert(element < n);
+        int which = element / sqrt_n;
+        return sets[which].size() != 0 && sets[which].get(element - which * sqrt_n);
+    }
+
+		template <class Archive>
+    void serialize(Archive & archive) {
+        archive(sets, n, sqrt_n);
+    }
+
+private:
+    unsigned long n;
+    unsigned int sqrt_n;
+    vector<MySet> sets;
+};
+
+template <typename T>
+class SparseMatrix {
+public:
+    SparseMatrix() {
+        n = 0;
+    }
+
+    SparseMatrix(unsigned long n): 
+        v(n) {
+        this->n = n; 
+    }
+
+    SparseMatrix<T> & operator = (const SparseMatrix<T>& matrix) {
+        if (&matrix != this) {
+            n = matrix.n;
+            v = matrix.v;            
+        }
+
+        return *this;
+    }
+
+    T get(int node1, int node2) const {
+        if (v[node1].size() == 0) {
+            return false;
+        }
+
+        return v[node1].get(node2);
+    }
+
+    unsigned long size() const {
+        return n;
+    }
+
+    void set(int value, int node1, int node2) {
+        if (v[node1].size() == 0) {
+            v[node1].init(n);
+        }
+
+        v[node1].set(node2);
+    }
+
+    template <class Archive>
+    void serialize(Archive & archive) {
+        archive(v, n);
+    }
+
+    SparseMatrix<T> multiply(const SparseMatrix<T> & m) const {
+        if (size() != m.size()) {
+            throw "Cannot multiply: Left matrix column count and right matrix row count don't match.";
+        }
+
+        SparseMatrix<T> result(size());
+
+        T a;
+        for (int j = 1; j <= size(); j++){
+            for (int k = 1; k <= m.size(); k++){
+                a = 0;
+                if(m.get(k, j) != 0){
+                    for (int i = 1; i <= size(); i++) {
+                        if(get(i, k) != 0 && m.get(k, j) != 0){
+                            a += get(i, k) * m.get(k, j);
+                            result.set(a, i, j);
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+private:
+    unsigned long n;
+    vector<SparseSet> v;
+};
+
+#endif

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -149,7 +149,15 @@ public:
     void serialize(Archive & archive) {
         archive(v, n);
     }
-
+    
+   /**
+    * This function is part of the SparseMatrix library implemented by Petr Kessler
+    *
+    * Copyright (c) 2014 Petr Kessler (http://kesspess.1991.cz)
+    *
+    * @license  MIT
+    * @link     https://github.com/uestla/Sparse-Matrix
+    */
     SparseMatrix<T> multiply(const SparseMatrix<T> & m) const {
         if (size() != m.size()) {
             throw "Cannot multiply: Left matrix column count and right matrix row count don't match.";

--- a/src/utils/SparseMatrix.hpp
+++ b/src/utils/SparseMatrix.hpp
@@ -93,7 +93,7 @@ public:
         return sets[which].size() != 0 && sets[which].get(element - which * sqrt_n);
     }
 
-		template <class Archive>
+    template <class Archive>
     void serialize(Archive & archive) {
         archive(sets, n, sqrt_n);
     }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -64,7 +64,7 @@ double vectorSum(const vector<double>& v) {
     return m;
 }
 
-void randomShuffle(vector<ushort>& v) {
+void randomShuffle(vector<uint>& v) {
     random_shuffle(v.begin(), v.end(), randMod);
 }
 
@@ -73,8 +73,8 @@ void randomShuffle(vector<vector<string>>& v) {
 }
 
 //result[map[i]] = i
-vector<ushort> reverseMapping(const vector<ushort>& map, int range) {
-    vector<ushort> result(range, -1); //-1 overflows for ushort
+vector<uint> reverseMapping(const vector<uint>& map, int range) {
+    vector<uint> result(range, -1); //-1 overflows for uint
     for (uint i = 0; i < map.size(); i++) {
         result[map[i]] = i;
     }

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -27,7 +27,7 @@ double randDouble();
 int randInt(int low, int high);
 int randMod(int n);
 
-vector<ushort> reverseMapping(const vector<ushort>& map, int range);
+vector<uint> reverseMapping(const vector<uint>& map, int range);
 
 int min(int a, int b);
 int max(int a, int b);
@@ -37,7 +37,7 @@ double vectorMax(const vector<double>& v);
 double vectorMin(const vector<double>& v);
 double vectorSum(const vector<double>& v);
 
-void randomShuffle(vector<ushort>& v);
+void randomShuffle(vector<uint>& v);
 void randomShuffle(vector<vector<string>>& v);
 
 void printTable(const vector<vector<string> >& table, int colSeparation, ostream& stream);


### PR DESCRIPTION
Most ushort is changed to uint. Since the number of nodes of a graph may now be larger than what ushort can represent. 
Most matrix.get(node1, node2) is changed back to matrix[node1][node2]. But use matrix.get(node1, node2) when the matrix is specified as const.