### PR TITLE
Optimize SA inner loop for 2-3.5x throughput improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ARCH=$(shell uname -a | awk '{if(/CYGWIN/){V="CYGWIN"}else if(/Darwin/){V="Darwi
 ARCH_FLAGS=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-U__STRICT_ANSI__"}')
 
 MY_CC = g++$(GCC_VER)
-CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-fno-inline
+CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -DNDEBUG -flto -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-fno-inline
 
 # Version 2.2: Refactored edge measures (EdgeMin, EdgeRatio, EdgeGeoMean, EdgeDifference) with WeightedMeasure base class
 SANA_VER=2.2

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -80,6 +80,38 @@ Graph::Graph(const bool directed, const string& graphName, const string& optiona
     }
     adjLists.shrink_to_fit();
     injLists.shrink_to_fit();
+
+    // Build CSR (Compressed Sparse Row) from adjacency lists.
+    // All neighbor data goes into one contiguous array, eliminating the
+    // per-node heap allocation and pointer chase of vector<vector<uint>>.
+    {
+        uint n = adjLists.size();
+        csrAdjOff_.resize(n + 1);
+        uint total = 0;
+        for (uint i = 0; i < n; i++) {
+            csrAdjOff_[i] = total;
+            total += adjLists[i].size();
+        }
+        csrAdjOff_[n] = total;
+        csrAdjData_.resize(total);
+        for (uint i = 0; i < n; i++)
+            for (uint j = 0; j < adjLists[i].size(); j++)
+                csrAdjData_[csrAdjOff_[i] + j] = adjLists[i][j];
+
+        n = injLists.size();
+        csrInjOff_.resize(n + 1);
+        total = 0;
+        for (uint i = 0; i < n; i++) {
+            csrInjOff_[i] = total;
+            total += injLists[i].size();
+        }
+        csrInjOff_[n] = total;
+        csrInjData_.resize(total);
+        for (uint i = 0; i < n; i++)
+            for (uint j = 0; j < injLists[i].size(); j++)
+                csrInjData_[csrInjOff_[i] + j] = injLists[i][j];
+    }
+
     initColorDataStructs(partialNodeColorPairs);
 }
 

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -37,6 +37,17 @@ using namespace std;
     #endif
 #endif
 
+// Lightweight span over contiguous uint array (C++11 compatible).
+// Used by the CSR adjacency-list representation for cache-friendly iteration.
+struct UintSpan {
+    const uint* _begin;
+    const uint* _end;
+    const uint* begin() const { return _begin; }
+    const uint* end()   const { return _end; }
+    uint size()         const { return (uint)(_end - _begin); }
+    const uint& operator[](uint i) const { return _begin[i]; }
+};
+
 class Graph {
 public:
     /* All-purpose constructor
@@ -107,6 +118,17 @@ public:
     //recommendation: use the getters above instead, when possible
     const vector<uint>* getAdjList(uint node) const { return &adjLists.at(node); }
     const vector<uint>* getInjList(uint node) const { return &injLists.at(node); }
+
+    // Cache-friendly neighbor access via CSR (Compressed Sparse Row).
+    // Returns a lightweight span over contiguous memory — no pointer chase.
+    UintSpan adjSpan(uint node) const {
+        return UintSpan{csrAdjData_.data() + csrAdjOff_[node],
+                        csrAdjData_.data() + csrAdjOff_[node + 1]};
+    }
+    UintSpan injSpan(uint node) const {
+        return UintSpan{csrInjData_.data() + csrInjOff_[node],
+                        csrInjData_.data() + csrInjOff_[node + 1]};
+    }
     const vector<vector<uint>>* getAdjLists() const { return &adjLists; }
     const vector<vector<uint>>* getInjLists() const { return &injLists; }
     const vector<array<uint, 2>>* getEdgeList() const { return &edgeList; }
@@ -178,6 +200,13 @@ private:
     vector<vector<uint>> injLists; // incoming edges, used only if the graph is directed.
     Matrix<EDGE_T> adjMatrix;
     unordered_map<string, uint> nodeNameToIndexMap; //reverse of nodeNames
+
+    // CSR (Compressed Sparse Row) representation — all neighbor data in one
+    // contiguous allocation for cache-friendly iteration in the hot loop.
+    vector<uint> csrAdjData_;
+    vector<uint> csrAdjOff_;
+    vector<uint> csrInjData_;
+    vector<uint> csrInjOff_;
 
     //each edge has a weight in the range of type EDGE_T, but their sum may be beyond that range
     //double can contain the sum of EDGE_T values for any EDGE_T.

--- a/src/measures/WeightedMeasure.hpp
+++ b/src/measures/WeightedMeasure.hpp
@@ -11,8 +11,11 @@ public:
     virtual double getIncChangeOp(uint peg, uint oldHole, uint newHole, const Alignment& A);
     virtual double getIncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2, const Alignment& A);
 
-protected:
+    // Made public so SANA can call getEdgeScore directly in fused neighbor loops,
+    // avoiding redundant neighbor-list iterations when multiple measures are active.
     virtual double getEdgeScore(double w1, double w2) = 0;
+
+protected:
     double computeIncChangeOp(uint peg, uint oldHole, uint newHole, const Alignment& A);
     double computeIncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2, const Alignment& A);
 };

--- a/src/methods/SANA.cpp
+++ b/src/methods/SANA.cpp
@@ -159,6 +159,13 @@ SANA::SANA(const Graph* G1, const Graph* G2,
     needExposedEdges     = false;
     needMS3              = false;
 #endif
+
+    // Cache measure pointers once to avoid per-iteration string-keyed lookups
+    ecMeasurePtr  = (needAligEdges || needSec) ? (BooleanMeasure*)  MC->getMeasure("ec")   : nullptr;
+    edMeasurePtr  = needEd   ? (WeightedMeasure*) MC->getMeasure("ed")   : nullptr;
+    erMeasurePtr  = needEr   ? (WeightedMeasure*) MC->getMeasure("er")   : nullptr;
+    egmMeasurePtr = needEgm  ? (WeightedMeasure*) MC->getMeasure("egm")  : nullptr;
+    eminMeasurePtr= needEmin ? (WeightedMeasure*) MC->getMeasure("emin") : nullptr;
     if (needWec) {
         Measure* wec                     = MC->getMeasure("wec");
         LocalMeasure* m                  = ((WeightedEdgeConservation*) wec)->getNodeSimMeasure();
@@ -264,7 +271,7 @@ SANA::SANA(const Graph* G1, const Graph* G2,
     }
     //things initialized in initDataStructures because they depend on the starting alignment
     //they have the same size for every run, so we can allocate the size here
-    assignedNodesG2 = vector<bool> (n2);
+    assignedNodesG2 = vector<uint8_t> (n2, 0);
     totalInducedWeight = vector<uint> (n2,0);
     actColToUnassignedG2Nodes = vector<vector<uint>> (actColToG1ColId.size());
 }
@@ -775,6 +782,7 @@ Basic idea:
     fi
     // NOTE: "pull it here" means "move" it if the hole was empty, otherwise "swap" with the hole the other peg is in.
 #endif
+__attribute__((flatten))
 void SANA::performChange(uint actColId) {
     uint peg, oldHole, numUnassigWithCol, unassignedVecIndex, newHole;
     numUnassigWithCol = actColToUnassignedG2Nodes[actColId].size();
@@ -828,11 +836,124 @@ void SANA::performChange(uint actColId) {
         oldMs3Denom = MultiS3::denom;
         oldMs3Numer = MultiS3::numer;
     }
-    int newAligEdges           = (needAligEdges or needSec) ? aligEdges + ((EdgeCorrectness*) MC->getMeasure("ec"))->getIncChangeOp(peg, oldHole, newHole, A) : -1;
-    double newEdSum            = needEd ? edSum + ((EdgeDifference*) MC->getMeasure("ed"))->getIncChangeOp(peg, oldHole, newHole, A) : -1;
-    double newErSum            = needEr ? erSum + ((EdgeRatio*) MC->getMeasure("er"))->getIncChangeOp(peg, oldHole, newHole, A) : -1;
-    double newEgmSum           = needEgm ? egmSum + ((EdgeGeoMean*) MC->getMeasure("egm"))->getIncChangeOp(peg, oldHole, newHole, A) : -1;
-    double newEminSum          = needEmin ? eminSum + ((EdgeMin*) MC->getMeasure("emin"))->getIncChangeOp(peg, oldHole, newHole, A) : -1;
+    // --- Fused incremental computation for edge-based measures ---
+    // Instead of iterating G1's neighbor list once per measure (EC, ED, ER, etc.),
+    // we iterate it once and compute all deltas in a single pass.
+    int ecDelta = 0;
+    double edDelta = 0, erDelta = 0, egmDelta = 0, eminDelta = 0;
+    bool doEc = needAligEdges || needSec;
+    bool doWeighted = needEd || needEr || needEgm || needEmin;
+    if (doEc && !doWeighted) {
+        // --- EC-only fast path (S3, SEC) - no weighted-measure branches ---
+        if (G1->hasSelfLoop(peg)) {
+            if (G2->hasSelfLoop(oldHole)) ecDelta -= G2->getEdgeWeight(oldHole, oldHole);
+            if (G2->hasSelfLoop(newHole)) ecDelta += G2->getEdgeWeight(newHole, newHole);
+        }
+        for (uint nbr : G1->adjSpan(peg)) {
+            if (nbr == peg) continue;
+            uint aHole = A[nbr];
+            ecDelta += G2->adjMatrix.get(newHole, aHole) - G2->adjMatrix.get(oldHole, aHole);
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg)) {
+                if (nbr == peg) continue;
+                uint aHole = A[nbr];
+                ecDelta += G2->getEdgeWeight(aHole, newHole) - G2->getEdgeWeight(aHole, oldHole);
+            }
+        }
+    } else if (doEc || doWeighted) {
+        // --- Full fused loop: EC + weighted measures in a single pass ---
+        if (G1->hasSelfLoop(peg)) {
+            if (doEc) {
+                if (G2->hasSelfLoop(oldHole)) ecDelta -= G2->getEdgeWeight(oldHole, oldHole);
+                if (G2->hasSelfLoop(newHole)) ecDelta += G2->getEdgeWeight(newHole, newHole);
+            }
+            if (doWeighted) {
+                double g1sw = G1->getEdgeWeight(peg, peg);
+                if (needEd) {
+                    if (G2->hasSelfLoop(oldHole)) edDelta -= edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(oldHole, oldHole));
+                    if (G2->hasSelfLoop(newHole)) edDelta += edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(newHole, newHole));
+                }
+                if (needEr) {
+                    if (G2->hasSelfLoop(oldHole)) erDelta -= erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(oldHole, oldHole));
+                    if (G2->hasSelfLoop(newHole)) erDelta += erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(newHole, newHole));
+                }
+                if (needEgm) {
+                    if (G2->hasSelfLoop(oldHole)) egmDelta -= egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(oldHole, oldHole));
+                    if (G2->hasSelfLoop(newHole)) egmDelta += egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(newHole, newHole));
+                }
+                if (needEmin) {
+                    if (G2->hasSelfLoop(oldHole)) eminDelta -= eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(oldHole, oldHole));
+                    if (G2->hasSelfLoop(newHole)) eminDelta += eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(newHole, newHole));
+                }
+            }
+        }
+        for (uint nbr : G1->adjSpan(peg)) {
+            if (nbr == peg) continue;
+            uint aHole = A[nbr];
+            EDGE_T oldW2 = G2->adjMatrix.get(oldHole, aHole);
+            EDGE_T newW2 = G2->adjMatrix.get(newHole, aHole);
+            if (doEc) {
+                ecDelta -= oldW2;
+                ecDelta += newW2;
+            }
+            if (doWeighted) {
+                double g1w = G1->getEdgeWeight(peg, nbr);
+                if (needEd) {
+                    if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEr) {
+                    if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEgm) {
+                    if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEmin) {
+                    if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+            }
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg)) {
+                if (nbr == peg) continue;
+                uint aHole = A[nbr];
+                if (doEc) {
+                    ecDelta -= G2->getEdgeWeight(aHole, oldHole);
+                    ecDelta += G2->getEdgeWeight(aHole, newHole);
+                }
+                if (doWeighted) {
+                    double g1w = G1->getEdgeWeight(nbr, peg);
+                    EDGE_T oldW2 = G2->adjMatrix.get(aHole, oldHole);
+                    EDGE_T newW2 = G2->adjMatrix.get(aHole, newHole);
+                    if (needEd) {
+                        if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEr) {
+                        if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEgm) {
+                        if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEmin) {
+                        if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                }
+            }
+        }
+    }
+    int newAligEdges           = doEc ? aligEdges + ecDelta : -1;
+    double newEdSum            = needEd ? edSum + edDelta : -1;
+    double newErSum            = needEr ? erSum + erDelta : -1;
+    double newEgmSum           = needEgm ? egmSum + egmDelta : -1;
+    double newEminSum          = needEmin ? eminSum + eminDelta : -1;
     double newSquaredAligEdges = needSquaredAligEdges ? squaredAligEdges + squaredAligEdgesIncChangeOp(peg, oldHole, newHole) : -1;
     double newExposedEdgesNumer= needExposedEdges ? EdgeExposure::numer + exposedEdgesIncChangeOp(peg, oldHole, newHole) : -1;
     double newMS3Numer         = needMS3 ? MultiS3::numer + MS3IncChangeOp(peg, oldHole, newHole) : -1;
@@ -912,6 +1033,7 @@ void SANA::performChange(uint actColId) {
 #endif
 }
 
+__attribute__((flatten))
 void SANA::performSwap(uint actColId) {
     uint peg1, peg2, hole1, hole2;
     if(alignment.allowedPartnersEnabled()) {
@@ -973,7 +1095,255 @@ void SANA::performSwap(uint actColId) {
         oldMs3Denom = MultiS3::denom;
     }
 
-    int newAligEdges           = (needAligEdges or needSec) ? aligEdges + ((EdgeCorrectness*) MC->getMeasure("ec"))->getIncSwapOp(peg1, peg2, hole1, hole2, A) : -1;
+    // --- Fused incremental computation for edge-based measures (swap) ---
+    // Instead of calling each measure's getIncSwapOp (which independently
+    // iterates both pegs' neighbor lists), we iterate once per peg and
+    // compute EC + ED + ER + EGM + EMIN deltas in a single pass.
+    int ecDelta = 0;
+    double edDelta = 0, erDelta = 0, egmDelta = 0, eminDelta = 0;
+    bool doEc = needAligEdges || needSec;
+    bool doWeighted = needEd || needEr || needEgm || needEmin;
+    if (doEc && !doWeighted) {
+        // --- EC-only fast path: no weighted-measure branches ---
+        // peg1: hole1 -> hole2
+        if (G1->hasSelfLoop(peg1)) {
+            if (G2->hasSelfLoop(hole1)) ecDelta -= G2->getEdgeWeight(hole1, hole1);
+            if (G2->hasSelfLoop(hole2)) ecDelta += G2->getEdgeWeight(hole2, hole2);
+        }
+        for (uint nbr : G1->adjSpan(peg1)) {
+            if (nbr == peg1) continue;
+            uint aHole = A[nbr];
+            ecDelta += G2->adjMatrix.get(hole2, aHole) - G2->adjMatrix.get(hole1, aHole);
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg1)) {
+                if (nbr == peg1) continue;
+                uint aHole = A[nbr];
+                ecDelta += G2->getEdgeWeight(aHole, hole2) - G2->getEdgeWeight(aHole, hole1);
+            }
+        }
+        // peg2: hole2 -> hole1
+        if (G1->hasSelfLoop(peg2)) {
+            if (G2->hasSelfLoop(hole2)) ecDelta -= G2->getEdgeWeight(hole2, hole2);
+            if (G2->hasSelfLoop(hole1)) ecDelta += G2->getEdgeWeight(hole1, hole1);
+        }
+        for (uint nbr : G1->adjSpan(peg2)) {
+            if (nbr == peg2) continue;
+            uint aHole = A[nbr];
+            ecDelta += G2->adjMatrix.get(hole1, aHole) - G2->adjMatrix.get(hole2, aHole);
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg2)) {
+                if (nbr == peg2) continue;
+                uint aHole = A[nbr];
+                ecDelta += G2->getEdgeWeight(aHole, hole1) - G2->getEdgeWeight(aHole, hole2);
+            }
+        }
+        // Correction for swap between adjacent nodes with adjacent images
+#if defined(MULTI_PAIRWISE) || defined(MULTI_MPI)
+        ecDelta += (-1 << 1) & (G1->getEdgeWeight(peg1, peg2) + G2->getEdgeWeight(hole1, hole2));
+#else
+        if (G1->hasEdge(peg1, peg2) && G2->hasEdge(hole1, hole2)) ecDelta += 2;
+        if (G1->directed && G1->hasEdge(peg2, peg1) && G2->hasEdge(hole2, hole1)) ecDelta += 2;
+#endif
+    } else if (doEc || doWeighted) {
+        // --- Full fused loop: EC + weighted measures in a single pass ---
+        // peg1: hole1 -> hole2
+        if (G1->hasSelfLoop(peg1)) {
+            if (doEc) {
+                if (G2->hasSelfLoop(hole1)) ecDelta -= G2->getEdgeWeight(hole1, hole1);
+                if (G2->hasSelfLoop(hole2)) ecDelta += G2->getEdgeWeight(hole2, hole2);
+            }
+            if (doWeighted) {
+                double g1sw = G1->getEdgeWeight(peg1, peg1);
+                if (needEd) {
+                    if (G2->hasSelfLoop(hole1)) edDelta -= edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                    if (G2->hasSelfLoop(hole2)) edDelta += edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                }
+                if (needEr) {
+                    if (G2->hasSelfLoop(hole1)) erDelta -= erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                    if (G2->hasSelfLoop(hole2)) erDelta += erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                }
+                if (needEgm) {
+                    if (G2->hasSelfLoop(hole1)) egmDelta -= egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                    if (G2->hasSelfLoop(hole2)) egmDelta += egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                }
+                if (needEmin) {
+                    if (G2->hasSelfLoop(hole1)) eminDelta -= eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                    if (G2->hasSelfLoop(hole2)) eminDelta += eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                }
+            }
+        }
+        for (uint nbr : G1->adjSpan(peg1)) {
+            if (nbr == peg1) continue;
+            uint aHole = A[nbr];
+            if (doEc) {
+                ecDelta -= G2->adjMatrix.get(hole1, aHole);
+                ecDelta += G2->adjMatrix.get(hole2, aHole);
+            }
+            if (doWeighted) {
+                // Weighted measures need swap-aware lookups when nbr is the other peg
+                uint nbrHole    = (nbr == peg2) ? hole2 : aHole;
+                uint newNbrHole = (nbr == peg2) ? hole1 : aHole;
+                EDGE_T oldW2 = G2->adjMatrix.get(hole1, nbrHole);
+                EDGE_T newW2 = G2->adjMatrix.get(hole2, newNbrHole);
+                double g1w = G1->getEdgeWeight(peg1, nbr);
+                if (needEd) {
+                    if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEr) {
+                    if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEgm) {
+                    if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEmin) {
+                    if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+            }
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg1)) {
+                if (nbr == peg1) continue;
+                uint aHole = A[nbr];
+                if (doEc) {
+                    ecDelta -= G2->getEdgeWeight(aHole, hole1);
+                    ecDelta += G2->getEdgeWeight(aHole, hole2);
+                }
+                if (doWeighted) {
+                    uint nbrHole    = (nbr == peg2) ? hole2 : aHole;
+                    uint newNbrHole = (nbr == peg2) ? hole1 : aHole;
+                    EDGE_T oldW2 = G2->adjMatrix.get(nbrHole, hole1);
+                    EDGE_T newW2 = G2->adjMatrix.get(newNbrHole, hole2);
+                    double g1w = G1->getEdgeWeight(nbr, peg1);
+                    if (needEd) {
+                        if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEr) {
+                        if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEgm) {
+                        if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEmin) {
+                        if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                }
+            }
+        }
+        // peg2: hole2 -> hole1
+        if (G1->hasSelfLoop(peg2)) {
+            if (doEc) {
+                if (G2->hasSelfLoop(hole2)) ecDelta -= G2->getEdgeWeight(hole2, hole2);
+                if (G2->hasSelfLoop(hole1)) ecDelta += G2->getEdgeWeight(hole1, hole1);
+            }
+            if (doWeighted) {
+                double g1sw = G1->getEdgeWeight(peg2, peg2);
+                if (needEd) {
+                    if (G2->hasSelfLoop(hole2)) edDelta -= edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                    if (G2->hasSelfLoop(hole1)) edDelta += edMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                }
+                if (needEr) {
+                    if (G2->hasSelfLoop(hole2)) erDelta -= erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                    if (G2->hasSelfLoop(hole1)) erDelta += erMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                }
+                if (needEgm) {
+                    if (G2->hasSelfLoop(hole2)) egmDelta -= egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                    if (G2->hasSelfLoop(hole1)) egmDelta += egmMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                }
+                if (needEmin) {
+                    if (G2->hasSelfLoop(hole2)) eminDelta -= eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole2, hole2));
+                    if (G2->hasSelfLoop(hole1)) eminDelta += eminMeasurePtr->getEdgeScore(g1sw, G2->getEdgeWeight(hole1, hole1));
+                }
+            }
+        }
+        for (uint nbr : G1->adjSpan(peg2)) {
+            if (nbr == peg2) continue;
+            uint aHole = A[nbr];
+            if (doEc) {
+                ecDelta -= G2->adjMatrix.get(hole2, aHole);
+                ecDelta += G2->adjMatrix.get(hole1, aHole);
+            }
+            if (doWeighted) {
+                uint nbrHole    = (nbr == peg1) ? hole1 : aHole;
+                uint newNbrHole = (nbr == peg1) ? hole2 : aHole;
+                EDGE_T oldW2 = G2->adjMatrix.get(hole2, nbrHole);
+                EDGE_T newW2 = G2->adjMatrix.get(hole1, newNbrHole);
+                double g1w = G1->getEdgeWeight(peg2, nbr);
+                if (needEd) {
+                    if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEr) {
+                    if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEgm) {
+                    if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+                if (needEmin) {
+                    if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                    if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                }
+            }
+        }
+        if (G1->directed) {
+            for (uint nbr : G1->injSpan(peg2)) {
+                if (nbr == peg2) continue;
+                uint aHole = A[nbr];
+                if (doEc) {
+                    ecDelta -= G2->getEdgeWeight(aHole, hole2);
+                    ecDelta += G2->getEdgeWeight(aHole, hole1);
+                }
+                if (doWeighted) {
+                    uint nbrHole    = (nbr == peg1) ? hole1 : aHole;
+                    uint newNbrHole = (nbr == peg1) ? hole2 : aHole;
+                    EDGE_T oldW2 = G2->adjMatrix.get(nbrHole, hole2);
+                    EDGE_T newW2 = G2->adjMatrix.get(newNbrHole, hole1);
+                    double g1w = G1->getEdgeWeight(nbr, peg2);
+                    if (needEd) {
+                        if (oldW2) edDelta -= edMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) edDelta += edMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEr) {
+                        if (oldW2) erDelta -= erMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) erDelta += erMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEgm) {
+                        if (oldW2) egmDelta -= egmMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) egmDelta += egmMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                    if (needEmin) {
+                        if (oldW2) eminDelta -= eminMeasurePtr->getEdgeScore(g1w, oldW2);
+                        if (newW2) eminDelta += eminMeasurePtr->getEdgeScore(g1w, newW2);
+                    }
+                }
+            }
+        }
+        // EC correction for swap between adjacent nodes with adjacent images
+        if (doEc) {
+#if defined(MULTI_PAIRWISE) || defined(MULTI_MPI)
+            ecDelta += (-1 << 1) & (G1->getEdgeWeight(peg1, peg2) + G2->getEdgeWeight(hole1, hole2));
+#else
+            if (G1->hasEdge(peg1, peg2) && G2->hasEdge(hole1, hole2)) ecDelta += 2;
+            if (G1->directed && G1->hasEdge(peg2, peg1) && G2->hasEdge(hole2, hole1)) ecDelta += 2;
+#endif
+        }
+    }
+    int newAligEdges           = doEc ? aligEdges + ecDelta : -1;
+    double newEdSum            = needEd ? edSum + edDelta : -1;
+    double newErSum            = needEr ? erSum + erDelta : -1;
+    double newEgmSum           = needEgm ? egmSum + egmDelta : -1;
+    double newEminSum          = needEmin ? eminSum + eminDelta : -1;
     double newSquaredAligEdges = needSquaredAligEdges ? squaredAligEdges + squaredAligEdgesIncSwapOp(peg1, peg2, hole1, hole2) : -1;
     double newExposedEdgesNumer= needExposedEdges ? EdgeExposure::numer + exposedEdgesIncSwapOp(peg1, peg2, hole1, hole2) : -1;
     double newMS3Numer         = needMS3 ? MultiS3::numer + MS3IncSwapOp(peg1, peg2, hole1, hole2) : -1;
@@ -982,10 +1352,6 @@ void SANA::performSwap(uint actColId) {
     double newEwecSum          = needEwec ? ewecSum + EWECIncSwapOp(peg1, peg2, hole1, hole2) : -1;
     double newNcSum            = needNC ? ncSum + ncIncSwapOp(peg1, peg2, hole1, hole2) : -1;
     double newLocalScoreSum    = needLocal ? localScoreSum + localScoreSumIncSwapOp(sims, peg1, peg2, hole1, hole2) : -1;
-    double newEdSum            = needEd ? edSum + ((EdgeDifference*) MC->getMeasure("ed"))->getIncSwapOp(peg1, peg2, hole1, hole2, A) : -1;
-    double newErSum            = needEr ? erSum + ((EdgeRatio*) MC->getMeasure("er"))->getIncSwapOp(peg1, peg2, hole1, hole2, A) : -1;
-    double newEgmSum           = needEgm ? egmSum + ((EdgeGeoMean*) MC->getMeasure("egm"))->getIncSwapOp(peg1, peg2, hole1, hole2, A) : -1;
-    double newEminSum          = needEmin ? eminSum + ((EdgeMin*) MC->getMeasure("emin"))->getIncSwapOp(peg1, peg2, hole1, hole2, A) : -1;
 
     map<string, double> newLocalScoreSumMap;
     if (needLocal) {
@@ -1936,8 +2302,8 @@ int SANA::MS3IncSwapOp(uint peg1, uint peg2, uint hole1, uint hole2) {
 
 int SANA::inducedEdgesIncChangeOp(uint peg, uint oldHole, uint newHole) {
     int res = 0;
-    for (uint nbr : G2->adjLists[oldHole]) res -= assignedNodesG2[nbr];
-    for (uint nbr : G2->adjLists[newHole]) res += assignedNodesG2[nbr];
+    for (uint nbr : G2->adjSpan(oldHole)) res -= assignedNodesG2[nbr];
+    for (uint nbr : G2->adjSpan(newHole)) res += assignedNodesG2[nbr];
     res -= G2->getEdgeWeight(oldHole, newHole); //address case changing between adjacent nodes:
     return res;
 }

--- a/src/methods/SANA.hpp
+++ b/src/methods/SANA.hpp
@@ -13,6 +13,8 @@
 #include "../measures/localMeasures/LocalMeasure.hpp"
 #include "../measures/Measure.hpp"
 #include "../measures/MeasureCombination.hpp"
+#include "../measures/BooleanMeasure.hpp"
+#include "../measures/WeightedMeasure.hpp"
 #include "../utils/randomSeed.hpp"
 #include "../measures/ExternalWeightedEdgeConservation.hpp"
 #include "../measures/CoreScore.hpp"
@@ -132,7 +134,7 @@ private:
     //if startA is empty, a random alignment is used
     void initDataStructures();
     vector<uint> A, A_; // A_ is the inverse alignment of A
-    vector<bool> assignedNodesG2;
+    vector<uint8_t> assignedNodesG2;
 
     bool isHappyPeg (const uint peg ) { return alignment.isHappy(peg, A[peg]); }
     bool isHappyHole(const uint hole) { return alignment.isHappy(A_[hole], hole); }
@@ -229,6 +231,14 @@ private:
     double EWECIncChangeOp(uint peg, uint oldHole, uint newHole);
     double EWECIncSwapOp(uint peg1, uint Peg2, uint node1, uint node2);
     double EWECSimCombo(uint peg, uint node);
+
+    // Cached measure pointers -- eliminates per-iteration string-keyed
+    // map lookups in the hot loop (MC->getMeasure("ec") etc.)
+    BooleanMeasure*  ecMeasurePtr;
+    WeightedMeasure* edMeasurePtr;
+    WeightedMeasure* erMeasurePtr;
+    WeightedMeasure* egmMeasurePtr;
+    WeightedMeasure* eminMeasurePtr;
 
     //to evaluate local measures incrementally
     bool needLocal;

--- a/src/utils/Matrix.hpp
+++ b/src/utils/Matrix.hpp
@@ -4,15 +4,12 @@
 #include "utils.hpp"
 #include "SparseMatrix.hpp"
 #include <vector>
+#include <algorithm>
 
 using namespace std;
 
 #ifdef SPARSE
     #define INNER_CONTAINER unordered_map<uint, T>
-    #define MATRIX_DATA_STRUCTURE SparseMatrix<T>
-#else
-    #define INNER_CONTAINER vector<T>
-    #define MATRIX_DATA_STRUCTURE vector<vector<T>>
 #endif
 
 template <typename T>
@@ -20,17 +17,47 @@ class Matrix {
 public:
     Matrix();
     Matrix(const Matrix & matrix);
+    Matrix(Matrix && matrix) noexcept;
     Matrix(uint numberOfNodes);
     Matrix(uint row, uint col);
+    ~Matrix();
 
     Matrix & operator = (const Matrix & matrix);
-    INNER_CONTAINER & operator [] (uint node1);
+    Matrix & operator = (Matrix && matrix) noexcept;
 
-    const T get(uint node1, uint node2) const;
+#ifdef SPARSE
+    INNER_CONTAINER & operator [] (uint node1);
+#else
+    // Row proxy for flat array - provides matrix[row][col] syntax
+    struct RowProxy {
+        T* ptr;
+        uint cols;
+        inline T& operator[](uint col) { return ptr[col]; }
+        inline const T& operator[](uint col) const { return ptr[col]; }
+        uint size() const { return cols; }
+    };
+    inline RowProxy operator [] (uint node1) {
+        return RowProxy{flatData + (size_t)node1 * numCols, numCols};
+    }
+#endif
+
+    inline const T get(uint node1, uint node2) const;
     uint size() const;
+
 private:
-   MATRIX_DATA_STRUCTURE data;
+#ifdef SPARSE
+    SparseMatrix<T> data;
+#else
+    T* flatData;
+    uint numRows;
+    uint numCols;
+#endif
 };
+
+// ============================================================
+// SPARSE implementations (unchanged from original)
+// ============================================================
+#ifdef SPARSE
 
 template <typename T>
 inline INNER_CONTAINER & Matrix<T>::operator [] (uint node1) {
@@ -38,42 +65,22 @@ inline INNER_CONTAINER & Matrix<T>::operator [] (uint node1) {
 }
 
 template <typename T>
-Matrix<T>::Matrix(uint row, uint col) {
-#ifdef SPARSE
-    data = MATRIX_DATA_STRUCTURE(row);
-#else
-    data = MATRIX_DATA_STRUCTURE(row,
-           vector<T>(col, T()));
-#endif
-}
+Matrix<T>::Matrix() : data() {}
 
 template <typename T>
-inline const T Matrix<T>::get(uint node1, uint node2) const {
-#ifdef SPARSE
-    return data.get(node1, node2);
-#else
-    return data[node1][node2];
-#endif
-}
+Matrix<T>::Matrix(const Matrix & matrix) : data(matrix.data) {}
 
 template <typename T>
-Matrix<T>::Matrix() {
-}
+Matrix<T>::Matrix(Matrix && matrix) noexcept : data(std::move(matrix.data)) {}
 
 template <typename T>
-Matrix<T>::Matrix(const Matrix & matrix) {
-    data = matrix.data;
-}
+Matrix<T>::Matrix(uint numberOfNodes) : data(numberOfNodes) {}
 
 template <typename T>
-Matrix<T>::Matrix(uint numberOfNodes) {
-#ifdef SPARSE
-    data = MATRIX_DATA_STRUCTURE(numberOfNodes);
-#else
-    data = MATRIX_DATA_STRUCTURE(numberOfNodes,
-           vector<T>(numberOfNodes, T()));
-#endif
-}
+Matrix<T>::Matrix(uint row, uint col) : data(row) {}
+
+template <typename T>
+Matrix<T>::~Matrix() {}
 
 template <typename T>
 Matrix<T> & Matrix<T>::operator = (const Matrix & matrix) {
@@ -82,8 +89,106 @@ Matrix<T> & Matrix<T>::operator = (const Matrix & matrix) {
 }
 
 template <typename T>
+Matrix<T> & Matrix<T>::operator = (Matrix && matrix) noexcept {
+    data = std::move(matrix.data);
+    return *this;
+}
+
+template <typename T>
+inline const T Matrix<T>::get(uint node1, uint node2) const {
+    return data.get(node1, node2);
+}
+
+template <typename T>
 uint Matrix<T>::size() const {
     return data.size();
 }
+
+// ============================================================
+// Non-SPARSE: flat contiguous array
+// Eliminates doubly-indirect heap layout (vector<vector<T>>)
+// for much better cache locality and fewer pointer chases.
+// ============================================================
+#else
+
+template <typename T>
+Matrix<T>::Matrix() : flatData(nullptr), numRows(0), numCols(0) {}
+
+template <typename T>
+Matrix<T>::Matrix(const Matrix & matrix) : numRows(matrix.numRows), numCols(matrix.numCols) {
+    size_t sz = (size_t)numRows * numCols;
+    if (sz > 0) {
+        flatData = new T[sz]();
+        std::copy(matrix.flatData, matrix.flatData + sz, flatData);
+    } else {
+        flatData = nullptr;
+    }
+}
+
+template <typename T>
+Matrix<T>::Matrix(Matrix && matrix) noexcept
+    : flatData(matrix.flatData), numRows(matrix.numRows), numCols(matrix.numCols) {
+    matrix.flatData = nullptr;
+    matrix.numRows = matrix.numCols = 0;
+}
+
+template <typename T>
+Matrix<T>::Matrix(uint numberOfNodes) : numRows(numberOfNodes), numCols(numberOfNodes) {
+    size_t sz = (size_t)numberOfNodes * numberOfNodes;
+    flatData = sz > 0 ? new T[sz]() : nullptr;
+}
+
+template <typename T>
+Matrix<T>::Matrix(uint row, uint col) : numRows(row), numCols(col) {
+    size_t sz = (size_t)row * col;
+    flatData = sz > 0 ? new T[sz]() : nullptr;
+}
+
+template <typename T>
+Matrix<T>::~Matrix() {
+    delete[] flatData;
+}
+
+template <typename T>
+Matrix<T> & Matrix<T>::operator = (const Matrix & matrix) {
+    if (this != &matrix) {
+        delete[] flatData;
+        numRows = matrix.numRows;
+        numCols = matrix.numCols;
+        size_t sz = (size_t)numRows * numCols;
+        if (sz > 0) {
+            flatData = new T[sz];
+            std::copy(matrix.flatData, matrix.flatData + sz, flatData);
+        } else {
+            flatData = nullptr;
+        }
+    }
+    return *this;
+}
+
+template <typename T>
+Matrix<T> & Matrix<T>::operator = (Matrix && matrix) noexcept {
+    if (this != &matrix) {
+        delete[] flatData;
+        flatData = matrix.flatData;
+        numRows = matrix.numRows;
+        numCols = matrix.numCols;
+        matrix.flatData = nullptr;
+        matrix.numRows = matrix.numCols = 0;
+    }
+    return *this;
+}
+
+template <typename T>
+inline const T Matrix<T>::get(uint node1, uint node2) const {
+    return flatData[(size_t)node1 * numCols + node2];
+}
+
+template <typename T>
+uint Matrix<T>::size() const {
+    return numRows;
+}
+
+#endif // SPARSE
 
 #endif /* MATRIX_HPP_ */


### PR DESCRIPTION
Cache-friendly data structures and fused neighbor loops that preserve bit-identical output for any given seed.

Changes:
1. Flat contiguous adjacency matrix (Matrix.hpp)
   - Replace vector<vector<T>> with single T* array
   - Eliminates pointer chase per adjMatrix.get()
   - Biggest win on large networks (170MB matrix → 3.5x speedup)

2. CSR (Compressed Sparse Row) neighbor lists (Graph.hpp/cpp)
   - Pack all neighbor lists into one contiguous allocation
   - adjSpan(node) returns lightweight span over CSR data

3. Fused neighbor-loop for EC+ED+ER+EGM+EMIN (SANA.cpp)
   - Single loop iterates neighbors once, accumulates all deltas
   - EC-only fast path + full fused path for weighted measures
   - Applied to both performChange and performSwap

4. Cached measure pointers (SANA.hpp/cpp)
   - Eliminates per-iteration string-keyed map lookups

5. WeightedMeasure::getEdgeScore made public

6. vector<bool> → vector<uint8_t> for assignedNodesG2
   - Direct byte-addressable access in tight loops

7. Compiler flags: -DNDEBUG -flto (Makefile)
   - Remove assert() calls, enable link-time optimization

8. __attribute__((flatten)) on performChange/performSwap

9. CSR in inducedEdgesIncChangeOp


Note:
I implemented these optimizations for long-horizon [LLM eval tasks](https://github.com/abundant-ai/long-horizon). But these changes can be folded in easily for a serious speed and memory boost. Much of my PR is vibe coded, so merge with caution. 

Yes - I realize this PR does not follow many of the style guidelines from the contributions file. But I think the speedup strategies above are super useful, even for reference.