### PR TITLE
Fix Github labeling .gml and .el files as languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.gml linguist-detectable=false
+*.el linguist-detectable=false


### PR DESCRIPTION
GitHub shows the most-used languages in a graph on the repository page.

Files with extensions .gml and .el were mapping to Game Maker Language and Emacs Lisp, which aren't languages in use.

This was fixed by adding a .gitattributes file, telling GitHub not to count those file extensions as languages.

- **Before**:
<img width="415" height="187" alt="image" src="https://github.com/user-attachments/assets/53d6f011-73d4-46a1-b107-6dd80b68b1da" />

- **After**:
<img width="423" height="168" alt="image" src="https://github.com/user-attachments/assets/36d4baa3-bf65-4d12-958b-5d0454aaac62" />
