### PR TITLE
moved coreScore code out of SANA to measures/CoreScore file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ MEASURES_SRCS = 							\
 	src/measures/WeightedEdgeConservation.cpp 			\
 	src/measures/JaccardSimilarityScore.cpp         			\
 	src/measures/MultiS3.cpp							\
+	src/measures/CoreScore.cpp						\
 	src/measures/localMeasures/EdgeCount.cpp 			\
 	src/measures/localMeasures/EdgeDensity.cpp 			\
 	src/measures/localMeasures/ExternalSimMatrix.cpp 		\

--- a/src/Report.hpp
+++ b/src/Report.hpp
@@ -6,6 +6,7 @@
 #include "Alignment.hpp"
 #include "measures/MeasureCombination.hpp"
 #include "methods/Method.hpp"
+#include "measures/CoreScore.hpp"
 
 using namespace std;
 
@@ -16,13 +17,16 @@ static void saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
     const MeasureCombination& M, const Method* method, const string& reportFileName, bool longVersion);
 static void saveLocalMeasures(const Graph& G1, const Graph& G2, const Alignment& A,
     const MeasureCombination& M, const Method* method, const string& localMeasureFile);
-static void saveCoreScores(const Graph& G1, const Graph& G2, const Alignment& A, const Method*,
-        Matrix<unsigned long>& pegHoleFreq, vector<unsigned long>& numPegSamples,
-        Matrix<double>& weightedPegHoleFreq_pBad, vector<double>& totalWeightedPegWeight_pBad,
-        Matrix<double>& weightedPegHoleFreq_1mpBad, vector<double>& totalWeightedPegWeight_1mpBad,
-        Matrix<double>& weightedPegHoleFreq_pwPBad, vector<double>& totalWeightedPegWeight_pwPBad,
-        Matrix<double>& weightedPegHoleFreq_1mpwPBad, vector<double>& totalWeightedPegWeight_1mpwPBad,
-        const string& outputFileName);
+
+/*Some pair of nodes dubbed as "core alignment" appear to have greater affinity
+  for aligning with each other as opposed to other nodes. We've tried to
+  measure this affinity across iterations by assigning scores based on
+  frequency and pBad value (SANA.cpp). This function prints the node pairs
+  along with corresponding scores in a file with .naf (network alignment
+  frequency) extension. For more detail:
+  https://github.com/waynebhayes/SANA/pull/132#issuecomment-646183330 */
+static void saveCoreScore(const Graph& G1, const Graph& G2, const Alignment& A, const Method*,
+        CoreScoreData& coreScoreData, const string& outputFileName);
 
 private:
 

--- a/src/measures/CoreScore.cpp
+++ b/src/measures/CoreScore.cpp
@@ -1,0 +1,102 @@
+#include "CoreScore.hpp"
+
+void CoreScoreData::initDataStructures(uint n1, uint n2) {
+#ifdef UNWEIGHTED_CORES
+    numPegSamples = vector<unsigned long>(n1, 0);
+    pegHoleFreq = Matrix<unsigned long>(n1, n2);
+#endif
+    weightedPegHoleFreq_pBad = Matrix<double>(n1, n2);
+    totalWeightedPegWeight_pBad = vector<double>(n1, 0);
+    weightedPegHoleFreq_1mpBad = Matrix<double>(n1, n2);
+    totalWeightedPegWeight_1mpBad = vector<double>(n1, 0);
+    weightedPegHoleFreq_pwPBad = Matrix<double>(n1, n2);
+    totalWeightedPegWeight_pwPBad = vector<double>(n1, 0);
+    weightedPegHoleFreq_1mpwPBad = Matrix<double>(n1, n2);
+    totalWeightedPegWeight_1mpwPBad = vector<double>(n1, 0);
+}
+
+
+/*The following is designed so that every single node from both networks
+  is printed at least once. First, we find for every single node (across
+  BOTH networks) what it's *highest* score is with a partner in the other
+  network. Once we compute every node's highest score, we then go and find
+  the smallest such score, and call it Smin. This defines the minimum score
+  that we want to output, and it guarantees that every node appears in at
+  least one aligned node-pair according to this score.  We output this Smin. */
+double CoreScoreData::trimCoreScore(Matrix<unsigned long>& Freq, vector<unsigned long>& numPegSamples) {
+    uint n1 = Freq.size(), n2 = Freq[0].size();
+    vector<double> high1(n1,0.0);
+    vector<double> high2(n2,0.0);
+    for (uint i=0; i<n1; i++) {
+        double denom =  1.0 / (double)numPegSamples[i];
+        for (uint j=0;j<n2; j++) {
+            double score = Freq[i][j] * denom;
+            if (score > high1[i]) high1[i] = score;
+            if (score > high2[j]) high2[j] = score;
+        }
+    }
+    double Smin = high1[0];
+    for (uint i=0;i<n1;i++) if (high1[i] < Smin) Smin = high1[i];
+    for (uint j=0;j<n2;j++) if (high2[j] < Smin) Smin = high2[j];
+    return Smin;
+}
+double CoreScoreData::trimCoreScore(Matrix<double>& Freq, vector<double>& totalPegWeight) {
+    uint n1 = Freq.size(), n2 = Freq[0].size();
+    vector<double> high1(n1,0.0);
+    vector<double> high2(n2,0.0);
+    for (uint i=0; i<n1; i++) {
+        double denom =  1.0 / (double)totalPegWeight[i];
+        for (uint j=0;j<n2; j++) {
+            double score = Freq[i][j] * denom;
+            if (score > high1[i]) high1[i] = score;
+            if (score > high2[j]) high2[j] = score;
+        }
+    }
+    double Smin = high1[0];
+    for (uint i=0;i<n1;i++) if (high1[i] < Smin) Smin = high1[i];
+    for (uint j=0;j<n2;j++) if (high2[j] < Smin) Smin = high2[j];
+    return Smin;
+}
+
+void CoreScoreData::incChangeOp(uint source, uint betterHole, double pBad, double meanPBad)
+{
+#ifdef UNWEIGHTED_CORES
+    numPegSamples[source]++;
+    pegHoleFreq[source][betterHole]++;
+#endif
+    totalWeightedPegWeight_pBad[source] += meanPBad;
+    weightedPegHoleFreq_pBad[source][betterHole] += meanPBad;
+    totalWeightedPegWeight_1mpBad[source] += 1-meanPBad;
+    weightedPegHoleFreq_1mpBad[source][betterHole] += 1-meanPBad;
+    totalWeightedPegWeight_pwPBad[source] += pBad;
+    weightedPegHoleFreq_pwPBad[source][betterHole] += pBad;
+    totalWeightedPegWeight_1mpwPBad[source] += 1-pBad;
+    weightedPegHoleFreq_1mpwPBad[source][betterHole] += 1-pBad;
+}
+
+void CoreScoreData::incSwapOp(uint source1, uint source2, uint betterDest1, uint betterDest2, double pBad, double meanPBad)
+{
+#ifdef UNWEIGHTED_CORES
+    numPegSamples[source1]++; numPegSamples[source2]++;
+    pegHoleFreq[source1][betterDest1]++; pegHoleFreq[source2][betterDest2]++;
+#endif
+    totalWeightedPegWeight_pBad[source1] += meanPBad;
+    weightedPegHoleFreq_pBad[source1][betterDest1] += meanPBad;
+    totalWeightedPegWeight_pBad[source2] += meanPBad;
+    weightedPegHoleFreq_pBad[source2][betterDest2] += meanPBad;
+
+    totalWeightedPegWeight_1mpBad[source1] += 1-meanPBad;
+    weightedPegHoleFreq_1mpBad[source1][betterDest1] += 1-meanPBad;
+    totalWeightedPegWeight_1mpBad[source2] += 1-meanPBad;
+    weightedPegHoleFreq_1mpBad[source2][betterDest2] += 1-meanPBad;
+    
+    totalWeightedPegWeight_pwPBad[source1] += pBad;
+    weightedPegHoleFreq_pwPBad[source1][betterDest1] += pBad;
+    totalWeightedPegWeight_pwPBad[source2] += pBad;
+    weightedPegHoleFreq_pwPBad[source2][betterDest2] += pBad;
+
+    totalWeightedPegWeight_1mpwPBad[source1] += 1-pBad;
+    weightedPegHoleFreq_1mpwPBad[source1][betterDest1] += 1-pBad;
+    totalWeightedPegWeight_1mpwPBad[source2] += 1-pBad;
+    weightedPegHoleFreq_1mpwPBad[source2][betterDest2] += 1-pBad;
+}

--- a/src/measures/CoreScore.hpp
+++ b/src/measures/CoreScore.hpp
@@ -1,0 +1,36 @@
+#ifndef CORESCORE_HPP
+#define CORESCORE_HPP
+
+#include "../utils/utils.hpp"
+#include "../utils/Matrix.hpp"
+//can this be a static constexpr SANA variable? -Nil
+#define UNWEIGHTED_CORES
+
+using namespace std;
+
+class CoreScoreData {
+    public:
+
+#ifdef UNWEIGHTED_CORES
+        Matrix<unsigned long> pegHoleFreq;
+        vector<unsigned long> numPegSamples; // number of times this node in g1 was sampled.
+#endif
+        Matrix<double> weightedPegHoleFreq_pBad; // weighted by pBad
+        vector<double> totalWeightedPegWeight_pBad;
+        Matrix<double> weightedPegHoleFreq_1mpBad; // weighted by 1-pBad
+        vector<double> totalWeightedPegWeight_1mpBad;
+        Matrix<double> weightedPegHoleFreq_pwPBad; // weighted by actual(pairwise) pBad
+        vector<double> totalWeightedPegWeight_pwPBad;
+        Matrix<double> weightedPegHoleFreq_1mpwPBad; // weighted by 1-actual pBad
+        vector<double> totalWeightedPegWeight_1mpwPBad;
+
+        void initDataStructures(uint n1, uint n2);
+
+        static double trimCoreScore(Matrix<unsigned long>& Freq, vector<unsigned long>& numPegSamples);
+        static double trimCoreScore(Matrix<double>& Freq, vector<double>& numPegSamples);
+
+        void incChangeOp(uint source, uint betterHole, double pBad, double meanPBad);
+        void incSwapOp(uint source1, uint source2, uint betterDest1, uint betterDest2, double pBad, double meanPBad);
+};
+
+#endif

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -45,7 +45,6 @@ using namespace std;
 bool SANA::saveAligAndExitOnInterruption = false;
 bool SANA::saveAligAndContOnInterruption = false;
 uint SANA::INVALID_ACTIVE_COLOR_ID;
-const double LOW_PBAD_LIMIT = 1e10;
 
 SANA::SANA(const Graph* G1, const Graph* G2,
         double TInitial, double TDecay, double maxSeconds, long long int maxIterations, bool addHillClimbing,
@@ -150,18 +149,7 @@ SANA::SANA(const Graph* G1, const Graph* G2,
     }
 
 #ifdef CORES
-#ifdef UNWEIGHTED_CORES
-    numPegSamples = vector<unsigned long>(n1, 0);
-    pegHoleFreq = Matrix<unsigned long>(n1, n2);
-#endif
-    weightedPegHoleFreq_pBad = Matrix<double>(n1, n2);
-    totalWeightedPegWeight_pBad = vector<double>(n1, 0);
-    weightedPegHoleFreq_1mpBad = Matrix<double>(n1, n2);
-    totalWeightedPegWeight_1mpBad = vector<double>(n1, 0);
-    weightedPegHoleFreq_pwPBad = Matrix<double>(n1, n2);
-    totalWeightedPegWeight_pwPBad = vector<double>(n1, 0);
-    weightedPegHoleFreq_1mpwPBad = Matrix<double>(n1, n2);
-    totalWeightedPegWeight_1mpwPBad = vector<double>(n1, 0);
+    coreScoreData.initDataStructures(n1, n2);
 #endif
 
     //other execution options
@@ -317,47 +305,6 @@ void SANA::initDataStructures() {
     timer.start();
 }
 
-/*The following is designed so that every single node from both networks
-  is printed at least once. First, we find for every single node (across
-  BOTH networks) what it's *highest* score is with a partner in the other
-  network. Once we compute every node's highest score, we then go and find
-  the smallest such score, and call it Smin. This defines the minimum score
-  that we want to output, and it guarantees that every node appears in at
-  least one aligned node-pair according to this score.  We output this Smin. */
-double SANA::TrimCoreScores(Matrix<unsigned long>& Freq, vector<unsigned long>& numPegSamples) {
-    uint n1 = Freq.size(), n2 = Freq[0].size();
-    vector<double> high1(n1,0.0);
-    vector<double> high2(n2,0.0);
-    for (uint i=0; i<n1; i++) {
-        double denom =  1.0 / (double)numPegSamples[i];
-        for (uint j=0;j<n2; j++) {
-            double score = Freq[i][j] * denom;
-            if (score > high1[i]) high1[i] = score;
-            if (score > high2[j]) high2[j] = score;
-        }
-    }
-    double Smin = high1[0];
-    for (uint i=0;i<n1;i++) if (high1[i] < Smin) Smin = high1[i];
-    for (uint j=0;j<n2;j++) if (high2[j] < Smin) Smin = high2[j];
-    return Smin;
-}
-double SANA::TrimCoreScores(Matrix<double>& Freq, vector<double>& totalPegWeight) {
-    uint n1 = Freq.size(), n2 = Freq[0].size();
-    vector<double> high1(n1,0.0);
-    vector<double> high2(n2,0.0);
-    for (uint i=0; i<n1; i++) {
-        double denom =  1.0 / (double)totalPegWeight[i];
-        for (uint j=0;j<n2; j++) {
-            double score = Freq[i][j] * denom;
-            if (score > high1[i]) high1[i] = score;
-            if (score > high2[j]) high2[j] = score;
-        }
-    }
-    double Smin = high1[0];
-    for (uint i=0;i<n1;i++) if (high1[i] < Smin) Smin = high1[i];
-    for (uint j=0;j<n2;j++) if (high2[j] < Smin) Smin = high2[j];
-    return Smin;
-}
 
 Alignment SANA::run() {
     initDataStructures();
@@ -384,11 +331,10 @@ Alignment SANA::run() {
     }
     trackProgress(iter, maxIters);
     cout<<"Performed "<<iter<<" total iterations\n";
-
     if (addHillClimbing) performHillClimbing(10000000LL); //arbitrarily chosen, probably too big.
 
 #ifdef CORES
-    Report::saveCoreScores(*G1, *G2, A, this, pegHoleFreq, numPegSamples, weightedPegHoleFreq_pBad, totalWeightedPegWeight_pBad, weightedPegHoleFreq_1mpBad, totalWeightedPegWeight_1mpBad, weightedPegHoleFreq_pwPBad, totalWeightedPegWeight_pwPBad, weightedPegHoleFreq_1mpwPBad, totalWeightedPegWeight_1mpwPBad, outputFileName);
+    Report::saveCoreScore(*G1, *G2, A, this, coreScoreData, outputFileName);
 #endif
 
     return A;
@@ -490,7 +436,7 @@ void SANA::printReportOnInterruption() {
     Report::saveReport(*G1, *G2, A, *MC, this, outFile, true);
     Report::saveLocalMeasures(*G1, *G2, A, *MC, this, localFile);
 #ifdef CORES
-    Report::saveCoreScores(*G1, *G2, A, this, pegHoleFreq, numPegSamples, weightedPegHoleFreq_pBad, totalWeightedPegWeight_pBad, weightedPegHoleFreq_1mpBad, totalWeightedPegWeight_1mpBad, weightedPegHoleFreq_pwPBad, totalWeightedPegWeight_pwPBad, weightedPegHoleFreq_1mpwPBad, totalWeightedPegWeight_1mpwPBad, outputFileName);
+    Report::saveCoreScore(*G1, *G2, A, this, coreScoreData, outputFileName);
 #endif
     cout << "Alignment saved. SANA will now continue." << endl;
 }
@@ -581,18 +527,8 @@ void SANA::performChange(uint actColId) {
 
     double meanPBad = incrementalMeanPBad(); // maybe we should use the *actual* pBad of *this* move?
     if (meanPBad <= 0 || myNan(meanPBad)) meanPBad = LOW_PBAD_LIMIT;
-#ifdef UNWEIGHTED_CORES
-    numPegSamples[source]++;
-    pegHoleFreq[source][betterHole]++;
-#endif
-    totalWeightedPegWeight_pBad[source] += meanPBad;
-    weightedPegHoleFreq_pBad[source][betterHole] += meanPBad;
-    totalWeightedPegWeight_1mpBad[source] += 1-meanPBad;
-    weightedPegHoleFreq_1mpBad[source][betterHole] += 1-meanPBad;
-    totalWeightedPegWeight_pwPBad[source] += pBad;
-    weightedPegHoleFreq_pwPBad[source][betterHole] += pBad;
-    totalWeightedPegWeight_1mpwPBad[source] += 1-pBad;
-    weightedPegHoleFreq_1mpwPBad[source][betterHole] += 1-pBad;
+
+    coreScoreData.incChangeOp(source, betterHole, pBad, meanPBad);
 #endif
 
     if (makeChange) {
@@ -680,29 +616,8 @@ void SANA::performSwap(uint actColId) {
 
         uint betterDest1 = wasBadMove ? target1 : target2;
         uint betterDest2 = wasBadMove ? target2 : target1;
-#ifdef UNWEIGHTED_CORES
-        numPegSamples[source1]++; numPegSamples[source2]++;
-        pegHoleFreq[source1][betterDest1]++; pegHoleFreq[source2][betterDest2]++;
-#endif
-        totalWeightedPegWeight_pBad[source1] += meanPBad;
-        weightedPegHoleFreq_pBad[source1][betterDest1] += meanPBad;
-        totalWeightedPegWeight_pBad[source2] += meanPBad;
-        weightedPegHoleFreq_pBad[source2][betterDest2] += meanPBad;
 
-        totalWeightedPegWeight_1mpBad[source1] += 1-meanPBad;
-        weightedPegHoleFreq_1mpBad[source1][betterDest1] += 1-meanPBad;
-        totalWeightedPegWeight_1mpBad[source2] += 1-meanPBad;
-        weightedPegHoleFreq_1mpBad[source2][betterDest2] += 1-meanPBad;
-        
-        totalWeightedPegWeight_pwPBad[source1] += pBad;
-        weightedPegHoleFreq_pwPBad[source1][betterDest1] += pBad;
-        totalWeightedPegWeight_pwPBad[source2] += pBad;
-        weightedPegHoleFreq_pwPBad[source2][betterDest2] += pBad;
-
-        totalWeightedPegWeight_1mpwPBad[source1] += 1-pBad;
-        weightedPegHoleFreq_1mpwPBad[source1][betterDest1] += 1-pBad;
-        totalWeightedPegWeight_1mpwPBad[source2] += 1-pBad;
-        weightedPegHoleFreq_1mpwPBad[source2][betterDest2] += 1-pBad;
+        coreScoreData.incSwapOp(source1, source2, betterDest1, betterDest2, pBad, meanPBad);
 #endif
 
     if (makeChange) {

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -15,11 +15,10 @@
 #include "../measures/MeasureCombination.hpp"
 #include "../utils/randomSeed.hpp"
 #include "../measures/ExternalWeightedEdgeConservation.hpp"
+#include "../measures/CoreScore.hpp"
 
 using namespace std;
 
-//can this be a static constexpr SANA variable? -Nil
-#define UNWEIGHTED_CORES
 
 class SANA: public Method {
 
@@ -45,9 +44,6 @@ public:
     double getPBad(double temp, double maxTimeInS = 1.0, int logLevel = 1); //0 for no output, 2 for verbose
     list<pair<double, double>> ipsList;
 
-    static double TrimCoreScores(Matrix<unsigned long>& Freq, vector<unsigned long>& numPegSamples);
-    static double TrimCoreScores(Matrix<double>& Freq, vector<double>& totalPegWeight);
-
 private:
     Alignment startA;
 
@@ -63,6 +59,7 @@ private:
     int numPBadsInBuffer;
     int pBadBufferIndex;
     double pBadBufferSum;
+    const double LOW_PBAD_LIMIT = 1e10;
 
     //may incorrect probabilities (even negative) if the pbads in the buffer are small enough
     //due to accumulated precision errors of adding and subtracting tiny values from pBadBufferSum
@@ -216,19 +213,9 @@ private:
     map<string, double> localScoreSumMap;
     vector<vector<float>> sims;
 
+    //to evaluate core scores    
 #ifdef CORES
-#ifdef UNWEIGHTED_CORES
-    Matrix<unsigned long> pegHoleFreq;
-    vector<unsigned long> numPegSamples; // number of times this node in g1 was sampled.
-#endif
-    Matrix<double> weightedPegHoleFreq_pBad; // weighted by pBad
-    vector<double> totalWeightedPegWeight_pBad;
-    Matrix<double> weightedPegHoleFreq_1mpBad; // weighted by 1-pBad
-    vector<double> totalWeightedPegWeight_1mpBad;
-    Matrix<double> weightedPegHoleFreq_pwPBad; // weighted by actual(pairwise) not mean pBad
-    vector<double> totalWeightedPegWeight_pwPBad;
-    Matrix<double> weightedPegHoleFreq_1mpwPBad; // weighted by 1-actual pBad
-    vector<double> totalWeightedPegWeight_1mpwPBad;
+    CoreScoreData coreScoreData;
 #endif
 
     map<string, vector<vector<float>>> localSimMatrixMap;


### PR DESCRIPTION
- Added comment in Report.hpp explaining the purpose of CoreScore code.
- Encapsulated all CoreScore data and function in the class CoreScoreData.
- Tried to move out code from SANA.cpp to measures/CoreScore.cpp.
- Corrected TrimCoreScores() to trimCoreScores(), removed circular include.
Please let me know in case of other issues, or better design ideas.
