### PR TITLE
fixed importance bug

### DIFF
--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -79,7 +79,10 @@ vector<double> Importance::getImportances(const Graph& G) {
 
     uint n = G.getNumNodes();
     vector<vector<double>> edgeWeights(n, vector<double> (n, 0));
-    for (const auto& edge : *(G.getEdgeList())) edgeWeights[edge[0]][edge[1]] = 1;
+    for (const auto& edge : *(G.getEdgeList())) {
+        edgeWeights[edge[0]][edge[1]] = 1;
+        edgeWeights[edge[1]][edge[0]] = 1;
+    }
 
     vector<double> nodeWeights(n, 0);
 
@@ -109,8 +112,9 @@ vector<double> Importance::getImportances(const Graph& G) {
                 for (uint j = i+1; j < adjLists[u].size(); j++) {
                     uint v2 = adjLists[u][j];
                     double numNeighbors = adjLists[u].size();
-                    edgeWeights[v1][v2] +=
-                        uWeight/((numNeighbors*(numNeighbors-1))/2.0);
+                    double edgeWeightInc = uWeight/((numNeighbors*(numNeighbors-1))/2.0);
+                    edgeWeights[v1][v2] += edgeWeightInc;
+                    edgeWeights[v2][v1] += edgeWeightInc;
                 }
             }
         }


### PR DESCRIPTION
Hey Nil,

I'm currently a student doing research under Dr. Hayes, and I had to migrate the SANA C++ code for calculating Importance to C code in BLANT. While doing that, I found that the two implementations weren't giving the same results, and that led me to find an error in this implementation. In your code, you only set half of the edgeWeights to 1 at the beginning or increment half of them later on. This would work if edgeWeights were an upper or lower triangular matrix, but it's not, because sometimes edge[0] > edge[1] and sometimes edge[1] > edge[0], and same for v1 and v2. After making these changes in the SANA code, I was able to get consistent importance values between SANA and BLANT.

Best,
Patrick