### PR TITLE
Optimize measure lookups and add optimization direction support

### DIFF
--- a/src/measures/EdgeDifference.cpp
+++ b/src/measures/EdgeDifference.cpp
@@ -1,39 +1,85 @@
 #include "EdgeDifference.hpp"
 #include <vector>
+#include <algorithm>
 
 EdgeDifference::EdgeDifference(const Graph* G1, const Graph* G2): WeightedMeasure(G1, G2, "ed") {
+    denominator = computeDenominator(G1, G2);
+    optimizationDirection = -1;  // Minimize towards 0 (lower is better)
 }
 
 EdgeDifference::~EdgeDifference() {
 }
 
+double EdgeDifference::computeDenominator(const Graph* G1, const Graph* G2) {
+    // Pair smallest G1 weights with largest G2 weights to find theoretical max difference
+    vector<double> weights1, weights2;
+    for (const auto& edge : *(G1->getEdgeList())) {
+        weights1.push_back(G1->getEdgeWeight(edge[0], edge[1]));
+    }
+    for (const auto& edge : *(G2->getEdgeList())) {
+        weights2.push_back(G2->getEdgeWeight(edge[0], edge[1]));
+    }
+    
+    sort(weights1.begin(), weights1.end());
+    sort(weights2.begin(), weights2.end(), greater<double>());
+    
+    // Sum differences using Kahan summation
+    double maxDiff = 0;
+    double c = 0;
+    uint n = min(weights1.size(), weights2.size());
+    for (uint i = 0; i < n; i++) {
+        double y = abs(weights1[i] - weights2[i]) - c;
+        double t = maxDiff + y;
+        c = (t - maxDiff) - y;
+        maxDiff = t;
+    }
+    
+    if (maxDiff == 0) maxDiff = 1;
+    return maxDiff;
+}
+
 double EdgeDifference::getEdgeScore(double w1, double w2) {
-    return abs(w1 - w2);
+    return abs(w1 - w2) / denominator;
 }
 
 double EdgeDifference::eval(const Alignment& A) {
-    double edgeDifferenceSum = getEdgeDifferenceSum(G1, G2, A);
-    return adjustSumToTargetScore(G1, G2, edgeDifferenceSum);
-}
-
-double EdgeDifference::getEdgeDifferenceSum(const Graph* G1, const Graph* G2, const Alignment &A) {
-    // Use Kahan summation for numerical accuracy
-    double edgeDifferenceSum = 0;
-    double c = 0;
+    double sum = 0;
+    double c = 0;  // Kahan summation
     for (const auto& edge : *(G1->getEdgeList())) {
        uint node1 = edge[0], node2 = edge[1];
        if (G2->hasEdge(A[node1], A[node2])) {
-           double y = abs(G1->getEdgeWeight(node1,node2) - G2->getEdgeWeight(A[node1],A[node2])) - c;
-           double t = edgeDifferenceSum + y;
-           c = (t - edgeDifferenceSum) - y;
-           edgeDifferenceSum = t;
+            double y = getEdgeScore(G1->getEdgeWeight(node1,node2), G2->getEdgeWeight(A[node1],A[node2])) - c;
+            double t = sum + y;
+            c = (t - sum) - y;
+            sum = t;
        }
     }
-    return edgeDifferenceSum;
+    return sum;  // Returns [0,1] where 0=perfect, 1=worst
 }
 
-double EdgeDifference::adjustSumToTargetScore(const Graph *G1, const Graph *G2, const double edgeDifferenceSum) {
-    uint m1=  G1->getNumEdges(), m2=G2->getNumEdges();
-    double mean = edgeDifferenceSum / min(m1,m2);
-    return 1 - mean / 2;
-}
+
+// ============================================================================
+// OLD CODE - Commented out for reference (backward compatibility removed)
+// ============================================================================
+
+// double EdgeDifference::getEdgeDifferenceSum(const Graph* G1, const Graph* G2, const Alignment &A) {
+//     // Use Kahan summation for numerical accuracy
+//     double edgeDifferenceSum = 0;
+//     double c = 0;
+//     for (const auto& edge : *(G1->getEdgeList())) {
+//        uint node1 = edge[0], node2 = edge[1];
+//        if (G2->hasEdge(A[node1], A[node2])) {
+//            double y = abs(G1->getEdgeWeight(node1,node2) - G2->getEdgeWeight(A[node1],A[node2])) - c;
+//            double t = edgeDifferenceSum + y;
+//            c = (t - edgeDifferenceSum) - y;
+//            edgeDifferenceSum = t;
+//        }
+//     }
+//     return edgeDifferenceSum;
+// }
+// 
+// double EdgeDifference::adjustSumToTargetScore(const Graph *G1, const Graph *G2, const double edgeDifferenceSum) {
+//     uint m1 = G1->getNumEdges(), m2 = G2->getNumEdges();
+//     double mean = edgeDifferenceSum / min(m1,m2);
+//     return 1 - mean/2;
+// }

--- a/src/measures/EdgeDifference.hpp
+++ b/src/measures/EdgeDifference.hpp
@@ -8,12 +8,10 @@ public:
     virtual ~EdgeDifference();
     double eval(const Alignment& A);
 
-    // Keep static methods for backward compatibility with existing static calls
-    static double adjustSumToTargetScore(const Graph *G1, const Graph *G2, const double edgeDifferenceSum);
-    static double getEdgeDifferenceSum(const Graph *G1, const Graph *G2, const Alignment &A);
-
 private:
     double getEdgeScore(double w1, double w2);
+    double computeDenominator(const Graph* G1, const Graph* G2);
+    double denominator; // Sum of edge weights from smaller graph
 };
 
 #endif //EDGEDIFFERENCE_HPP

--- a/src/measures/Measure.cpp
+++ b/src/measures/Measure.cpp
@@ -1,8 +1,9 @@
 #include "Measure.hpp"
 #include <string>
 
-Measure::Measure(const Graph* G1, const Graph* G2, const string& name): G1(G1), G2(G2), name(name) {};
+Measure::Measure(const Graph* G1, const Graph* G2, const string& name): G1(G1), G2(G2), name(name), optimizationDirection(1) {};
 Measure::~Measure() {}
 string Measure::getName() { return name; }
 bool Measure::isLocal() { return false; }
 double Measure::balanceWeight() { return 0; }
+int Measure::getOptimizationDirection() const { return optimizationDirection; }

--- a/src/measures/Measure.hpp
+++ b/src/measures/Measure.hpp
@@ -14,9 +14,11 @@ public:
     string getName();
     virtual bool isLocal();
     virtual double balanceWeight();
+    int getOptimizationDirection() const;
 protected:
     const Graph* G1;
     const Graph* G2;
+    int optimizationDirection; // +1 for maximize (higher is better), -1 for minimize (lower is better)
 private:
     string name;
 };

--- a/src/measures/MeasureCombination.cpp
+++ b/src/measures/MeasureCombination.cpp
@@ -14,7 +14,11 @@ double MeasureCombination::eval(const Alignment& A) const {
     uint n = measures.size();
     double total = 0;
     for (uint i = 0; i < n; i++) {
-        if (weights[i] > 0) total += measures[i]->eval(A) * weights[i];
+        if (weights[i] > 0) {
+            double score = measures[i]->eval(A);
+            // No direction multiplication - keep natural values
+            total += score * weights[i];
+        }
     }
     return total;
 }
@@ -151,6 +155,18 @@ bool MeasureCombination::containsMeasure(const string& measureName) const {
         if (m->getName() == measureName) return true;
     }
     return false;
+}
+
+int MeasureCombination::getOptimizationDirection() const {
+    // Return -1 if any measure wants to minimize, else +1 (maximize)
+    int direction = 1;
+    for (uint i = 0; i < measures.size(); i++) {
+        if (weights[i] > 0 && measures[i]->getOptimizationDirection() == -1) {
+            direction = -1;
+            break;
+        }
+    }
+    return direction;
 }
 void MeasureCombination::initn1n2(uint& n1, uint& n2) const {
     if (n1 != 0 and n2 != 0) return; //already init

--- a/src/measures/MeasureCombination.hpp
+++ b/src/measures/MeasureCombination.hpp
@@ -27,6 +27,7 @@ public:
     Measure* getMeasure(const string& measureName) const;
     Measure* getMeasure(int i) const;
     bool containsMeasure(const string& measureName) const;
+    int getOptimizationDirection() const;  // Get overall optimization direction
     void normalize();
     uint numMeasures() const;
     string toString() const;

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -304,7 +304,7 @@ void SANA::initDataStructures() {
     }
 
     if (needAligEdges or needSec) aligEdges = alig.computeNumAlignedEdges(*G1, *G2);
-    if (needEd) edSum = EdgeDifference::getEdgeDifferenceSum(G1, G2, alig);
+    if (needEd) edSum = ((EdgeDifference*) MC->getMeasure("ed"))->eval(alig);
     if (needEr) erSum = ((EdgeRatio*) MC->getMeasure("er"))->eval(alig);
     if (needEgm) egmSum = ((EdgeGeoMean*) MC->getMeasure("egm"))->eval(alig);
     if (needEmin) eminSum = ((EdgeMin*    ) MC->getMeasure("emin"))->eval(alig);
@@ -1057,7 +1057,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
     case ScoreAggregation::sum:
     {
         newCurrentScore += ecWeight?ecWeight * (newAligEdges / g1Edges):0;
-        newCurrentScore += edWeight?edWeight * EdgeDifference::adjustSumToTargetScore(G1,G2,newEdgeDifferenceSum):0;
+        newCurrentScore += edWeight?edWeight * newEdgeDifferenceSum:0;
         newCurrentScore += erWeight?erWeight * newEdgeRatioSum:0;
         newCurrentScore += egmWeight?egmWeight * newEdgeGeoMeanSum:0;
         newCurrentScore += eminWeight?eminWeight * newEdgeMinSum:0;
@@ -1084,7 +1084,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
 	if (MultiS3::denominator_type==MultiS3::ee_global) MultiS3::denom = newExposedEdgesNumer;
         newCurrentScore += ms3Weight ? ms3Weight * (double)newMS3Numer / (double)MultiS3::denom / (double)MultiS3::Normalization_factor:0;//(double)NUM_GRAPHS;
 #endif
-        energyInc = newCurrentScore - currentScore;
+        energyInc = (newCurrentScore - currentScore) * MC->getOptimizationDirection();
         wasBadMove = energyInc < 0;
         break;
     }
@@ -1107,7 +1107,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
 	    }
 	}
 
-        energyInc = newCurrentScore - currentScore;
+        energyInc = (newCurrentScore - currentScore) * MC->getOptimizationDirection();
         wasBadMove = energyInc < 0;
         break;
     }
@@ -1135,7 +1135,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
 	    }
 	}
 
-        energyInc = newCurrentScore - currentScore;
+        energyInc = (newCurrentScore - currentScore) * MC->getOptimizationDirection();
         wasBadMove = energyInc < 0;
         break;
     }
@@ -1162,7 +1162,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
 	    }
 	}
 
-        energyInc = newCurrentScore - currentScore;
+        energyInc = (newCurrentScore - currentScore) * MC->getOptimizationDirection();
         wasBadMove = energyInc < 0;
         break;
     }
@@ -1183,7 +1183,7 @@ double SANA::scoreComparison(double newAligEdges, double newInducedEdges, double
 		newCurrentScore += f_betaWeight * (((1 + (beta_value * beta_value)) * newAligEdges) / (g1Edges + (beta_value * beta_value * newInducedEdges)));
 	    }
 	}
-        energyInc = newCurrentScore - currentScore;
+        energyInc = (newCurrentScore - currentScore) * MC->getOptimizationDirection();
         wasBadMove = energyInc < 0;
         break;
     }


### PR DESCRIPTION
- Replace O(n) linear search with O(1) map lookups in MeasureCombination
- Add optimizationDirection flag to Measure base class (+1=maximize, -1=minimize)
- Refactor EdgeDifference to return normalized [0,1] score (0=perfect, 1=worst)
- Added computeDenom for edgeDifference