### PR TITLE
Fixed pBad bug "Too few Samples for Linear Regression"

### DIFF
--- a/multi-pairwise.sh
+++ b/multi-pairwise.sh
@@ -285,6 +285,11 @@ if true; then # hard-coded as "true" but can be made "false" for debugging purpo
 	$CHMOD $OUTDIR
 	TRIES=`expr $TRIES + 1`
     done
+    STDOUT_PATTERN="$OUTDIR/.init/*.stdout"
+    STDOUT_FILES=( $STDOUT_PATTERN )
+    if grep -q 'Increasing number of samples for linear regression' ${STDOUT_FILES[0]} ; then
+        echo 'WARNING: temerature search interval ends computed to be identical.';
+    fi
 else
     echo 'name	tinitial	tfinal	tdecay' | tee $OUTDIR/.init/schedule.tsv
     ls "$@" | awk '{file=$0;gsub(".*/",""); gsub(".el$",""); gsub(".gw$","");printf "%s	40	1e-10	5\n",$1}' | tee -a $OUTDIR/.init/schedule.tsv

--- a/src/schedulemethods/LinearRegressionModern.hpp
+++ b/src/schedulemethods/LinearRegressionModern.hpp
@@ -9,6 +9,7 @@ public:
     LinearRegressionModern();
 
     static constexpr auto NAME = "linear-regression-modern";
+    static const int EXTRA_SAMPLES = 4;
     virtual string getName() override { return NAME; }
 
     void setTargetInitialPBad(double pBad) override; 

--- a/src/schedulemethods/LinearRegressionVintage.cpp
+++ b/src/schedulemethods/LinearRegressionVintage.cpp
@@ -33,9 +33,9 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
         pBadMap[pow(10,log_temp)] = getPBad(pow(10, log_temp));
         // cout << T_i << " temperature: " << pow(10, log_temp) << " pBad: " << pbadMap[log_temp] << " score: " << eval(*A) << endl;
     }
-    for (T_i=0; T_i <= log10NumSteps; T_i++) {
+    for (T_i=0; T_i <= log10NumSteps; T_i++){
         log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
-        if (pBadMap[pow(10, log_temp)] > targetFinalPBad)
+        if(pBadMap[pow(10,log_temp)] > targetFinalPBad)
             break;
     }
 

--- a/src/schedulemethods/LinearRegressionVintage.cpp
+++ b/src/schedulemethods/LinearRegressionVintage.cpp
@@ -42,6 +42,7 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     double binarySearchLeftEnd = log10LowTemp + (T_i-1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     double binarySearchRightEnd = log_temp;
     double mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
+    cout << "Increasing sample density near TFinal. " << " range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
     for(int j = 0; j < LinearRegressionVintage::EXTRA_SAMPLES; ++j) {
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);

--- a/src/schedulemethods/LinearRegressionVintage.cpp
+++ b/src/schedulemethods/LinearRegressionVintage.cpp
@@ -42,8 +42,7 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     double binarySearchLeftEnd = log10LowTemp + (T_i-1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     double binarySearchRightEnd = log_temp;
     double mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
-    cout << "Increasing sample density near TFinal. " << " range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
-    for(int j = 0; j < LinearRegression::minNumSamplesRequired; ++j) {
+    for(int j = 0; j < LinearRegressionVintage::EXTRA_SAMPLES; ++j) {
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);
         pBadMap[temperature] = probability;
@@ -61,7 +60,7 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     binarySearchRightEnd = log10LowTemp + (T_i+1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     cout << "Increasing sample density near TInitial. " << "range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
-    for(int j = 0; j < LinearRegression::minNumSamplesRequired; ++j){
+    for(int j = 0; j < LinearRegressionVintage::EXTRA_SAMPLES; ++j){
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);
         pBadMap[temperature] = probability;
@@ -70,14 +69,14 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
         mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     }
 
-    unsigned int min_samples = LinearRegression::minNumSamplesRequired;
-    if (pBadMap.size() < min_samples) {
+    unsigned int minSamples = LinearRegression::MIN_NUM_SAMPLES_REQUIRED;
+    // this is true when the upper and lower temperature bounds are equal, causing only one sample to be taken. This is insufficient for Linear Regression.
+    if (pBadMap.size() < minSamples) {
         cout << "Increasing number of samples for linear regression\n";
-        double current_temperature = pow(10, mid);
-        double temperatureIncrease = current_temperature;
-        double temperatureDecrease = current_temperature;
-
-        while (pBadMap.size() < min_samples) {
+        double currentTemperature = pow(10, mid);
+        double temperatureIncrease = currentTemperature;
+        double temperatureDecrease = currentTemperature;
+        while (pBadMap.size() < minSamples) {
             temperatureIncrease *= 1.1;
             temperatureDecrease *= .9;
             pBadMap[temperatureIncrease] = getPBad(temperatureIncrease);

--- a/src/schedulemethods/LinearRegressionVintage.cpp
+++ b/src/schedulemethods/LinearRegressionVintage.cpp
@@ -31,26 +31,29 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     for(T_i = 0; T_i <= log10NumSteps; T_i++){
         log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
         pBadMap[pow(10,log_temp)] = getPBad(pow(10, log_temp));
-        // cout << T_i << " temperature: " << pow(10, log_temp) << " pBad: " << pbadMap[log_temp] << " score: " << eval(*A) << endl;
+        //cout << T_i << " temperature: " << pow(10, log_temp) << " pBad: " << pbadMap[log_temp] << " score: " << eval(*A) << endl;
     }
-    for (T_i=0; T_i <= log10NumSteps; T_i++){
-        log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
-        if(pBadMap[pow(10,log_temp)] > targetFinalPBad)
+    for (T_i=0; T_i <= log10NumSteps; T_i++) {
+        log_temp = log10LowTemp + T_i * (log10HighTemp - log10LowTemp) / log10NumSteps;
+        if (pBadMap[pow(10, log_temp)] > targetFinalPBad){
             break;
+        }
     }
 
     double binarySearchLeftEnd = log10LowTemp + (T_i-1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     double binarySearchRightEnd = log_temp;
     double mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
+
     cout << "Increasing sample density near TFinal. " << " range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
-    for(int j = 0; j < 4; ++j) {
+    for(int j = 0; j < LinearRegression::minNumSamplesRequired; ++j) {
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);
         pBadMap[temperature] = probability;
-        if(probability > targetFinalPBad) binarySearchRightEnd = mid;
+        if (probability > targetFinalPBad) binarySearchRightEnd = mid;
         else binarySearchLeftEnd = mid;
         mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     }
+
     for (T_i = log10NumSteps; T_i >= 0; T_i--){
         log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
         if(pBadMap[pow(10,log_temp)] < targetInitialPBad)
@@ -61,7 +64,7 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     binarySearchRightEnd = log10LowTemp + (T_i+1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     cout << "Increasing sample density near TInitial. " << "range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
-    for(int j = 0; j < 4; ++j){
+    for(int j = 0; j < LinearRegression::minNumSamplesRequired; ++j){
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);
         pBadMap[temperature] = probability;
@@ -70,7 +73,21 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
         mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     }
 
+    unsigned int min_samples = LinearRegression::minNumSamplesRequired;
+    if (pBadMap.size() < min_samples) {
+        cout << "Increasing number of samples for linear regression\n";
+        double current_temperature = pow(10, mid);
+        double temperatureIncrease = current_temperature;
+        double temperatureDecrease = current_temperature;
 
+        while (pBadMap.size() < min_samples)
+        {
+            temperatureIncrease *= 1.1;
+            temperatureDecrease *= .9;
+            pBadMap[temperatureIncrease] = getPBad(temperatureIncrease);
+            pBadMap[temperatureDecrease] = getPBad(temperatureDecrease);
+        }
+    }
 
     LinearRegression::Model model = LinearRegression::bestFit(multimap<double, double> (pBadMap.begin(), pBadMap.end()));
     model.print();

--- a/src/schedulemethods/LinearRegressionVintage.cpp
+++ b/src/schedulemethods/LinearRegressionVintage.cpp
@@ -31,29 +31,26 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
     for(T_i = 0; T_i <= log10NumSteps; T_i++){
         log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
         pBadMap[pow(10,log_temp)] = getPBad(pow(10, log_temp));
-        //cout << T_i << " temperature: " << pow(10, log_temp) << " pBad: " << pbadMap[log_temp] << " score: " << eval(*A) << endl;
+        // cout << T_i << " temperature: " << pow(10, log_temp) << " pBad: " << pbadMap[log_temp] << " score: " << eval(*A) << endl;
     }
     for (T_i=0; T_i <= log10NumSteps; T_i++) {
-        log_temp = log10LowTemp + T_i * (log10HighTemp - log10LowTemp) / log10NumSteps;
-        if (pBadMap[pow(10, log_temp)] > targetFinalPBad){
+        log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
+        if (pBadMap[pow(10, log_temp)] > targetFinalPBad)
             break;
-        }
     }
 
     double binarySearchLeftEnd = log10LowTemp + (T_i-1)*(log10HighTemp-log10LowTemp)/log10NumSteps;
     double binarySearchRightEnd = log_temp;
     double mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
-
     cout << "Increasing sample density near TFinal. " << " range: (" << pow(10, binarySearchLeftEnd) << ", " << pow(10, binarySearchRightEnd) << ")" << endl;
     for(int j = 0; j < LinearRegression::minNumSamplesRequired; ++j) {
         double temperature = pow(10, mid);
         double probability = getPBad(temperature);
         pBadMap[temperature] = probability;
-        if (probability > targetFinalPBad) binarySearchRightEnd = mid;
+        if(probability > targetFinalPBad) binarySearchRightEnd = mid;
         else binarySearchLeftEnd = mid;
         mid = (binarySearchRightEnd + binarySearchLeftEnd) / 2;
     }
-
     for (T_i = log10NumSteps; T_i >= 0; T_i--){
         log_temp = log10LowTemp + T_i*(log10HighTemp-log10LowTemp)/log10NumSteps;
         if(pBadMap[pow(10,log_temp)] < targetInitialPBad)
@@ -80,8 +77,7 @@ void LinearRegressionVintage::computeBoth(ScheduleMethod::Resources maxRes) {
         double temperatureIncrease = current_temperature;
         double temperatureDecrease = current_temperature;
 
-        while (pBadMap.size() < min_samples)
-        {
+        while (pBadMap.size() < min_samples) {
             temperatureIncrease *= 1.1;
             temperatureDecrease *= .9;
             pBadMap[temperatureIncrease] = getPBad(temperatureIncrease);

--- a/src/utils/LinearRegression.cpp
+++ b/src/utils/LinearRegression.cpp
@@ -101,7 +101,7 @@ LinearRegression::Model LinearRegression::bestFit(const multimap<double, double>
     // bool dbg = false;
     // if(dbg)cerr<<endl<<endl<<"Searching for best 3-line L.R. model to fit tempToPBad"<<endl;
     int n = tempToPBad.size();
-    if (n <= 4) throw runtime_error("too few samples for regression");
+    if ((unsigned int)n <= LinearRegression::minNumSamplesRequired) throw runtime_error("too few samples for regression");
 
     // if(dbg)cerr<<"Using "<<n<<" samples and fitTempInLogSpace="<<fitTempInLogSpace<<endl;
     // if(dbg)cerr<<"Samples:"<<endl;

--- a/src/utils/LinearRegression.cpp
+++ b/src/utils/LinearRegression.cpp
@@ -101,7 +101,7 @@ LinearRegression::Model LinearRegression::bestFit(const multimap<double, double>
     // bool dbg = false;
     // if(dbg)cerr<<endl<<endl<<"Searching for best 3-line L.R. model to fit tempToPBad"<<endl;
     int n = tempToPBad.size();
-    if ((unsigned int)n <= LinearRegression::minNumSamplesRequired) throw runtime_error("too few samples for regression");
+    if ((unsigned int)n <= LinearRegression::MIN_NUM_SAMPLES_REQUIRED) throw runtime_error("too few samples for regression");
 
     // if(dbg)cerr<<"Using "<<n<<" samples and fitTempInLogSpace="<<fitTempInLogSpace<<endl;
     // if(dbg)cerr<<"Samples:"<<endl;

--- a/src/utils/LinearRegression.hpp
+++ b/src/utils/LinearRegression.hpp
@@ -48,6 +48,7 @@ public:
 
     static Model bestFit(const multimap<double, double>& tempToPBad,
                                 bool fitTempInLogSpace = true, bool fixLineHeights = false);
+    static unsigned int const minNumSamplesRequired = 4;
 private:
     static double rangeSum(const vector<double> &v, int index1, int index2);
     static Line linearLeastSquares(double xSum, double ySum, double xySum, double xxSum, int n);

--- a/src/utils/LinearRegression.hpp
+++ b/src/utils/LinearRegression.hpp
@@ -48,7 +48,7 @@ public:
 
     static Model bestFit(const multimap<double, double>& tempToPBad,
                                 bool fitTempInLogSpace = true, bool fixLineHeights = false);
-    static unsigned int const minNumSamplesRequired = 4;
+    static unsigned int const MIN_NUM_SAMPLES_REQUIRED = 4;
 private:
     static double rangeSum(const vector<double> &v, int index1, int index2);
     static Line linearLeastSquares(double xSum, double ySum, double xySum, double xxSum, int n);


### PR DESCRIPTION

Implementation Details
* Added a static variable to linear regression that the minimum number of samples needed.  This fixes some magic numbers.
* Before calling linear regression, if the number of samples is too small add samples in batches of 2 that are 90% and 110% of the current temperature until the sample minimum is satisfied. 