### PR TITLE
SANA Version 2.2 WeightedMeasure Refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ ARCH_FLAGS=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-U__STRICT_
 MY_CC = g++$(GCC_VER)
 CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-fno-inline
 
-SANA_VER=2.1
+# Version 2.2: Refactored edge measures (EdgeMin, EdgeRatio, EdgeGeoMean, EdgeDifference) with WeightedMeasure base class
+SANA_VER=2.2
 MAIN = sana$(SANA_VER)
 
 #you can give these on Make's command line, eg "SPARSE=1" or "WEIGHT=1" or "MULTI=1"

--- a/src/measures/EdgeGeoMean.cpp
+++ b/src/measures/EdgeGeoMean.cpp
@@ -2,19 +2,12 @@
 #include <vector>
 
 EdgeGeoMean::EdgeGeoMean(const Graph* G1, const Graph* G2): WeightedMeasure(G1, G2, "egm") {
+    denominator = 0;
     denominator = computeDenom(G1, G2);
     std::cerr << "Computed EdgeGeoMean denominator: " << denominator << std::endl;
 }
 
 EdgeGeoMean::~EdgeGeoMean() {
-}
-
-double EdgeGeoMean::getEdgeScore(double w1, double w2) {
-    //assert(w1 > 0 && w2 > 0); // for FlyWire, edges are positive
-    double sgn = w1*w2>=0 ? 1:-1;
-    double numer = sgn * sqrt(abs(w1*w2));
-    if(denominator) return numer/denominator;
-    else return numer;
 }
 
 static bool CmpEdge(double w1, double w2) { return (w1 > w2); }
@@ -29,6 +22,14 @@ double EdgeGeoMean::computeDenom(const Graph* G1, const Graph* G2) {
     unsigned minSize = min(W1.size(), W2.size());
     for(unsigned i=0; i<minSize; i++) sum += getEdgeScore(W1[i], W2[i]);
     return sum;
+}
+
+double EdgeGeoMean::getEdgeScore(double w1, double w2) {
+    //assert(w1 > 0 && w2 > 0); // for FlyWire, edges are positive
+    double sgn = w1*w2>=0 ? 1:-1;
+    double numer = sgn * sqrt(abs(w1*w2));
+    if(denominator) return numer/denominator;
+    else return numer;
 }
 
 double EdgeGeoMean::eval(const Alignment& A) {

--- a/src/measures/EdgeMin.cpp
+++ b/src/measures/EdgeMin.cpp
@@ -4,6 +4,7 @@
 #include <array>
 
 EdgeMin::EdgeMin(const Graph* G1, const Graph* G2): WeightedMeasure(G1, G2, "emin") {
+    denominator = 0;
     denominator = computeDenom();
     std::cerr << "Computed EdgeMin denominator: " << denominator << std::endl;
 }

--- a/src/measures/EdgeRatio.cpp
+++ b/src/measures/EdgeRatio.cpp
@@ -4,6 +4,7 @@
 #include <array>
 
 EdgeRatio::EdgeRatio(const Graph* G1, const Graph* G2): WeightedMeasure(G1, G2, "er") {
+    denominator = 0;
     denominator = computeDenom();
     std::cerr << "Computed EdgeRatio denominator: " << denominator << std::endl;
 }


### PR DESCRIPTION
- Updated SANA version to 2.2
- Added denominator=0 in constructors
- Reordered functions to have the same order in measures EdgeGeoMean, EdgeMin, EdgeRatio