### PR TITLE
Optimize random number generation in implementLastRequest

### DIFF
--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -611,13 +611,15 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
 // it all off into its own function has solved this only marginally. It works, but there has got to
 // be a less intrusive way to do this!
 double SANAThree::implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator) {
-    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
+    double randomNum = randomReal(generator);
+	
+	unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
 
     holeLocks[input.hole1] = holeLocks[input.hole2] = false;
     if (input.twoPegs) totalSwapsCalculated++;
     else totalMovesCalculated++;
 
-    if (randomReal(generator) >= pBad) return currentScore;
+    if (randomNum >= pBad) return currentScore;
 
     if (input.twoPegs) {
         alignment.swap(input.peg1, input.peg2);


### PR DESCRIPTION
Refactor implementation to generate random number before locking and use it for comparison.