### PR TITLE
changed sigint handler so the current alignment can be saved without stopping SANA

### DIFF
--- a/src/arguments/methodSelector.cpp
+++ b/src/arguments/methodSelector.cpp
@@ -111,6 +111,8 @@ Method* initSANA(Graph& G1, Graph& G2, ArgumentParser& args, MeasureCombination&
 #else
     sana = new SANA(&G1, &G2, TInitial, TDecay, time, args.bools["-usingIterations"], args.bools["-add-hill-climbing"], &M, args.strings["-combinedScoreAs"]);
 #endif
+    ((SANA*) sana)->setOutputFilenames(args.strings["-o"], args.strings["-localScoresFile"]);
+
     // t_initial "auto" defaults to by-linear-regression
     if (args.strings["-tinitial"] == "by-linear-regression") {
         Timer T;

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -84,6 +84,9 @@ public:
     double searchTDecay(double TInitial, double minutes);
     double searchTDecay(double TInitial, uint iterations);
     double getTInitial(void), getTFinal(void), getTDecay(void);
+    
+    //set the file names passed in args in case we want to store the alignment on the fly
+    void setOutputFilenames(string outputFileName, string localMeasuresFileName);
 
 private:
     int maxTriangles = 0;
@@ -357,6 +360,9 @@ private:
     //others
     Timer timer;
     void setInterruptSignal(); //allows the execution to be paused with Control+C
+    void printReport(); //print out reports from inside SANA
+    string outputFileName = "sana";
+    string localScoresFileName = "sana";
 
     // Used to support locking
     Alignment getStartingAlignment();

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -346,14 +346,24 @@ void writeDataToFile(const vector<vector<string> >& data, string fileName, bool 
     }
     outfile.close();
 }
-
+//exit, save alignment and exit, save alignment and continue
 bool interrupt;
+bool saveAlignment;
 void sigIntHandler(int s) {
-    interrupt = true;
-    cerr << "Save alignment? (y/n)" << endl << ">> ";
-    char c;
-    cin >> c;
-    if (c != 'y' and c != 'Y') exit(0);
+    int c;
+    do {
+        cerr << "Select an option (1 - 3):\n  (1) Exit\n  (2) Save Alignment and Exit\n  (3) Save Alignment and Continue\n>> ";
+        cin >> c;
+        if(c == 1)
+            exit(0);
+        else if(c == 2)
+            interrupt = true;
+        else if(c == 3)
+            saveAlignment = true;
+    } while(c < 1 || c > 3);
+    
+    
+    
 }
 
 uint factorial(uint n) {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -79,6 +79,7 @@ void deleteFile(string name);
 void writeDataToFile(const vector<vector<string> >& data, string fileName, bool useTabs = false);
 
 extern bool interrupt;
+extern bool saveAlignment;
 void sigIntHandler(int s);
 
 uint factorial(uint n);


### PR DESCRIPTION
In the past, when using CTRL+C on SANA, you would be provided with the following options:
```
Save alignment? (y/n)
>>
```
In this pull request, I have modified this behavior so that the user has the following options: exit, exit and save the alignment, or save the alignment and continue SANA.

```
Select an option (1 - 3):
  (1) Exit
  (2) Save Alignment and Exit
  (3) Save Alignment and Continue
>>
```
The first two options behave identically to the previous implementation. The third option, save alignment and continue, is what I have implemented. When that option is chosen, the current alignment and local scores will be stored in the files specified by the argument parser appended by a timestamp. For example, `foo_2019-05-31_05:25:28.align` or `bar_2019-05-31_05:25:28.out`