### PR TITLE
(2021-Nov-01): Yet another variation on MS3, with fixed merge errors

### DIFF
--- a/src/arguments/SupportedArguments.cpp
+++ b/src/arguments/SupportedArguments.cpp
@@ -151,8 +151,8 @@ vector<array<string, 6>> supportedArguments = {
     { "-ee", "double", "0", "Weight of EE", "The weight of the Edge Exposure Score in the objective function. To be used when \"-objfuntype\" is \"generic\".", "1" },
     { "-ms3", "double", "0", "Weight of MS3", "The weight of the Multi Symmetric Substructer Score in the objective function. To be used when \"-objfuntype\" is \"generic\".", "1" },
     { "-ms3_type", "double", "0", "type of MS3", "some description", "0" },
-    { "-ms3_numer", "string", "default", "numerator MS3", "Chioces are: default, ra_k, la_k, la_global, ra_global", "0" },
-    { "-ms3_denom", "string", "default", "denominator MS3", "Choices are: default, rt_k, mre_k, ee_k, ee_global, rt_global", "0" },
+    { "-ms3_numer", "string", "default", "numerator MS3", "Choices are: default, ra_k, la_k, la_global, ra_global, ms3_var_num", "0" },
+    { "-ms3_denom", "string", "default", "denominator MS3", "Choices are: default, rt_k, mre_k, ee_k, ee_global, rt_global, ms3_var_dem", "0" },
     { "End Objective Function Specification and Weight. Combine with \"-objfuntype x\"", "", "banner", "", "", "0" },
     //-------------------END Objective Function Tyoe Specifications----------------------
 

--- a/src/arguments/measureSelector.cpp
+++ b/src/arguments/measureSelector.cpp
@@ -182,7 +182,9 @@ void initMeasures(MeasureCombination& M, const Graph& G1, const Graph& G2, Argum
     else if (args.strings["-ms3_numer"] == "la_global"){
         _numerator_type = MultiS3::la_global;}
     else if (args.strings["-ms3_numer"] == "ra_global"){
-        _numerator_type = MultiS3::ra_global;}
+        _numerator_type = MultiS3::ra_global; }
+    else if (args.strings["-ms3_numer"] == "ms3_var_num"){
+        _numerator_type = MultiS3::ms3_var_num; }
     else {_numerator_type = MultiS3::numer_default;}
 
     if (args.strings["-ms3_denom"] == "default"){
@@ -197,6 +199,8 @@ void initMeasures(MeasureCombination& M, const Graph& G1, const Graph& G2, Argum
         _denominator_type = MultiS3::ee_global;}
     else if (args.strings["-ms3_denom"] == "rt_global"){
         _denominator_type = MultiS3::rt_global;}
+    else if (args.strings["-ms3_denom"] == "ms3_var_dem"){
+        _denominator_type = MultiS3::ms3_var_dem; }
     else {_denominator_type = MultiS3::denom_default;}
 
     m = new MultiS3(&G1, &G2, _numerator_type, _denominator_type);

--- a/src/measures/MultiS3.cpp
+++ b/src/measures/MultiS3.cpp
@@ -7,6 +7,7 @@ uint NUM_GRAPHS;
 double MultiS3::Normalization_factor = 2;
 uint MultiS3::denom=1, MultiS3::numer=1, MultiS3::EL_k=0, MultiS3::ER_k=0, MultiS3::RA_k=0, MultiS3::RU_k=0, MultiS3::RO_k=0;
 vector<uint> MultiS3::totalInducedWeight(MAX_N2,0);
+vector<uint> MultiS3::inducedNeighborRungs(MAX_N2,0);
 MultiS3::NumeratorType MultiS3::numerator_type;
 MultiS3::DenominatorType MultiS3::denominator_type;
 double MultiS3::_type = 0;
@@ -44,6 +45,9 @@ MultiS3::MultiS3(const Graph* G1, const Graph* G2, NumeratorType _numerator_type
         case ra_global:
             cout<<"ra_global"<<endl;
             break;
+        case ms3_var_num:
+            cout<<"ms3_var_num"<<endl;
+            break;
         default:
             cout<<"default"<<endl;
     }
@@ -66,6 +70,9 @@ MultiS3::MultiS3(const Graph* G1, const Graph* G2, NumeratorType _numerator_type
         case rt_global:
             cout<<"rt_global"<<endl;
             break;
+        case ms3_var_dem:
+            cout<<"ms3_var_dem"<<endl;
+            break;
         default:
             cout<<"default"<<endl;
     }
@@ -76,6 +83,23 @@ MultiS3::MultiS3(const Graph* G1, const Graph* G2, NumeratorType _numerator_type
 }
 
 MultiS3::~MultiS3() {}
+
+void MultiS3::prefillInducedNeighborRungs(const Alignment& A) {
+    const uint n1 = G1->getNumNodes();
+    const uint n2 = G2->getNumNodes();
+    vector<uint> whichPeg(n2, n1); // element equal to n1 represents not used/aligned
+    for (uint i = 0; i < n1; ++i){
+        whichPeg[A[i]] = i; // inverse of the alignment
+    }
+    for (uint i = 0; i < n2; ++i){
+        inducedNeighborRungs[i] = 0;
+        for (uint nbr : *(G2->getAdjList(i))) {
+            if (whichPeg[nbr] != n1) {
+                inducedNeighborRungs[i] += G2->getEdgeWeight(i, nbr);
+            }
+        }
+    }
+}
 
 void MultiS3::setDenom(const Alignment& A) {
     denom = 0;
@@ -222,6 +246,17 @@ uint MultiS3::computeNumer(const Alignment& A) const {
             }
         }
             break;
+        case ms3_var_num:
+        {
+            for (const auto& edge: *(G1->getEdgeList())) // for every edge in G1
+            {
+                peg1 = edge[0], peg2 = edge[1];
+                uint shadowWeight = G2->getEdgeWeight(A[peg1],A[peg2]);
+                if (shadowWeight > 0) { // if non-lonely
+                    ret += shadowWeight + 1; }  // +1 is the edge in e_i that was pruned out of G2
+            }
+        }
+            break;
         default:
         {
             for (const auto& edge: *(G1->getEdgeList()))
@@ -233,7 +268,6 @@ uint MultiS3::computeNumer(const Alignment& A) const {
         }
             break;
     }
-    
     return ret;
 #else
     return 0;
@@ -363,7 +397,19 @@ uint MultiS3::computeDenom(const Alignment& A) const {
             }
         }
             break;
-        default:
+        case ms3_var_dem:
+        {
+            assert(ret == 0);
+            ret = G1->getEdgeList()->size(); // add number of edges in e_i
+            uint n1 = G1->getNumNodes();
+            for (uint i = 0; i < n1; ++i){
+               for (uint j = i+1; j < n1; ++j){
+                   ret += G2->getEdgeWeight(A[i], A[j]);
+               }
+            }
+        }
+            break;
+            default:
         {
 #if 0	    //const uint n1 = G1->getNumNodes();
 	    if (not degreesInit) initDegrees(A, *G1, *G2);
@@ -398,11 +444,15 @@ double MultiS3::eval(const Alignment& A) {
 
 //    if (_type==1) denom = EdgeExposure::numExposedEdges(A, *G1, *G2);
 //    else if (_type==0) setDenom(A);
-    denom = computeDenom(A);
-    uint correctNumer = computeNumer(A);
-    if(correctNumer != numer) {
-        cerr<<"inc eval MS3numer wrong: should be "<<correctNumer<<" but is "<<numer<<endl;
+    int correctDenom = computeDenom(A);
+    int correctNumer = computeNumer(A);
+    if(correctNumer != ((int)numer)) {
+        cerr<<"inc eval MS3 numer wrong: should be "<<correctNumer<<" but is "<<numer << ". Difference " << correctNumer - ((int)numer) << endl;
         numer = correctNumer;
+    }
+    if(correctDenom != ((int)denom)) {
+        cerr<<"inc eval MS3 denom wrong: should be "<<correctDenom<<" but is "<<denom<< ". Difference " << correctDenom - ((int)denom) << endl;
+        denom = correctDenom;
     }
     return ((double) numer) / denom / Normalization_factor;//NUM_GRAPHS;
 #else

--- a/src/measures/MultiS3.hpp
+++ b/src/measures/MultiS3.hpp
@@ -13,8 +13,8 @@ static const uint MAX_N2=100000;
 
 class MultiS3 : public Measure {
 public:
-    enum NumeratorType{numer_default, ra_k, la_k, la_global, ra_global};
-    enum DenominatorType{denom_default, rt_k, mre_k, ee_k, ee_global, rt_global};
+    enum NumeratorType{numer_default, ra_k, la_k, la_global, ra_global, ms3_var_num};
+    enum DenominatorType{denom_default, rt_k, mre_k, ee_k, ee_global, rt_global, ms3_var_dem};
     static NumeratorType numerator_type;
     static DenominatorType denominator_type;
 
@@ -28,12 +28,14 @@ public:
     uint computeNumer(const Alignment& A) const;
     uint computeDenom(const Alignment& A) const;
     void getNormalizationFactor() const;
+    void prefillInducedNeighborRungs(const Alignment& A);
 
     //these don't belong here, they should be members in SANA -Nil
     // WH: Not sure I agree, these are MS3 specific... OTOH measure *values* are associated with a specific alignment,
     // and putting these in *either* SANA:: or here breaks when there are multiple Alignment instances.
     static uint numer, denom, ER_k, EL_k, RA_k, RU_k, RO_k; // computed from scratch; compare to incremental values in SANA.cpp
     static vector<uint> totalInducedWeight; // total weight of shadow node induced only on the aligned edges of G1.
+    static vector<uint> inducedNeighborRungs;
     static double Normalization_factor;
     static double _type; //0 default ; 1 ee
 

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -1357,7 +1357,6 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
       int res = 0;
 #if MULTI_PAIRWISE || MULTI_MPI
       uint pegNeigh, holeNeigh, diff;
-      int res = 0;
       switch (MultiS3::numerator_type){
           case MultiS3::ra_k:
           {

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -49,7 +49,6 @@ using namespace std;
 bool SANA::saveAligAndExitOnInterruption = false;
 bool SANA::saveAligAndContOnInterruption = false;
 uint SANA::INVALID_ACTIVE_COLOR_ID;
-
 SANA::SANA(const Graph* G1, const Graph* G2,
         double TInitial, double TDecay, double maxSeconds, long long int maxIterations, bool addHillClimbing,
         MeasureCombination* MC, const string& scoreAggrStr, const Alignment& startA,
@@ -282,6 +281,7 @@ void SANA::initDataStructures() {
     if (needMS3) {
         MultiS3::numer = ((MultiS3*) MC->getMeasure("ms3"))->computeNumer(alig);
         MultiS3::denom = ((MultiS3*) MC->getMeasure("ms3"))->computeDenom(alig);
+        //((MultiS3*) MC->getMeasure("ms3"))->prefillInducedNeighborRungs(alig.asVector());
 	EL_k = MultiS3::EL_k;
 	ER_k = MultiS3::ER_k;
 	RU_k = MultiS3::RU_k;
@@ -597,6 +597,7 @@ void SANA::performChange(uint actColId) {
 }
 
 void SANA::performSwap(uint actColId) {
+
     uint peg1 = randomG1NodeWithActiveColor(actColId);
     
     uint peg2;
@@ -1108,6 +1109,28 @@ int SANA::exposedEdgesIncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
     return res;
 }
 
+int SANA::MS3VariantHelper(const uint peg, const uint hole, bool departs){
+    int res = 0;
+    uint s = hole; // shadow node that u is departing
+    if (departs)
+        assert(hole == A[peg]);
+    else
+        assert(hole != A[peg]);
+    vector<uint> whichPeg(n2, n1); // value of n1 represents not used
+    uint numNeigh = G1->adjLists[peg].size();
+    int factor = departs? -1 : 1;
+    for (uint i = 0; i < numNeigh; ++i){ // for all of u's neighbor
+        uint v = G1->adjLists[peg][i];
+        int W = G2->getEdgeWeight(s,A[v]); // get edge weight of edge between s and u's neighbor's shadow node
+        if (W>0) {
+            res += (factor * (W+1)); // subtract this weight from numerator
+            // +1 because it is non lonely
+            //MultiS3::inducedNeighborRungs[A[v]] += (factor * W); //update total induced weight
+        }
+    }
+    return res;
+}
+
 // Return the change in NUMERATOR of MS3
 int SANA::MS3IncChangeOp(uint peg, uint oldHole, uint newHole) {
     int res = 0;
@@ -1180,7 +1203,13 @@ int SANA::MS3IncChangeOp(uint peg, uint oldHole, uint newHole) {
             }
         }
 	break;
-            
+	    case MultiS3::ms3_var_num:
+	    {
+            res += MS3VariantHelper(peg, oldHole, true);
+            res += MS3VariantHelper(peg, newHole, false);
+	    }
+    break;
+
         default:
         {
             //unsigned oldoldHoleDeg = MultiS3::shadowDegree[oldHole];
@@ -1266,6 +1295,24 @@ int SANA::MS3IncChangeOp(uint peg, uint oldHole, uint newHole) {
             }
         }
 	break;
+	    case MultiS3::ms3_var_dem:
+	    {
+            int oldEdgeWeights = 0;
+            for ( uint nbr : *(G2->getAdjList(oldHole))) {
+                if (whichPeg[nbr] != n1){
+                    oldEdgeWeights += G2->getEdgeWeight(oldHole, nbr);
+                }
+            }
+            int newEdgeWeights = 0;
+            for ( uint nbr : *(G2->getAdjList(newHole))) {
+                if (whichPeg[nbr] != n1 and nbr != oldHole) {
+                    newEdgeWeights += G2->getEdgeWeight(newHole, nbr);
+                }
+            }
+            MultiS3::denom -= oldEdgeWeights;
+            MultiS3::denom += newEdgeWeights;
+        }
+    break;
             
         default:
 	{
@@ -1310,6 +1357,7 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
       int res = 0;
 #if MULTI_PAIRWISE || MULTI_MPI
       uint pegNeigh, holeNeigh, diff;
+      int res = 0;
       switch (MultiS3::numerator_type){
           case MultiS3::ra_k:
           {
@@ -1463,6 +1511,35 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
               return res;
           }
               break;
+          case MultiS3::ms3_var_num:
+          {
+              assert(res == 0);
+              for (uint nbr : G1->adjLists[peg1]){
+                  if (nbr == peg2) {continue;} // if edge between peg1 and peg2 ignore so we don't double count
+                  int old_shadow_weight = G2->getEdgeWeight(A[peg1],A[nbr]);
+                  int new_shadow_weight = G2->getEdgeWeight(hole2,A[nbr]);
+
+                  if (old_shadow_weight > 0) {
+                      res -= old_shadow_weight + 1;
+                  }
+                  if (new_shadow_weight > 0) {
+                      res += new_shadow_weight + 1;
+                  }
+              }
+              for (uint nbr : G1->adjLists[peg2]){
+                  if (nbr == peg1) {continue;} // if edge between peg1 and peg2 ignore so we don't double count
+                  int old_shadow_weight = G2->getEdgeWeight(A[peg2],A[nbr]);
+                  int new_shadow_weight = G2->getEdgeWeight(hole1, A[nbr]);
+
+                  if (old_shadow_weight > 0) {
+                      res -= old_shadow_weight + 1;
+                  }
+                  if (new_shadow_weight > 0) {
+                      res += new_shadow_weight + 1;
+                  }
+              }
+          }
+          break;
           default:
           {
               //uint oldhole1Deg = MultiS3::shadowDegree[hole1];
@@ -1581,6 +1658,10 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
               }
         }
             break;
+        case MultiS3::ms3_var_dem: {
+            // do nothing
+        }
+        break;
 	default:
         {
 #if 0
@@ -1643,6 +1724,7 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
               }
 #endif
         }
+        break;
     }
 #endif // MULTI_PAIRWISE
     return res;

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -171,7 +171,7 @@ private:
 	RO_k; // |RO_k| where RO_k = rungs outside, ie rungs with at least one endpoint not under a peg.
     int MS3IncChangeOp(uint peg, uint oldHole, uint newHole);
     int MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2);
-
+    int MS3VariantHelper(const uint peg, const uint hole, bool departs);
     //to evaluate SEC incrementally
     bool needSec;
     double secSum;


### PR DESCRIPTION
(2021-Nov-01): Yet another variation on MS3, this one seems easier to explain: aligning G_i to the (pruned) shadow network, the score MS^3_i for G_i is 	|number of rungs under of E_i + non-lonely edges in E_i/|number of rungs induced under V_i + E_i|, aka: 	|total weight of shadow edges under E_i + non-lonely edges in E_i| / |total shadow weights induced on S_i + E_i|. We include only non-lonely edges of E_i in the numerator, but all edges in E_i in the denominator. If u\in G_i, let s=A[u] be the shadow node under u. The edge weight induced on s comes only from those edges who’s other endpoint is also aligned. Note that when we perform a swap, the denominator doesn’t change, because the set of aligned shadow nodes doesn’t change; but moving u from s->t affects both ends of all affected shadow edges because s becomes unaligned, t becomes aligned, all the neighbors of both must have their “aligned neighbor” sets updated to remove s and add t.