### PR TITLE
Remove fileToStrings calls from ExternalSimMatrix and add helper for decompressing files

### DIFF
--- a/src/measures/localMeasures/ExternalSimMatrix.cpp
+++ b/src/measures/localMeasures/ExternalSimMatrix.cpp
@@ -1,4 +1,3 @@
-#include <vector>
 #include <iostream>
 #include "ExternalSimMatrix.hpp"
 #include "../../utils/utils.hpp"
@@ -14,49 +13,87 @@ ExternalSimMatrix::ExternalSimMatrix(Graph* G1, Graph* G2, string file, int form
 }
 
 void ExternalSimMatrix::initSimMatrix() {
+    FILE* fp;
+    bool isPipe = false;
+    uint fileNameLength = file.size();
     uint n1 = G1->getNumNodes();
     uint n2 = G2->getNumNodes();
     sims = vector<vector<float> > (n1, vector<float> (n2, 0));
 
-    switch(format) {
-    case 0:    loadFormat0();    break;
-    case 1:    loadFormat1();    break;
-    case 2: loadFormat2();  break;
-    default:                break;
+    checkFileExists(file);
+
+    if (fileNameLength > 3 && file.substr(fileNameLength-3,3) == ".gz") {
+        fp = decompressFile("gunzip", file);
+        isPipe = true;
+    } else if (fileNameLength > 3 && file.substr(fileNameLength-3,3) == ".xz") {
+        fp = decompressFile("xzcat", file);
+        isPipe = true;
+    } else {
+        fp = fopen(file.c_str(), "r");
     }
 
+    if (fp == NULL) {
+        throw runtime_error("ExternalSimMatrix: Error opening file");
+    }
+
+    switch(format) {
+    case 0:     loadFormat0(fp);    break;
+    case 1:     loadFormat1(fp);    break;
+    case 2: loadFormat2(fp);    break;
+    default:                    break;
+    }
+
+    if (isPipe) pclose(fp);
+    else fclose(fp);
 }
 
-void ExternalSimMatrix::loadFormat0() {
-    vector<string> words = fileToStrings(file, false);
+void ExternalSimMatrix::loadFormat0(FILE* infile) {
+    uint lineCount = 0;
+    uint i;
+    uint j;
+    float value;
 
-    for(uint i = 0; i < words.size(); i +=3) {
-        int n = atoi(words[i].c_str());
-        int m = atoi(words[i+1].c_str());
-        sims[n][m] = stod(words[i+2]);
-     }
+    while (fscanf(infile, "%ud %ud %f", &i, &j, &value) == 3) {
+        sims[i][j] = value;
+        ++lineCount;
+    }
+
+    if (lineCount != getNumEntries()) 
+        throw runtime_error("ExternalSimMatrix: Did not find the expected number of entries in the sim file.");
 }
 
-void ExternalSimMatrix::loadFormat1() {
+void ExternalSimMatrix::loadFormat1(FILE* infile) {
+    uint lineCount = 0;
+    char buf1[1024];
+    char buf2[1024];
+    float value;
+
     unordered_map<string,uint> g1Map = G1->getNodeNameToIndexMap();
     unordered_map<string,uint> g2Map = G2->getNodeNameToIndexMap();
-    vector<string> words = fileToStrings(file, false);
 
-    for(uint i = 0; i < words.size(); i +=3) {
-        uint n = g1Map[words[i]];
-        uint m = g2Map[words[i+1]];
-        sims[n][m] = stod(words[i+2]);
+    while (fscanf(infile, "%s %s %f", buf1, buf2, &value) == 3) {
+        uint i = g1Map[string(buf1)];
+        uint j = g2Map[string(buf2)];
+        sims[i][j] = value;
+        ++lineCount;
     }
+
+    if (lineCount != getNumEntries()) 
+        throw runtime_error("ExternalSimMatrix: Did not find the expected number of entries in the sim file.");
 }
 
-void ExternalSimMatrix::loadFormat2() {
-    vector<string> words = fileToStrings(file, false);
+void ExternalSimMatrix::loadFormat2(FILE* infile) {
+    float value;
+    uint entryCount = 0;
     for(uint i = 0; i < G1->getNumNodes(); i++){
         for(uint j = 0; j < G2->getNumNodes(); j++){
-            double sim = stod(words[i*G2->getNumNodes() + j]);
-            sims[i][j] = sim;
+            entryCount += fscanf(infile, "%f", &value);
+            sims[i][j] = value;  
         }
     }
+
+    if ((fscanf(infile, "%f", &value) != EOF) || entryCount != getNumEntries())
+        throw runtime_error("ExternalSimMatrix: Did not find the expected number of entries in the sim file.");
 }
 
 ExternalSimMatrix::~ExternalSimMatrix() {

--- a/src/measures/localMeasures/ExternalSimMatrix.hpp
+++ b/src/measures/localMeasures/ExternalSimMatrix.hpp
@@ -1,5 +1,6 @@
 #ifndef EXTERNALSIMMATRIX_HPP
 #define EXTERNALSIMMATRIX_HPP
+#include <cstdio>
 #include "LocalMeasure.hpp"
 
 class ExternalSimMatrix: public LocalMeasure {
@@ -8,9 +9,10 @@ public:
     virtual ~ExternalSimMatrix();
 private:
     void initSimMatrix();
-    void loadFormat0();
-    void loadFormat1();
-    void loadFormat2();
+    void loadFormat0(FILE* infile);
+    void loadFormat1(FILE* infile);
+    void loadFormat2(FILE* infile);
+    uint getNumEntries() const { return  sims.size() * sims[0].size(); }
     string file;
     int format;
 };

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -164,16 +164,12 @@ vector<string> fileToStrings(const string& fileName, bool asLines) {
     uint fileNameLen = fileName.size();
     FILE *fp;
     char buf[10240], pipe = 0;
-    if(fileNameLen>=3 && fileName.substr(fileNameLen-3,3) == ".gz"){
-    pipe=1;
-    cerr << "fileToStrings: decompressing using gunzip: " << fileName << endl;
-    string unzip_cmd = "gunzip < " + fileName;
-    fp = popen(unzip_cmd.c_str(), "r");
-    } else if(fileNameLen>=3 && fileName.substr(fileNameLen-3,3) == ".xz"){
-    pipe=1;
-    cerr << "fileToStrings: decompressing using xzcat: " << fileName << endl;
-    string unzip_cmd = "xzcat < " + fileName;
-    fp = popen(unzip_cmd.c_str(), "r");
+    if (fileNameLen>=3 && fileName.substr(fileNameLen-3,3) == ".gz"){
+        fp = decompressFile("gunzip", fileName);
+        pipe=1;
+    } else if (fileNameLen>=3 && fileName.substr(fileNameLen-3,3) == ".xz"){
+        fp = decompressFile("xzcat", fileName);
+        pipe=1;
     } else fp=fopen(fileName.c_str(),"r");
     vector<string> result;
     if(asLines) {
@@ -185,6 +181,15 @@ vector<string> fileToStrings(const string& fileName, bool asLines) {
     if(pipe) pclose(fp);
     else fclose(fp);
     return result;
+}
+
+FILE* decompressFile(const string& decompProg, const string& fileName) {
+    stringstream stream;
+    string command;
+    cerr << "decompressFile: decompressing using " << decompProg << ": " << fileName << endl;
+    stream << decompProg << " < " << fileName;
+    command = stream.str();
+    return popen(command.c_str(), "r");
 }
 
 vector<vector<string> > fileToStringsByLines(const string& fileName) {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -46,6 +46,8 @@ const string currentDateTime();
 
 void normalizeWeights(vector<double>& weights);
 
+FILE* decompressFile(const string& decompProg, const string& fileName);
+
 vector<string> fileToStrings(const string& fileName, bool asLines = false);
 vector<vector<string> > fileToStringsByLines(const string& fileName);
 void memExactFileParseByLine(vector<vector<string> >& result, const string& fileName);


### PR DESCRIPTION
Replaced calls of "fileToStrings" from ExternalSimMatrix initMatrix with code to parse the file. Created helper function for decompressing files. Added a little more error checking for ExternalSimMatrix than was previously implemented.

Here are the massif.out files for running SANA on MMusculus18 and HSapiens18: [before](https://github.com/waynebhayes/SANA/files/2903539/sana_orig.massif.out.txt), [after](https://github.com/waynebhayes/SANA/files/2903540/sana_mod.massif.out.txt).
