### PR TITLE
Preventing measure and format mismatch

### DIFF
--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -60,6 +60,7 @@ Graph::Graph(const string& graphName, const string& optionalFilePath,
     }
 
     bool uniformWeights = optionalEdgeWeights.size() == 0;
+    third_Weight_Column = uniformWeights;
     assert(uniformWeights or optionalEdgeWeights.size() == edgeList.size());
 
     adjLists.resize(numNodes);

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -100,6 +100,8 @@ public:
     double getTotalEdgeWeight() const { return totalEdgeWeight; }
     double getTotalWeight(uint node) const { return totalWeight[node]; }
     bool hasSelfLoop(uint node) const { return adjMatrix.get(node, node) != 0; }
+
+    bool get_Third_Weight_Column(){ return third_Weight_Column; }
     
     //large data structures are returned as const pointers
     //recommendation: use the getters above instead, when possible
@@ -183,6 +185,7 @@ private:
     vector<string> colorNames; //color index to color name
     unordered_map<string, uint> colorNameToId; //color name to color index
     vector<vector<uint>> nodeGroupsByColor; //color index to list of node indices
+    bool third_Weight_Column; //boolean to check if there is a third weight column or not
     
     friend class SANA; //for convenience and speed(maybe?)
 }; 

--- a/src/arguments/ArgumentParser.cpp
+++ b/src/arguments/ArgumentParser.cpp
@@ -5,6 +5,8 @@
 #include "SupportedArguments.hpp"
 using namespace std;
 
+bool erFlag;
+
 ArgumentParser::ArgumentParser(int argc, char* argv[]) {
     if(argc == 1) {
 	cout << "Usage: " << argv[0] << " [OPTION] [ARG(S)] [OPTION] [ARG(S)]..." << endl
@@ -88,6 +90,7 @@ ArgumentParser::ArgumentParser(int argc, char* argv[]) {
                 throw runtime_error("Unknown argument: "+arg+". See the README for the correct syntax");
         }
     }
+    erFlag = false;
 }
 
 void ArgumentParser::writeArguments() {
@@ -98,6 +101,11 @@ void ArgumentParser::writeArguments() {
     }
     cout << endl;
     for (auto kv : doubles) {
+        if(kv.second!=0){
+            if(kv.first=="-er"){
+                erFlag=true;
+            }
+        }
         if (kv.second != 0) cout << kv.first << ": " << kv.second << '\t';
     }
     cout << endl;

--- a/src/arguments/ArgumentParser.hpp
+++ b/src/arguments/ArgumentParser.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 using namespace std;
 
+extern bool erFlag;
+
 class ArgumentParser {
 public:
     /* initializes the arguments and stores them in the maps below

--- a/src/arguments/GraphLoader.cpp
+++ b/src/arguments/GraphLoader.cpp
@@ -12,6 +12,7 @@
 #include "../utils/Timer.hpp"
 #include "../utils/FileIO.hpp"
 #include "../Alignment.hpp"
+#include "ArgumentParser.hpp"
 
 using namespace std;
 
@@ -272,6 +273,9 @@ Graph GraphLoader::loadGraphFromFile(const string& graphName, const string& file
     string format = fileName.substr(fileName.find_last_of('.')+1);
     string uncompressedFileExt = FileIO::getUncompressedFileExtension(fileName);
 
+    if (erFlag and (format != "elw")){
+           throw runtime_error("GraphLoader does not support format '"+format+"' for the er measure");
+    }
     if (loadWeights and (format == "gml" or format == "lgf" or format == "xml" or format == "csv"))
         throw runtime_error("GraphLoader does not support weights for format '"+format+"'");
     //for dbg:

--- a/src/arguments/GraphLoader.cpp
+++ b/src/arguments/GraphLoader.cpp
@@ -12,6 +12,7 @@
 #include "../utils/Timer.hpp"
 #include "../utils/FileIO.hpp"
 #include "../Alignment.hpp"
+#include "../Graph.hpp"
 #include "ArgumentParser.hpp"
 
 using namespace std;
@@ -282,8 +283,16 @@ Graph GraphLoader::loadGraphFromFile(const string& graphName, const string& file
     //cerr<<graphName<<" "<<fileName<<" "<<loadWeights<<endl<<format<<" "<<uncompressedFileExt;
     if (format == "gw" || uncompressedFileExt == "gw")
         return loadGraphFromGWFile(graphName, fileName, loadWeights);
-    if (format == "el" || uncompressedFileExt == "el" || format == "elw" || uncompressedFileExt == "elw")
-        return loadGraphFromEdgeListFile(graphName, fileName, loadWeights);
+    if (format == "el" || uncompressedFileExt == "el" || format == "elw" || uncompressedFileExt == "elw"){
+        auto G =  loadGraphFromEdgeListFile(graphName, fileName, loadWeights);
+        //Graph g = G.get()
+        if(erFlag && format == "elw"){
+            if(G.get_Third_Weight_Column()){
+                throw runtime_error("GraphLoader does not support no weights for the er measure"); 
+            }
+        }
+        return G;
+    }
     if (format == "gml") return loadGraphFromGmlFile(graphName, fileName);
     if (format == "lgf") return loadGraphFromLgfFile(graphName, fileName);
     if (format == "xml") return loadGraphFromXmlFile(graphName, fileName);


### PR DESCRIPTION
This update addresses a bug that allows the -er measure to be used with file types other than "elw". Now, it will result in an error.  