### PR TITLE
Sana3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH_FLAGS=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-U__STRICT_
 MY_CC = g++$(GCC_VER)
 CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-pg -fno-inline
 
-SANA_VER=3.3
+SANA_VER=3.4
 MAIN = sana$(SANA_VER)
 
 #you can give these on Make's command line, eg "SPARSE=1" or "WEIGHT=1" or "MULTI=1"
@@ -22,23 +22,6 @@ endif
 ifeq ($(SPARSE), 1) # this one should be listed first so largest networks are run using SPARSE
     CXXFLAGS := $(CXXFLAGS) -DSPARSE
     MAIN := $(MAIN).sparse
-endif
-
-
-ifeq ($(LEGACY), 1)
-    $(info Legacy build detected.)
-ifdef THREADS
-	$(error Multithreading is not supported for legacy SANA.)
-endif
-    CXXFLAGS := $(CXXFLAGS) -DLEGACY
-    MAIN := $(MAIN).legacy
-else
-ifdef THREADS # this is the number of calculator threads
-	CXXFLAGS := $(CXXFLAGS) "-DTHREADS=$(THREADS)"
-	MAIN := $(MAIN).threads
-else
-	MAIN := $(MAIN)
-endif
 endif
 
 ifeq ($(STATIC), 1)
@@ -69,39 +52,39 @@ endif
 endif
 endif
 
-ifeq ($(CORES), 1) # CORES should be listed last to ensure it's used on the smallest networks during regression tests.
-    CXXFLAGS := $(CXXFLAGS) -DCORES
-    MAIN := $(MAIN).cores
-endif
-
-## Below here are not "normal" pairwise SANA executables
-
-ifeq ($(MULTI), 1)
-    CXXFLAGS := $(CXXFLAGS) -DMULTI_PAIRWISE
-    MAIN := $(MAIN).multi
-endif
-
-ifeq ($(WEIGHT), 1)
-    CXXFLAGS := $(CXXFLAGS) -DWEIGHT
-    ifndef EDGE_T
-	EDGE_T=float # default; use uchar or ushort to reduce memory usage (if weights are ints)
-    endif
-    SUFFIX=.$(EDGE_T)
-    CXXFLAGS := $(CXXFLAGS) "-DEDGE_T=$(EDGE_T)"
-    MAIN := $(MAIN).weight$(SUFFIX)
-endif
-
-######## THIS ONE MUST BE LAST to ensure "MAIN=error" when an incompatible combination occurs ##################
-ifeq ($(MULTI), 1)
-    ifeq ($(WEIGHT), 1)
-    ERROR="SANA cannot currently use WEIGHT in MULTI-alignments"
-    MAIN=error
-    endif
-    ifeq ($(CORES), 1)
-    ERROR="SANA cannot currently compute CORES in MULTI-alignments"
-    MAIN=error
-    endif
-endif
+#ifeq ($(CORES), 1) # CORES should be listed last to ensure it's used on the smallest networks during regression tests.
+#    CXXFLAGS := $(CXXFLAGS) -DCORES
+#    MAIN := $(MAIN).cores
+#endif
+#
+### Below here are not "normal" pairwise SANA executables
+#
+#ifeq ($(MULTI), 1)
+#    CXXFLAGS := $(CXXFLAGS) -DMULTI_PAIRWISE
+#    MAIN := $(MAIN).multi
+#endif
+#
+#ifeq ($(WEIGHT), 1)
+#    CXXFLAGS := $(CXXFLAGS) -DWEIGHT
+#    ifndef EDGE_T
+#	EDGE_T=float # default; use uchar or ushort to reduce memory usage (if weights are ints)
+#    endif
+#    SUFFIX=.$(EDGE_T)
+#    CXXFLAGS := $(CXXFLAGS) "-DEDGE_T=$(EDGE_T)"
+#    MAIN := $(MAIN).weight$(SUFFIX)
+#endif
+#
+######### THIS ONE MUST BE LAST to ensure "MAIN=error" when an incompatible combination occurs ##################
+#ifeq ($(MULTI), 1)
+#    ifeq ($(WEIGHT), 1)
+#    ERROR="SANA cannot currently use WEIGHT in MULTI-alignments"
+#    MAIN=error
+#    endif
+#    ifeq ($(CORES), 1)
+#    ERROR="SANA cannot currently compute CORES in MULTI-alignments"
+#    MAIN=error
+#    endif
+#endif
 
 INCLUDES =
 LFLAGS =

--- a/Makefile
+++ b/Makefile
@@ -31,19 +31,19 @@ endif
 
 # this one should be second-last since the debugging ones run slowly and should be used on smallish networks.
 ifeq ($(GDB), 4)
-    CXXFLAGS := $(CXXFLAGS) -ggdb -O3 -fno-omit-frame-pointer -fsanitize=thread
+    CXXFLAGS := $(CXXFLAGS) -g -O3 -fno-omit-frame-pointer -fsanitize=thread -rdynamic
     MAIN := $(MAIN).sanitize.o3.gdb
 else
 ifeq ($(GDB), 3)
-    CXXFLAGS := $(CXXFLAGS) -ggdb -O0 -fno-omit-frame-pointer -fsanitize=thread
+    CXXFLAGS := $(CXXFLAGS) -g -O0 -fno-omit-frame-pointer -fsanitize=thread -rdynamic
     MAIN := $(MAIN).sanitize.gdb
 else
 ifeq ($(GDB), 2) # For profiling
-    CXXFLAGS := $(CXXFLAGS) -ggdb -O3 -fno-omit-frame-pointer
+    CXXFLAGS := $(CXXFLAGS) -g -O3 -fno-omit-frame-pointer -rdynamic
     MAIN := $(MAIN).o3.gdb
 else
 ifeq ($(GDB), 1) # For debugging
-    CXXFLAGS := $(CXXFLAGS) -ggdb -O0 -fno-omit-frame-pointer
+    CXXFLAGS := $(CXXFLAGS) -g -O0 -fno-omit-frame-pointer -rdynamic
     MAIN := $(MAIN).gdb
 else
     CXXFLAGS := $(CXXFLAGS) -O3 # always turn on optimization if not debugging

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH_FLAGS=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-U__STRICT_
 MY_CC = g++$(GCC_VER)
 CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-pg -fno-inline
 
-SANA_VER=3.4
+SANA_VER=3.5.0
 MAIN = sana$(SANA_VER)
 
 #you can give these on Make's command line, eg "SPARSE=1" or "WEIGHT=1" or "MULTI=1"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH_FLAGS=$(shell ($(GCC) -v 2>&1; uname -a) | awk '/CYGWIN/{print "-U__STRICT_
 MY_CC = g++$(GCC_VER)
 CXXFLAGS = -I "src/utils" "-DLIBWAYNE=1" -Wall -std=gnu++11 -pthread $(ARCH_FLAGS) #-pg -fno-inline
 
-SANA_VER=3.5.0
+SANA_VER=3.5.1
 MAIN = sana$(SANA_VER)
 
 #you can give these on Make's command line, eg "SPARSE=1" or "WEIGHT=1" or "MULTI=1"

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -4,73 +4,32 @@
 #include "utils/FileIO.hpp"
 using namespace std;
 
-// WARNING: the allowed list is GLOBAL to the Alignment class
-unordered_map<uint, unordered_set<uint>> Alignment::allowedPeg2Hole, Alignment::allowedHole2Peg;
+Alignment::Alignment() = default;
+Alignment::Alignment(const vector<uint>& mapping) {
+    vector<atomic_uint> align(mapping.size());
 
-Alignment::Alignment(): n1(0), n2(0), A(vector<atomic_uint>(0))
-#ifdef PREFERRED_HOLES
-    ,invA(vector<atomic_uint>(0))
-#endif
-{}
-
-Alignment::Alignment(const vector<uint>& mapping, unsigned n2):
-    n1(mapping.size()),
-    n2(n2),
-    A(n1)
-#ifdef PREFERRED_HOLES
-    ,invA(n2)
-{
-    for (auto hole: invA) hole.store(n1);
-#else
-{
-#endif
-
-    for (size_t peg = 0; peg < mapping.size(); ++peg) {
-        const unsigned hole = mapping[peg];
-        if (hole < n2) {
-            A[peg].store(hole);
-#ifdef PREFERRED_HOLES
-            invA[hole].store(peg)
-#endif
-        }
-        else A[peg].store(n2);
+    for (size_t i = 0; i < mapping.size(); ++i) {
+        align[i].store(mapping[i]);
     }
+    A = move(align);
 }
-Alignment::Alignment(const Alignment& alig):
-    n1(alig.n1),
-    n2(alig.n2),
-    A(n1)
-#ifdef PREFERRED_HOLES
-    ,invA(n2) {
-    for (unsigned i = 0; i < n2; ++i) {
-        invA[i].store(alig.invA[i].load());
+Alignment::Alignment(const Alignment& alig){
+    vector<atomic_uint> align(alig.A.size());
+
+    for (size_t i = 0; i < alig.A.size(); ++i) {
+        align[i].store(alig.A[i].load());
     }
-#else
-{
-#endif
-    for (unsigned i = 0; i < n1; ++i) {
-        A[i].store(alig.A[i].load());
-    }
+    A = move(align);
 };
 
-Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList):
-    n1(G1.getNumNodes()),
-    n2(G2.getNumNodes()),
-    A(n1)
-#ifdef PREFERRED_HOLES
-    ,invA(n2) {
-    for (auto &value: invA) value.store(n1); //n1 used to denote invalid inverse index
-#else
-{
-#endif
-    for (auto &value: A) value.store(n2); //n2 used to denote invalid index
-
+Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList) {
+    uint n1 = G1.getNumNodes(), n2 = G2.getNumNodes();
+    assert(n1 == edgeList.size());
+    A = vector<atomic_uint>(n1); //n2 used to denote invalid index
+    for (auto &value: A) value.store(n2);
     for (const auto& edge : edgeList) {
         const string &nodeG1 = edge[0], &nodeG2 = edge[1];
-        A.at(G1.getNameIndex(nodeG1)).store(G2.getNameIndex(nodeG2));
-#ifdef PREFERRED_HOLES
-        invA.at(G2.getNameIndex(nodeG2)).store(G1.getNameIndex(nodeG2));
-#endif
+        A[G1.getNameIndex(nodeG1)].store(G2.getNameIndex(nodeG2));
     }
     printDefinitionErrors(G1,G2);
     assert(isCorrectlyDefined(G1, G2));
@@ -165,13 +124,13 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2,
             G2AssignedNodes[j] = true;
         }
     }
-    Alignment alig(A, n2);
+    Alignment alig(A);
     alig.printDefinitionErrors(G1, G2);
     assert(alig.isCorrectlyDefined(G1, G2));
     return alig;
 }
 
-Alignment Alignment::loadMapping(const string& fileName, unsigned n2) {
+Alignment Alignment::loadMapping(const string& fileName) {
     if (not FileIO::fileExists(fileName)) {
         throw runtime_error("Starting alignment file "+fileName+" not found");
     }
@@ -182,18 +141,7 @@ Alignment Alignment::loadMapping(const string& fileName, unsigned n2) {
     vector<uint> A(0);
     int g2Ind;
     while (iss >> g2Ind) A.push_back(g2Ind);
-    return {A, n2};
-}
-
-// Function to read a line from an input stream and split it into words.
-static std::vector<std::string> lineToWords(const std::string& line) {
-    std::vector<std::string> words;
-    std::stringstream ss(line);
-    std::string word;
-    while (ss >> word) {
-	words.push_back(word);
-    }
-    return words;
+    return A;
 }
 
 Alignment Alignment::random(uint n1, uint n2) {
@@ -213,11 +161,20 @@ Alignment Alignment::random(uint n1, uint n2) {
         }
     }
     randomShuffle(alignment);
-    return {alignment, n2};
+    return alignment;
 }
 
 Alignment Alignment::empty() {
-    return {};
+    vector<uint> emptyMapping(0);
+    return {emptyMapping};
+}
+
+Alignment Alignment::identity(uint n) {
+    vector<uint> A(n);
+    for (uint i = 0; i < n; i++) {
+        A[i] = i;
+    }
+    return {A};
 }
 
 Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
@@ -228,11 +185,12 @@ Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
     for (uint i = 0; i < G1.getNumNodes(); i++) {
         A[i] = G2.getNameIndex(G1.getNodeName(i));
     }
-    return {A, G2.getNumNodes()};
+    return {A};
 }
 
-Alignment &Alignment::operator=(const Alignment &other) {
-    return Alignment(other);
+Alignment &Alignment::operator=(Alignment other) {
+    std::swap(A, other.A);
+    return *this;
 }
 
 uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
@@ -254,15 +212,11 @@ Alignment Alignment::reverse(uint n2) const {
     uint n1 = numOfPegs();
     vector<uint> A(n2, n1); //n1 used for invalid mapping
     for (uint i = 0; i < n1; i++) A[this->A[i].load()] = i;
-    return {A, n1};
+    return {A};
 }
 
 void Alignment::compose(const Alignment& other) {
-    for (uint i = 0; i < numOfPegs(); i++) {
-        const unsigned f_of_i = A[i].load();
-        const unsigned g_of_f_of_i = other.A[f_of_i].load();
-        A[i].store(g_of_f_of_i);
-    }
+    for (uint i = 0; i < numOfPegs(); i++) A[i].store(other.A[A[i].load()].load());
 }
 
 bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) const {
@@ -340,10 +294,10 @@ Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph
         g1ColIdToG2Nodes[g1ColId].pop_back();
     }
 
-    Alignment alig(A, G2.getNumNodes());
+    Alignment alig(A);
     if (not alig.isCorrectlyDefined(G1, G2)) {
         alig.printDefinitionErrors(G1, G2);
         throw runtime_error("alignment not correctly defined");
     }
-    return alig;
+    return alig;   
 }

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -1,35 +1,65 @@
 #include "Alignment.hpp"
 #include "Graph.hpp"
+#include "measures/EdgeCorrectness.hpp"
 #include "utils/utils.hpp"
 #include "utils/FileIO.hpp"
 using namespace std;
 
-Alignment::Alignment() = default;
-Alignment::Alignment(const vector<uint>& mapping) {
-    vector<atomic_uint> align(mapping.size());
+Alignment::Alignment():
+pegNum(0), holeNum(0), pegsToHoles(0), holesToPegs(0) {}
 
-    for (size_t i = 0; i < mapping.size(); ++i) {
-        align[i].store(mapping[i]);
+Alignment::Alignment(const Alignment& other):
+    pegNum(other.pegNum),
+    holeNum(other.holeNum) {
+    pegsToHoles = move(vector<atomic_uint>(pegNum));
+    holesToPegs = move(vector<atomic_uint>(holeNum));
+    for (size_t peg = 0; peg < pegNum; ++peg) {
+        pegsToHoles[peg].store(other.pegsToHoles[peg].load());
     }
-    A = move(align);
+    for (size_t hole = 0; hole < holeNum; ++hole) {
+        holesToPegs[hole].store(other.holesToPegs[hole].load());
+    }
 }
-Alignment::Alignment(const Alignment& alig){
-    vector<atomic_uint> align(alig.A.size());
 
-    for (size_t i = 0; i < alig.A.size(); ++i) {
-        align[i].store(alig.A[i].load());
+Alignment &Alignment::operator=(Alignment other) {
+    std::swap(pegsToHoles, other.pegsToHoles);
+    std::swap(holesToPegs, other.holesToPegs);
+    pegNum = other.pegNum;
+    holeNum = other.holeNum;
+    return *this;
+}
+
+Alignment::Alignment(const vector<uint>& mapping, uint holeNum):
+    pegNum(mapping.size()),
+    holeNum(holeNum) {
+    pegsToHoles = move(vector<atomic_uint>(mapping.size()));
+    holesToPegs = move(vector<atomic_uint>(holeNum));
+
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+
+    for (size_t peg = 0; peg < mapping.size(); ++peg) {
+        uint hole = mapping[peg];
+        pegsToHoles[peg].store(hole);
+        holesToPegs[hole].store(peg);
     }
-    A = move(align);
-};
+}
 
-Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList) {
-    uint n1 = G1.getNumNodes(), n2 = G2.getNumNodes();
-    assert(n1 == edgeList.size());
-    A = vector<atomic_uint>(n1); //n2 used to denote invalid index
-    for (auto &value: A) value.store(n2);
+Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList):
+    pegNum(G1.getNumNodes()),
+    holeNum(G2.getNumNodes()) {
+    assert(pegNum == edgeList.size());
+
+    pegsToHoles = move(vector<atomic_uint>(pegNum));
+    holesToPegs = move(vector<atomic_uint>(holeNum));
+    for (auto &pegsHole: pegsToHoles) pegsHole.store(invalidHole);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+
     for (const auto& edge : edgeList) {
-        const string &nodeG1 = edge[0], &nodeG2 = edge[1];
-        A[G1.getNameIndex(nodeG1)].store(G2.getNameIndex(nodeG2));
+        const string &pegName = edge[0], &holeName = edge[1];
+        uint peg = G1.getNameIndex(pegName);
+        uint hole = G2.getNameIndex(holeName);
+        pegsToHoles[peg].store(hole);
+        holesToPegs[hole].store(peg);
     }
     printDefinitionErrors(G1,G2);
     assert(isCorrectlyDefined(G1, G2));
@@ -42,7 +72,7 @@ Alignment Alignment::loadEdgeList(const Graph& G1, const Graph& G2, const string
     for (uint i = 0; i < edges.size(); i += 2) {
         edgeList.push_back({edges[i], edges[i+1]});
     }
-    return {G1, G2, edgeList};
+    return Alignment(G1, G2, edgeList);
 }
 
 Alignment Alignment::loadEdgeListUnordered(const Graph& G1, const Graph& G2, const string& fileName) {
@@ -62,29 +92,42 @@ Alignment Alignment::loadEdgeListUnordered(const Graph& G1, const Graph& G2, con
             edgeList.push_back({name2, name1});
         }
     }
-    return {G1, G2, edgeList};
+    return Alignment(G1, G2, edgeList);
 }
 
-Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2,
-                                    const string& fileName, bool byName) {
+Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2, const string& fileName, bool byName) {
     vector<string> edges = FileIO::fileToWords(fileName);
     vector<array<string, 2>> edgeList;
     edgeList.reserve(edges.size()/2);
-    for (uint i = 0; i < edges.size(); i += 2) {
+    for (size_t i = 0; i < edges.size(); i += 2) {
         edgeList.push_back({edges[i], edges[i+1]});
     }
-    uint n1 = G1.getNumNodes(), n2 = G2.getNumNodes();
-    vector<uint> A(n1, n2); //n2 used to note invalid value
+    uint pegNum = G1.getNumNodes();
+    uint holeNum = G2.getNumNodes();
+
+    Alignment newAlignment;
+    newAlignment.pegNum = pegNum;
+    newAlignment.holeNum = holeNum;
+    newAlignment.pegsToHoles = move(vector<atomic_uint>(pegNum));
+    newAlignment.holesToPegs = move(vector<atomic_uint>(holeNum));
+
+    vector<atomic_uint> &pegsToHoles = newAlignment.pegsToHoles;
+    vector<atomic_uint> &holesToPegs = newAlignment.holesToPegs;
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+
     for (const auto& edge : edgeList) {
-        string nodeG1 = edge[0], nodeG2 = edge[1];
+        const string *pegName = &edge[0], *holeName = &edge[1];
         if (not byName) {
-            A[stoi(nodeG1)] = stoi(nodeG2);
+            uint peg = stoul(*pegName);
+            uint hole = stoul(*holeName);
+            pegsToHoles[peg].store(hole);
+            holesToPegs[hole].store(peg);
         } else {
             bool nodeG1Misplaced = false;
             bool nodeG2Misplaced = false;
-            if (not G1.hasNodeName(nodeG1)) {
-                cout << nodeG1 << " not in G1 " << G1.getName();
-                if (G2.hasNodeName(nodeG1)) {
+            if (not G1.hasNodeName(*pegName)) {
+                cout << pegName << " not in G1 " << G1.getName();
+                if (G2.hasNodeName(*pegName)) {
                     cout << ", but it is in G2. Will switch if appropriate." << endl;
                     nodeG1Misplaced = true;
                 } else {
@@ -92,9 +135,9 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2,
                     continue;
                 }
             }
-            if (not G2.hasNodeName(nodeG2)) {
-                cout << nodeG2 << " not in G2 " << G2.getName();
-                if (G1.hasNodeName(nodeG2)) {
+            if (not G2.hasNodeName(*holeName)) {
+                cout << holeName << " not in G2 " << G2.getName();
+                if (G1.hasNodeName(*holeName)) {
                     cout << ", but it is in G1. Will switch if appropriate." << endl;
                     nodeG2Misplaced = true;
                 } else {
@@ -103,34 +146,39 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2,
                 }
             }
             if (nodeG1Misplaced and nodeG2Misplaced) {
-                std::swap(nodeG1, nodeG2);
-                cout << nodeG1 << " and " << nodeG2 << " swapped." << endl;
+                std::swap(pegName, holeName);
+                cout << pegName << " and " << holeName << " swapped." << endl;
             }
-            A[G1.getNameIndex(nodeG1)] = G2.getNameIndex(nodeG2);
+            uint peg = G1.getNameIndex(*pegName);
+            uint hole = G2.getNameIndex(*holeName);
+            pegsToHoles[peg].store(hole);
+            holesToPegs[hole].store(peg);
         }
     }
-    vector<bool> G2AssignedNodes(n2, false);
-    for (uint i = 0; i < n1; i++) {
-        if (A[i] != n2) {
-            if (G2AssignedNodes[A[i]]) throw runtime_error("two G1 nodes map to the same G2 node");
-            G2AssignedNodes[A[i]] = true;
+    for (uint peg = 0; peg < pegNum; peg++) {
+        const uint hole = pegsToHoles[peg].load();
+        if (hole != invalidHole) {
+            if (holesToPegs[hole].load() != peg) {
+                throw runtime_error("two G1 nodes map to the same G2 node");
+            }
         }
     }
-    for (uint i = 0; i < n1; i++) {
-        if (A[i] == n2) {
-            unsigned j = randIndex(n2);
-            while (G2AssignedNodes[j]) j = randIndex(n2);
-            A[i] = j;
-            G2AssignedNodes[j] = true;
+    for (uint peg = 0; peg < pegNum; peg++) {
+        if (pegsToHoles[peg] == holeNum) {
+            uint hole = randIndex(holeNum);
+            while (holesToPegs[hole] != invalidPeg) {
+                hole = randIndex(holeNum);
+            }
+            pegsToHoles[peg].store(hole);
+            holesToPegs[hole].store(peg);
         }
     }
-    Alignment alig(A);
-    alig.printDefinitionErrors(G1, G2);
-    assert(alig.isCorrectlyDefined(G1, G2));
-    return alig;
+    newAlignment.printDefinitionErrors(G1, G2);
+    assert(newAlignment.isCorrectlyDefined(G1, G2));
+    return newAlignment;
 }
 
-Alignment Alignment::loadMapping(const string& fileName) {
+Alignment Alignment::loadMapping(const string& fileName, const Graph& G1, const Graph& G2) {
     if (not FileIO::fileExists(fileName)) {
         throw runtime_error("Starting alignment file "+fileName+" not found");
     }
@@ -141,17 +189,66 @@ Alignment Alignment::loadMapping(const string& fileName) {
     vector<uint> A(0);
     int g2Ind;
     while (iss >> g2Ind) A.push_back(g2Ind);
-    return A;
+    return Alignment(A, G2.getNumNodes());
 }
 
-Alignment Alignment::random(uint n1, uint n2) {
+
+//precondition: a valid color-restricted matching exists between G1 and G2
+//equivalently: every color in G1 has at least as many nodes in G2
+Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph& G2) {
+
+    const vector<uint> holeColorToPegColor = G2.myColorIdsToOtherGraphColorIds(G1);
+    vector<vector<uint>> pegColorToHoles(G1.numColors());
+    for (uint hole = 0; hole < G2.getNumNodes(); hole++) {
+        uint holeColor = G2.getNodeColor(hole);
+        uint pegColor = holeColorToPegColor[holeColor];
+        if (pegColor == Graph::INVALID_COLOR_ID) continue;
+        pegColorToHoles[pegColor].push_back(hole);
+    }
+    for (uint pegColor = 0; pegColor < G1.numColors(); pegColor++) {
+        randomShuffle(pegColorToHoles[pegColor]);
+    }
+
+    uint pegNum = G1.getNumNodes();
+    uint holeNum = G2.getNumNodes();
+
+    Alignment newAlignment;
+    newAlignment.pegNum = pegNum;
+    newAlignment.holeNum = holeNum;
+    newAlignment.pegsToHoles = move(vector<atomic_uint>(pegNum));
+    newAlignment.holesToPegs = move(vector<atomic_uint>(holeNum));
+
+    vector<atomic_uint> &pegsToHoles = newAlignment.pegsToHoles;
+    vector<atomic_uint> &holesToPegs = newAlignment.holesToPegs;
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+
+    for (uint peg = 0; peg < pegNum; peg++) {
+        uint pegColor = G1.getNodeColor(peg);
+        if (pegColorToHoles[pegColor].empty()) {
+            throw runtime_error("not enough nodes in G2 with color "+G1.getColorName(pegColor));
+        }
+        uint hole = pegColorToHoles[pegColor].back();
+        pegColorToHoles[pegColor].pop_back();
+
+        pegsToHoles[peg].store(hole);
+        holesToPegs[hole].store(peg);
+    }
+
+    if (not newAlignment.isCorrectlyDefined(G1, G2)) {
+        newAlignment.printDefinitionErrors(G1, G2);
+        throw runtime_error("alignment not correctly defined");
+    }
+    return newAlignment;
+}
+
+Alignment Alignment::random(uint pegNum, uint holeNum) {
     //taken from: http://stackoverflow.com/questions/311703/algorithm-for-sampling-without-replacement
-    vector<uint> alignment(n1);
+    vector<uint> alignment(pegNum);
     uint t = 0; // total input records dealt with
     uint m = 0; // number of items selected so far
-    while (m < n1) {
+    while (m < pegNum) {
         double u = randDouble();
-        if ((n2 - t)*u >= n1 - m) {
+        if ((holeNum - t)*u >= pegNum - m) {
             t++;
         }
         else {
@@ -161,20 +258,50 @@ Alignment Alignment::random(uint n1, uint n2) {
         }
     }
     randomShuffle(alignment);
-    return alignment;
+
+    return Alignment(alignment, holeNum);
 }
 
 Alignment Alignment::empty() {
-    vector<uint> emptyMapping(0);
-    return {emptyMapping};
+    return Alignment();
 }
 
 Alignment Alignment::identity(uint n) {
-    vector<uint> A(n);
-    for (uint i = 0; i < n; i++) {
-        A[i] = i;
+    Alignment newAlignment;
+    newAlignment.pegNum = n;
+    newAlignment.holeNum = n;
+
+    vector<atomic_uint> A(n);
+    vector<atomic_uint> invA(n);
+    for (size_t i = 0; i < n; i++) {
+        A[i].store(i);
+        invA[i].store(i);
     }
-    return {A};
+    newAlignment.pegsToHoles = move(A);
+    newAlignment.holesToPegs = move(invA);
+
+    return newAlignment;
+}
+
+Alignment Alignment::reverse() const {
+    Alignment newAlignment;
+    newAlignment.pegNum = holeNum;
+    newAlignment.holeNum = pegNum;
+
+    vector<atomic_uint> newA(holeNum);
+    vector<atomic_uint> newInvA(pegNum);
+
+    for (size_t i = 0; i < pegNum; i++) {
+        newInvA[i].store(pegsToHoles[i].load());
+    }
+    for (size_t i = 0; i < holeNum; i++) {
+        newA[i].store(holesToPegs[i].load());
+    }
+
+    newAlignment.holesToPegs = move(newInvA);
+    newAlignment.pegsToHoles = move(newA);
+
+    return newAlignment;
 }
 
 Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
@@ -185,12 +312,67 @@ Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
     for (uint i = 0; i < G1.getNumNodes(); i++) {
         A[i] = G2.getNameIndex(G1.getNodeName(i));
     }
-    return {A};
+    return Alignment(A, G2.getNumNodes());
 }
 
-Alignment &Alignment::operator=(Alignment other) {
-    std::swap(A, other.A);
-    return *this;
+vector<uint> Alignment::copyPegsToHoles() const {
+    vector<uint> v;
+    v.reserve(pegNum);
+    for (const auto& e : pegsToHoles) {
+        v.push_back(e.load());
+    }
+    return v;
+}
+
+vector<uint> Alignment::copyHolesToPegs() const {
+    vector<uint> v;
+    v.reserve(holeNum);
+    for (const auto& e : holesToPegs) {
+        v.push_back(e.load());
+    }
+    return v;
+}
+
+void Alignment::movePeg(uint peg, uint newHole) {
+    uint oldHole = pegsToHoles[peg].exchange(newHole);
+    holesToPegs[oldHole].store(invalidPeg);
+    holesToPegs[newHole].store(peg);
+}
+
+void Alignment::movePeg(uint peg, uint oldHole, uint newHole) {
+    pegsToHoles[peg].store(newHole);
+    holesToPegs[oldHole].store(invalidPeg);
+    holesToPegs[newHole].store(peg);
+}
+
+void Alignment::swapPegs(uint peg1, uint peg2) {
+    uint hole1 = pegsToHoles[peg1].load();
+    uint hole2 = pegsToHoles[peg2].exchange(hole1);
+    pegsToHoles[peg1].store(hole2);
+
+    holesToPegs[hole1].store(peg2);
+    holesToPegs[hole2].store(peg1);
+}
+
+void Alignment::swapPegs(uint peg1, uint peg2, uint hole1, uint hole2) {
+    pegsToHoles[peg1].store(hole2);
+    pegsToHoles[peg2].store(hole1);
+
+    holesToPegs[hole1].store(peg2);
+    holesToPegs[hole2].store(peg1);
+}
+
+void Alignment::compose(const Alignment& other) {
+    holeNum = other.holeNum;
+    holesToPegs = move(vector<atomic_uint>(holeNum));
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+
+    for (uint peg = 0; peg < numOfPegs(); peg++) {
+        uint oldHole = pegsToHoles[peg].load();
+        uint newHole = other.pegsToHoles[oldHole].load();
+        pegsToHoles[peg].store(newHole);
+        holesToPegs[newHole].store(peg);
+    }
 }
 
 uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
@@ -203,101 +385,123 @@ uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
     // arbitrary specifications on what an aligned edge costs. For example if the edges are weighted, then EdgeRatio
     // says the aligned edges is min(e1,e2)/max(e1,e2), whereas EdgeMin is just min(e1,e2). In such cases "counting"
     // aligned edges is irrelevant.
-    for (const auto& edge: *(G1.getEdgeList()))
-        res += G2.getEdgeWeight(A[edge[0]], A[edge[1]]);
+    for (const auto& edge: G1.getEdgeList()) {
+        uint peg1 = edge[0];
+        uint peg2 = edge[1];
+        uint hole1 = pegsToHoles[peg1].load();
+        uint hole2 = pegsToHoles[peg2].load();
+
+        res += G2.getEdgeWeight(hole1, hole2);
+    }
     return res;
-}
-
-Alignment Alignment::reverse(uint n2) const {
-    uint n1 = numOfPegs();
-    vector<uint> A(n2, n1); //n1 used for invalid mapping
-    for (uint i = 0; i < n1; i++) A[this->A[i].load()] = i;
-    return {A};
-}
-
-void Alignment::compose(const Alignment& other) {
-    for (uint i = 0; i < numOfPegs(); i++) A[i].store(other.A[A[i].load()].load());
 }
 
 bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) const {
     uint n1 = G1.getNumNodes();
     uint n2 = G2.getNumNodes();
-    vector<bool> G2AssignedNodes(n2, false);
+    if (n1 != pegNum || n2 != holeNum) {
+        return false;
+    }
+
+    if (n1 != pegsToHoles.size() || n2 != holesToPegs.size()) {
+        return false;
+    }
+
     vector<uint> colorMap = G1.myColorIdsToOtherGraphColorIds(G2);
 
-    if (A.size() != n1) return false;
-    for (uint i = 0; i < n1; i++) {
-        if (A[i] < 0 or A[i] >= n2 or G2AssignedNodes[A[i]]) return false;
-        G2AssignedNodes[A[i]] = true;
-        uint g1Color = G1.getNodeColor(i);
-        uint g2Color = G2.getNodeColor(A[i]);
-        if (colorMap.at(g1Color) != g2Color) return false;
+    for (uint peg = 0; peg < pegNum; ++peg) {
+        uint hole = pegsToHoles[peg].load();
+        if (hole >= invalidHole) {
+            return false;
+        }
+        if (holesToPegs[hole].load() != peg) {
+            return false;
+        }
+
+        uint pegColor = G1.getNodeColor(peg);
+        uint holeColor = G2.getNodeColor(pegsToHoles[peg]);
+        if (colorMap.at(pegColor) != holeColor) {
+            return false;
+        }
     }
+    for (uint hole = 0; hole < holeNum; ++hole) {
+        uint peg = holesToPegs[hole].load();
+        if (peg > invalidPeg) {
+            return false;
+        }
+        if (peg == invalidPeg) {
+            continue;
+        }
+        if (pegsToHoles[peg].load() != hole) {
+            return false;
+        }
+    }
+
     return true;
 }
 
 void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) const {
-    uint n1 = G1.getNumNodes(), n2 = G2.getNumNodes();
-    vector<bool> G2AssignedNodes(n2, false);
+    uint n1 = G1.getNumNodes();
+    uint n2 = G2.getNumNodes();
+
     vector<uint> colorMap = G1.myColorIdsToOtherGraphColorIds(G2);
+
     int count = 0;
-    if (A.size() != n1) 
-        cerr << "Incorrect size: "<<A.size()<<", should be "<<n1<<endl;
-    for (uint i = 0; i < n1; i++) {
-        if (A[i] < 0 or A[i] >= n2) {
-            cerr<<count<<": node "<<i<<" ("<<G1.getNodeName(i)<<") maps to ";
-            cerr<<A[i]<<", which is not in range 0..n2 ("<<n2<<")"<<endl;
-            count++;
+
+    if (pegNum != n1) {
+        cerr << "Incorrect pegNum: "<<pegNum<<", should be "<<n1<<endl;
+    }
+    if (pegsToHoles.size() != n1) {
+        cerr << "Incorrect pegsToHoles size: "<<pegsToHoles.size()<<", should be "<<n1<<endl;
+    }
+    if (holeNum != n2) {
+        cerr << "Incorrect holeNum: "<<pegNum<<", should be "<<n2<<endl;
+    }
+    if (holesToPegs.size() != n1) {
+        cerr << "Incorrect holesToPegs size: "<<holesToPegs.size()<<", should be "<<n2<<endl;
+    }
+
+    for (uint peg = 0; peg < pegNum; ++peg) {
+        uint hole = pegsToHoles[peg].load();
+        if (hole >= invalidHole) {
+            cerr<<count++<<": peg "<<peg<<" ("<<G1.getNodeName(peg)<<") maps to hole ";
+            cerr<<hole<<", which is not in range 0..n2 ("<<n2<<")"<<endl;
         }
-        if (G2AssignedNodes[A[i]]) {
-            cerr<<count<<": node "<<i<<" ("<<G1.getNodeName(i)<<") maps to "<<A[i]<<" (";
-            cerr<<G2.getNodeName(A[i])<<"), which is also mapped to by a previous node"<<endl;
-            count++;
+        uint peg2 = holesToPegs[hole].load();
+        if (peg != peg2 && peg2 < invalidPeg) {
+            cerr<<count++<<": peg "<<peg<<" ("<<G1.getNodeName(peg)<<") maps to hole "<<hole<<" (";
+            cerr<<G2.getNodeName(hole)<<"), which actually maps back to peg "<<peg2;
+            cerr<<" ("<<G1.getNodeName(peg2)<<")"<<endl;
         }
-        G2AssignedNodes[A[i]] = true;
-        uint g1Color = G1.getNodeColor(i);
-        uint g2Color = G2.getNodeColor(A[i]);
-        if (colorMap.at(g1Color) != g2Color) {
-            string g1ColorName = G1.getColorName(g1Color);
-            string g2ColorName = G2.getColorName(g2Color);
-            cerr<<count<<": node "<<i<<" ("<<G1.getNodeName(i)<<") of color ";
-            cerr<<G1.getColorName(g1Color)<<" maps to "<<A[i]<<" (";
-            cerr<<G2.getNodeName(A[i])<<") of color "<<G2.getColorName(g2Color)<<endl;
-            count++;
+        uint pegColor = G1.getNodeColor(peg);
+        uint holeColor = G2.getNodeColor(hole);
+        if (colorMap.at(pegColor) != holeColor) {
+            string pegColorName = G1.getColorName(pegColor);
+            string holeColorName = G2.getColorName(holeColor);
+            cerr<<count<<": peg "<<peg<<" ("<<G1.getNodeName(peg)<<") of color ";
+            cerr<<G1.getColorName(pegColor)<<" maps to hole "<<pegsToHoles[peg]<<" (";
+            cerr<<G2.getNodeName(pegsToHoles[peg])<<") of color "<<G2.getColorName(holeColor)<<endl;
+            ++count;
+        }
+    }
+
+    for (uint hole = 0; hole < pegNum; ++hole) {
+        uint peg = holesToPegs[hole].load();
+
+        if (peg > invalidPeg) {
+            cerr<<count++<<": hole "<<hole<<" ("<<G2.getNodeName(hole)<<") maps to ";
+            cerr<<peg<<", which is not neither a valid peg nor the None value ("<<invalidPeg<<")"<<endl;
+        }
+        if (peg == invalidPeg) {
+            continue;
+        }
+
+        uint hole2 = pegsToHoles[peg].load();
+        if (hole != hole2) {
+            cerr<<count++<<": hole "<<hole<<" ("<<G2.getNodeName(hole)<<") maps to peg "<<peg<<" (";
+            cerr<<G1.getNodeName(peg)<<"), which actually maps back to hole "<<hole2;
+            cerr<<" ("<<G2.getNodeName(hole2)<<")"<<endl;
         }
     }
 }
 
-//precondition: a valid color-restricted matching exists between G1 and G2
-//equivalently: every color in G1 has at least as many nodes in G2
-Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph& G2) {
-    vector<uint> g2ColIdToG1ColId = G2.myColorIdsToOtherGraphColorIds(G1);
-    vector<vector<uint>> g1ColIdToG2Nodes(G1.numColors());
-    for (uint g2Node = 0; g2Node < G2.getNumNodes(); g2Node++) {
-        uint g2ColId = G2.getNodeColor(g2Node);
-        uint g1ColId = g2ColIdToG1ColId[g2ColId];
-        if (g1ColId == Graph::INVALID_COLOR_ID) continue;
-        g1ColIdToG2Nodes[g1ColId].push_back(g2Node);
-    }
-    for (uint g1ColId = 0; g1ColId < G1.numColors(); g1ColId++) {
-        randomShuffle(g1ColIdToG2Nodes[g1ColId]);
-    }
-    
-    vector<uint> A(0);
-    A.reserve(G1.getNumNodes());
-    for (uint g1Node = 0; g1Node < G1.getNumNodes(); g1Node++) {
-        uint g1ColId = G1.getNodeColor(g1Node);
-        if (g1ColIdToG2Nodes[g1ColId].empty()) {
-            throw runtime_error("not enough nodes in G2 with color "+G1.getColorName(g1ColId));
-        }
-        A.push_back(g1ColIdToG2Nodes[g1ColId].back());
-        g1ColIdToG2Nodes[g1ColId].pop_back();
-    }
-
-    Alignment alig(A);
-    if (not alig.isCorrectlyDefined(G1, G2)) {
-        alig.printDefinitionErrors(G1, G2);
-        throw runtime_error("alignment not correctly defined");
-    }
-    return alig;   
-}

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -14,10 +14,10 @@ Alignment::Alignment(const Alignment& other):
     pegsToHoles = move(vector<atomic_uint>(pegNum));
     holesToPegs = move(vector<atomic_uint>(holeNum));
     for (size_t peg = 0; peg < pegNum; ++peg) {
-        pegsToHoles[peg].store(other.pegsToHoles[peg].load());
+        pegsToHoles[peg].store(other.pegsToHoles[peg].load(memory_order_relaxed), memory_order_relaxed);
     }
     for (size_t hole = 0; hole < holeNum; ++hole) {
-        holesToPegs[hole].store(other.holesToPegs[hole].load());
+        holesToPegs[hole].store(other.holesToPegs[hole].load(memory_order_relaxed), memory_order_relaxed);
     }
 }
 
@@ -35,12 +35,12 @@ Alignment::Alignment(const vector<uint>& mapping, uint holeNum):
     pegsToHoles = move(vector<atomic_uint>(mapping.size()));
     holesToPegs = move(vector<atomic_uint>(holeNum));
 
-    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg, memory_order_relaxed);
 
     for (size_t peg = 0; peg < mapping.size(); ++peg) {
         uint hole = mapping[peg];
-        pegsToHoles[peg].store(hole);
-        holesToPegs[hole].store(peg);
+        pegsToHoles[peg].store(hole, memory_order_relaxed);
+        holesToPegs[hole].store(peg, memory_order_relaxed);
     }
 }
 
@@ -51,15 +51,15 @@ Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string
 
     pegsToHoles = move(vector<atomic_uint>(pegNum));
     holesToPegs = move(vector<atomic_uint>(holeNum));
-    for (auto &pegsHole: pegsToHoles) pegsHole.store(invalidHole);
-    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+    for (auto &pegsHole: pegsToHoles) pegsHole.store(invalidHole, memory_order_relaxed);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg, memory_order_relaxed);
 
     for (const auto& edge : edgeList) {
         const string &pegName = edge[0], &holeName = edge[1];
         uint peg = G1.getNameIndex(pegName);
         uint hole = G2.getNameIndex(holeName);
-        pegsToHoles[peg].store(hole);
-        holesToPegs[hole].store(peg);
+        pegsToHoles[peg].store(hole, memory_order_relaxed);
+        holesToPegs[hole].store(peg, memory_order_relaxed);
     }
     printDefinitionErrors(G1,G2);
     assert(isCorrectlyDefined(G1, G2));
@@ -113,15 +113,15 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2, const
 
     vector<atomic_uint> &pegsToHoles = newAlignment.pegsToHoles;
     vector<atomic_uint> &holesToPegs = newAlignment.holesToPegs;
-    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg, memory_order_relaxed);
 
     for (const auto& edge : edgeList) {
         const string *pegName = &edge[0], *holeName = &edge[1];
         if (not byName) {
             uint peg = stoul(*pegName);
             uint hole = stoul(*holeName);
-            pegsToHoles[peg].store(hole);
-            holesToPegs[hole].store(peg);
+            pegsToHoles[peg].store(hole, memory_order_relaxed);
+            holesToPegs[hole].store(peg, memory_order_relaxed);
         } else {
             bool nodeG1Misplaced = false;
             bool nodeG2Misplaced = false;
@@ -151,14 +151,14 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2, const
             }
             uint peg = G1.getNameIndex(*pegName);
             uint hole = G2.getNameIndex(*holeName);
-            pegsToHoles[peg].store(hole);
-            holesToPegs[hole].store(peg);
+            pegsToHoles[peg].store(hole, memory_order_relaxed);
+            holesToPegs[hole].store(peg, memory_order_relaxed);
         }
     }
     for (uint peg = 0; peg < pegNum; peg++) {
-        const uint hole = pegsToHoles[peg].load();
+        const uint hole = pegsToHoles[peg].load(memory_order_relaxed);
         if (hole != invalidHole) {
-            if (holesToPegs[hole].load() != peg) {
+            if (holesToPegs[hole].load(memory_order_relaxed) != peg) {
                 throw runtime_error("two G1 nodes map to the same G2 node");
             }
         }
@@ -169,8 +169,8 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2, const
             while (holesToPegs[hole] != invalidPeg) {
                 hole = randIndex(holeNum);
             }
-            pegsToHoles[peg].store(hole);
-            holesToPegs[hole].store(peg);
+            pegsToHoles[peg].store(hole, memory_order_relaxed);
+            holesToPegs[hole].store(peg, memory_order_relaxed);
         }
     }
     newAlignment.printDefinitionErrors(G1, G2);
@@ -220,7 +220,7 @@ Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph
 
     vector<atomic_uint> &pegsToHoles = newAlignment.pegsToHoles;
     vector<atomic_uint> &holesToPegs = newAlignment.holesToPegs;
-    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg, memory_order_relaxed);
 
     for (uint peg = 0; peg < pegNum; peg++) {
         uint pegColor = G1.getNodeColor(peg);
@@ -230,8 +230,8 @@ Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph
         uint hole = pegColorToHoles[pegColor].back();
         pegColorToHoles[pegColor].pop_back();
 
-        pegsToHoles[peg].store(hole);
-        holesToPegs[hole].store(peg);
+        pegsToHoles[peg].store(hole, memory_order_relaxed);
+        holesToPegs[hole].store(peg, memory_order_relaxed);
     }
 
     if (not newAlignment.isCorrectlyDefined(G1, G2)) {
@@ -274,8 +274,8 @@ Alignment Alignment::identity(uint n) {
     vector<atomic_uint> A(n);
     vector<atomic_uint> invA(n);
     for (size_t i = 0; i < n; i++) {
-        A[i].store(i);
-        invA[i].store(i);
+        A[i].store(i, memory_order_relaxed);
+        invA[i].store(i, memory_order_relaxed);
     }
     newAlignment.pegsToHoles = move(A);
     newAlignment.holesToPegs = move(invA);
@@ -292,10 +292,10 @@ Alignment Alignment::reverse() const {
     vector<atomic_uint> newInvA(pegNum);
 
     for (size_t i = 0; i < pegNum; i++) {
-        newInvA[i].store(pegsToHoles[i].load());
+        newInvA[i].store(pegsToHoles[i].load(memory_order_relaxed), memory_order_relaxed);
     }
     for (size_t i = 0; i < holeNum; i++) {
-        newA[i].store(holesToPegs[i].load());
+        newA[i].store(holesToPegs[i].load(memory_order_relaxed), memory_order_relaxed);
     }
 
     newAlignment.holesToPegs = move(newInvA);
@@ -319,7 +319,7 @@ vector<uint> Alignment::copyPegsToHoles() const {
     vector<uint> v;
     v.reserve(pegNum);
     for (const auto& e : pegsToHoles) {
-        v.push_back(e.load());
+        v.push_back(e.load(memory_order_relaxed));
     }
     return v;
 }
@@ -328,50 +328,50 @@ vector<uint> Alignment::copyHolesToPegs() const {
     vector<uint> v;
     v.reserve(holeNum);
     for (const auto& e : holesToPegs) {
-        v.push_back(e.load());
+        v.push_back(e.load(memory_order_relaxed));
     }
     return v;
 }
 
 void Alignment::movePeg(uint peg, uint newHole) {
-    uint oldHole = pegsToHoles[peg].exchange(newHole);
-    holesToPegs[oldHole].store(invalidPeg);
-    holesToPegs[newHole].store(peg);
+    uint oldHole = pegsToHoles[peg].exchange(newHole, memory_order_relaxed);
+    holesToPegs[oldHole].store(invalidPeg, memory_order_relaxed);
+    holesToPegs[newHole].store(peg, memory_order_relaxed);
 }
 
 void Alignment::movePeg(uint peg, uint oldHole, uint newHole) {
-    pegsToHoles[peg].store(newHole);
-    holesToPegs[oldHole].store(invalidPeg);
-    holesToPegs[newHole].store(peg);
+    pegsToHoles[peg].store(newHole, memory_order_relaxed);
+    holesToPegs[oldHole].store(invalidPeg, memory_order_relaxed);
+    holesToPegs[newHole].store(peg, memory_order_relaxed);
 }
 
 void Alignment::swapPegs(uint peg1, uint peg2) {
-    uint hole1 = pegsToHoles[peg1].load();
-    uint hole2 = pegsToHoles[peg2].exchange(hole1);
-    pegsToHoles[peg1].store(hole2);
+    uint hole1 = pegsToHoles[peg1].load(memory_order_relaxed);
+    uint hole2 = pegsToHoles[peg2].exchange(hole1, memory_order_relaxed);
+    pegsToHoles[peg1].store(hole2, memory_order_relaxed);
 
-    holesToPegs[hole1].store(peg2);
-    holesToPegs[hole2].store(peg1);
+    holesToPegs[hole1].store(peg2, memory_order_relaxed);
+    holesToPegs[hole2].store(peg1, memory_order_relaxed);
 }
 
 void Alignment::swapPegs(uint peg1, uint peg2, uint hole1, uint hole2) {
-    pegsToHoles[peg1].store(hole2);
-    pegsToHoles[peg2].store(hole1);
+    pegsToHoles[peg1].store(hole2, memory_order_relaxed);
+    pegsToHoles[peg2].store(hole1, memory_order_relaxed);
 
-    holesToPegs[hole1].store(peg2);
-    holesToPegs[hole2].store(peg1);
+    holesToPegs[hole1].store(peg2, memory_order_relaxed);
+    holesToPegs[hole2].store(peg1, memory_order_relaxed);
 }
 
 void Alignment::compose(const Alignment& other) {
     holeNum = other.holeNum;
     holesToPegs = move(vector<atomic_uint>(holeNum));
-    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg);
+    for (auto &holesPeg: holesToPegs) holesPeg.store(invalidPeg, memory_order_relaxed);
 
     for (uint peg = 0; peg < numOfPegs(); peg++) {
-        uint oldHole = pegsToHoles[peg].load();
-        uint newHole = other.pegsToHoles[oldHole].load();
-        pegsToHoles[peg].store(newHole);
-        holesToPegs[newHole].store(peg);
+        uint oldHole = pegsToHoles[peg].load(memory_order_relaxed);
+        uint newHole = other.pegsToHoles[oldHole].load(memory_order_relaxed);
+        pegsToHoles[peg].store(newHole, memory_order_relaxed);
+        holesToPegs[newHole].store(peg, memory_order_relaxed);
     }
 }
 
@@ -388,8 +388,8 @@ uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
     for (const auto& edge: G1.getEdgeList()) {
         uint peg1 = edge[0];
         uint peg2 = edge[1];
-        uint hole1 = pegsToHoles[peg1].load();
-        uint hole2 = pegsToHoles[peg2].load();
+        uint hole1 = pegsToHoles[peg1].load(memory_order_relaxed);
+        uint hole2 = pegsToHoles[peg2].load(memory_order_relaxed);
 
         res += G2.getEdgeWeight(hole1, hole2);
     }
@@ -410,11 +410,11 @@ bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) const {
     vector<uint> colorMap = G1.myColorIdsToOtherGraphColorIds(G2);
 
     for (uint peg = 0; peg < pegNum; ++peg) {
-        uint hole = pegsToHoles[peg].load();
+        uint hole = pegsToHoles[peg].load(memory_order_relaxed);
         if (hole >= invalidHole) {
             return false;
         }
-        if (holesToPegs[hole].load() != peg) {
+        if (holesToPegs[hole].load(memory_order_relaxed) != peg) {
             return false;
         }
 
@@ -425,14 +425,14 @@ bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) const {
         }
     }
     for (uint hole = 0; hole < holeNum; ++hole) {
-        uint peg = holesToPegs[hole].load();
+        uint peg = holesToPegs[hole].load(memory_order_relaxed);
         if (peg > invalidPeg) {
             return false;
         }
         if (peg == invalidPeg) {
             continue;
         }
-        if (pegsToHoles[peg].load() != hole) {
+        if (pegsToHoles[peg].load(memory_order_relaxed) != hole) {
             return false;
         }
     }
@@ -457,17 +457,17 @@ void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) const {
     if (holeNum != n2) {
         cerr << "Incorrect holeNum: "<<pegNum<<", should be "<<n2<<endl;
     }
-    if (holesToPegs.size() != n1) {
+    if (holesToPegs.size() != n2) {
         cerr << "Incorrect holesToPegs size: "<<holesToPegs.size()<<", should be "<<n2<<endl;
     }
 
     for (uint peg = 0; peg < pegNum; ++peg) {
-        uint hole = pegsToHoles[peg].load();
+        uint hole = pegsToHoles[peg].load(memory_order_relaxed);
         if (hole >= invalidHole) {
             cerr<<count++<<": peg "<<peg<<" ("<<G1.getNodeName(peg)<<") maps to hole ";
             cerr<<hole<<", which is not in range 0..n2 ("<<n2<<")"<<endl;
         }
-        uint peg2 = holesToPegs[hole].load();
+        uint peg2 = holesToPegs[hole].load(memory_order_relaxed);
         if (peg != peg2 && peg2 < invalidPeg) {
             cerr<<count++<<": peg "<<peg<<" ("<<G1.getNodeName(peg)<<") maps to hole "<<hole<<" (";
             cerr<<G2.getNodeName(hole)<<"), which actually maps back to peg "<<peg2;
@@ -486,7 +486,7 @@ void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) const {
     }
 
     for (uint hole = 0; hole < pegNum; ++hole) {
-        uint peg = holesToPegs[hole].load();
+        uint peg = holesToPegs[hole].load(memory_order_relaxed);
 
         if (peg > invalidPeg) {
             cerr<<count++<<": hole "<<hole<<" ("<<G2.getNodeName(hole)<<") maps to ";
@@ -496,7 +496,7 @@ void Alignment::printDefinitionErrors(const Graph& G1, const Graph& G2) const {
             continue;
         }
 
-        uint hole2 = pegsToHoles[peg].load();
+        uint hole2 = pegsToHoles[peg].load(memory_order_relaxed);
         if (hole != hole2) {
             cerr<<count++<<": hole "<<hole<<" ("<<G2.getNodeName(hole)<<") maps to peg "<<peg<<" (";
             cerr<<G1.getNodeName(peg)<<"), which actually maps back to hole "<<hole2;

--- a/src/Alignment.cpp
+++ b/src/Alignment.cpp
@@ -7,32 +7,70 @@ using namespace std;
 // WARNING: the allowed list is GLOBAL to the Alignment class
 unordered_map<uint, unordered_set<uint>> Alignment::allowedPeg2Hole, Alignment::allowedHole2Peg;
 
-Alignment::Alignment() = default;
-Alignment::Alignment(const vector<uint>& mapping) {
-    vector<atomic_uint> align(mapping.size());
+Alignment::Alignment(): n1(0), n2(0), A(vector<atomic_uint>(0))
+#ifdef PREFERRED_HOLES
+    ,invA(vector<atomic_uint>(0))
+#endif
+{}
 
-    for (size_t i = 0; i < mapping.size(); ++i) {
-        align[i].store(mapping[i]);
+Alignment::Alignment(const vector<uint>& mapping, unsigned n2):
+    n1(mapping.size()),
+    n2(n2),
+    A(n1)
+#ifdef PREFERRED_HOLES
+    ,invA(n2)
+{
+    for (auto hole: invA) hole.store(n1);
+#else
+{
+#endif
+
+    for (size_t peg = 0; peg < mapping.size(); ++peg) {
+        const unsigned hole = mapping[peg];
+        if (hole < n2) {
+            A[peg].store(hole);
+#ifdef PREFERRED_HOLES
+            invA[hole].store(peg)
+#endif
+        }
+        else A[peg].store(n2);
     }
-    A = move(align);
 }
-Alignment::Alignment(const Alignment& alig){
-    vector<atomic_uint> align(alig.A.size());
-
-    for (size_t i = 0; i < alig.A.size(); ++i) {
-        align[i].store(alig.A[i].load());
+Alignment::Alignment(const Alignment& alig):
+    n1(alig.n1),
+    n2(alig.n2),
+    A(n1)
+#ifdef PREFERRED_HOLES
+    ,invA(n2) {
+    for (unsigned i = 0; i < n2; ++i) {
+        invA[i].store(alig.invA[i].load());
     }
-    A = move(align);
+#else
+{
+#endif
+    for (unsigned i = 0; i < n1; ++i) {
+        A[i].store(alig.A[i].load());
+    }
 };
 
-Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList) {
-    uint n1 = G1.getNumNodes(), n2 = G2.getNumNodes();
-    assert(n1 == edgeList.size());
-    A = vector<atomic_uint>(n1); //n2 used to denote invalid index
-    for (auto &value: A) value.store(n2);
+Alignment::Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList):
+    n1(G1.getNumNodes()),
+    n2(G2.getNumNodes()),
+    A(n1)
+#ifdef PREFERRED_HOLES
+    ,invA(n2) {
+    for (auto &value: invA) value.store(n1); //n1 used to denote invalid inverse index
+#else
+{
+#endif
+    for (auto &value: A) value.store(n2); //n2 used to denote invalid index
+
     for (const auto& edge : edgeList) {
         const string &nodeG1 = edge[0], &nodeG2 = edge[1];
-        A[G1.getNameIndex(nodeG1)].store(G2.getNameIndex(nodeG2));
+        A.at(G1.getNameIndex(nodeG1)).store(G2.getNameIndex(nodeG2));
+#ifdef PREFERRED_HOLES
+        invA.at(G2.getNameIndex(nodeG2)).store(G1.getNameIndex(nodeG2));
+#endif
     }
     printDefinitionErrors(G1,G2);
     assert(isCorrectlyDefined(G1, G2));
@@ -127,13 +165,13 @@ Alignment Alignment::loadPartialEdgeList(const Graph& G1, const Graph& G2,
             G2AssignedNodes[j] = true;
         }
     }
-    Alignment alig(A);
+    Alignment alig(A, n2);
     alig.printDefinitionErrors(G1, G2);
     assert(alig.isCorrectlyDefined(G1, G2));
     return alig;
 }
 
-Alignment Alignment::loadMapping(const string& fileName) {
+Alignment Alignment::loadMapping(const string& fileName, unsigned n2) {
     if (not FileIO::fileExists(fileName)) {
         throw runtime_error("Starting alignment file "+fileName+" not found");
     }
@@ -144,7 +182,7 @@ Alignment Alignment::loadMapping(const string& fileName) {
     vector<uint> A(0);
     int g2Ind;
     while (iss >> g2Ind) A.push_back(g2Ind);
-    return A;
+    return {A, n2};
 }
 
 // Function to read a line from an input stream and split it into words.
@@ -156,44 +194,6 @@ static std::vector<std::string> lineToWords(const std::string& line) {
 	words.push_back(word);
     }
     return words;
-}
-
-void Alignment::loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName) {
-    if (not FileIO::fileExists(fileName)) {
-        throw runtime_error("Starting alignment file "+fileName+" not found");
-    }
-    cout << "loading allowed partners from file " << fileName << '\n';
-    ifstream ifs(fileName);
-    string line;
-    while(FileIO::safeGetLine(ifs, line)) {
-	std::vector<std::string> words = lineToWords(line);
-	assert(words.size() >= 2);
-        if(!G1.hasNodeName(words[0])) {
-	    cerr << "WARNING: can't load allowedPartners for non-existant G1 node " << words[0] << '\n';
-	    continue;
-	}
-	uint peg = G1.getNameIndex(words[0]);
-	unordered_set<uint> partners;
-	for (size_t i = 1; i < words.size(); ++i) {
-            if(!G2.hasNodeName(words[i])) {
-		cerr << "WARNING: can't load non-existant allowedPartner G2 node " << words[i] << '\n';
-		continue;
-	    }
-	    uint hole = G2.getNameIndex(words[i]);
-	    partners.insert(hole);
-	    allowedHole2Peg[hole].insert(peg);
-	}
-	allowedPeg2Hole[peg] = partners;
-    }
-    cout << "loaded " << allowedPeg2Hole.size() << " allowed pegs and " << allowedHole2Peg.size() << " holes.\n";
-}
-
-uint Alignment::whichPeg(uint hole) {
-    for(const auto& peg : A) {
-	// assert(peg<98246); assert(A[peg] < 136648); // for FlyWire BANC <-> FAFB
-	if(A[peg]==hole) return (uint)peg;
-    }
-    return -1;
 }
 
 Alignment Alignment::random(uint n1, uint n2) {
@@ -213,20 +213,11 @@ Alignment Alignment::random(uint n1, uint n2) {
         }
     }
     randomShuffle(alignment);
-    return alignment;
+    return {alignment, n2};
 }
 
 Alignment Alignment::empty() {
-    vector<uint> emptyMapping(0);
-    return {emptyMapping};
-}
-
-Alignment Alignment::identity(uint n) {
-    vector<uint> A(n);
-    for (uint i = 0; i < n; i++) {
-        A[i] = i;
-    }
-    return {A};
+    return {};
 }
 
 Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
@@ -237,12 +228,11 @@ Alignment Alignment::correctMapping(const Graph& G1, const Graph& G2) {
     for (uint i = 0; i < G1.getNumNodes(); i++) {
         A[i] = G2.getNameIndex(G1.getNodeName(i));
     }
-    return {A};
+    return {A, G2.getNumNodes()};
 }
 
-Alignment &Alignment::operator=(Alignment other) {
-    std::swap(A, other.A);
-    return *this;
+Alignment &Alignment::operator=(const Alignment &other) {
+    return Alignment(other);
 }
 
 uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
@@ -261,14 +251,18 @@ uint Alignment::computeNumAlignedEdges(const Graph& G1, const Graph& G2) const {
 }
 
 Alignment Alignment::reverse(uint n2) const {
-    uint n1 = size();
+    uint n1 = numOfPegs();
     vector<uint> A(n2, n1); //n1 used for invalid mapping
     for (uint i = 0; i < n1; i++) A[this->A[i].load()] = i;
-    return {A};
+    return {A, n1};
 }
 
 void Alignment::compose(const Alignment& other) {
-    for (uint i = 0; i < size(); i++) A[i].store(other.A[A[i].load()].load());
+    for (uint i = 0; i < numOfPegs(); i++) {
+        const unsigned f_of_i = A[i].load();
+        const unsigned g_of_f_of_i = other.A[f_of_i].load();
+        A[i].store(g_of_f_of_i);
+    }
 }
 
 bool Alignment::isCorrectlyDefined(const Graph& G1, const Graph& G2) const {
@@ -346,10 +340,10 @@ Alignment Alignment::randomColorRestrictedAlignment(const Graph& G1, const Graph
         g1ColIdToG2Nodes[g1ColId].pop_back();
     }
 
-    Alignment alig(A);
+    Alignment alig(A, G2.getNumNodes());
     if (not alig.isCorrectlyDefined(G1, G2)) {
         alig.printDefinitionErrors(G1, G2);
         throw runtime_error("alignment not correctly defined");
     }
-    return alig;   
+    return alig;
 }

--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -12,18 +12,24 @@
 #include "utils/utils.hpp"
 #include <atomic>
 
+#define invalidPeg pegNum
+#define invalidHole holeNum
+
 using namespace std;
 
 /* Please make it a priority not to modify this class. This is a very general/abstract/core class
    that should not know anything about any of the measures/methods/modes that use it.
    Do not add anything specific to, or used only by, a particular measure/method/mode.
    Instead of adding a function here, add it to the would-be-caller class with an alignment as parameter. */
+// I do not know who said above, but I second this! -ML
 class Alignment {
 public:
+
+    // CONSTRUCTORS
     Alignment();
-    Alignment(const Alignment& alig);
+    Alignment(const Alignment& other);
     Alignment &operator=(Alignment);
-    Alignment(const vector<uint>& mapping);
+    Alignment(const vector<uint>& mapping, unsigned holeNum);
     Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList);
 
     static Alignment loadEdgeList(const Graph& G1, const Graph& G2, const string& fileName);
@@ -31,17 +37,17 @@ public:
     //list of pairs of aligned node names, but first node in each pair may be of G2
     static Alignment loadEdgeListUnordered(const Graph& G1, const Graph& G2, const string& fileName);
     static Alignment loadPartialEdgeList(const Graph& G1, const Graph& G2, const string& fileName, bool byName);
-    static Alignment loadMapping(const string& fileName);
+    static Alignment loadMapping(const string& fileName, const Graph& G1, const Graph& G2); // TODO
     static Alignment randomColorRestrictedAlignment(const Graph& G1, const Graph& G2);
     
     //returns a random alignment from a graph with n1 nodes to a graph with nodes n2 >= n1 nodes
-    static Alignment random(uint n1, uint n2);
+    static Alignment random(uint pegNum, uint holeNum);
     static Alignment empty();
     static Alignment identity(uint n);
 
     //returns an alignment of size n2 that is the inverse of this
     //value 'n1' is used as invalid mapping
-    Alignment reverse(uint n2) const;
+    Alignment reverse() const;
 
     //returns the correct alignment between G1 and G2 by looking at
     //their node names. it assumes that they have the same node names
@@ -49,19 +55,22 @@ public:
     //shuffled node order
     static Alignment correctMapping(const Graph& G1, const Graph& G2);
 
-    vector<uint> asVector() const {
-        vector<uint> v;
-        for (const auto& e : A) {
-            v.push_back(e.load());
-        }
-        return v;
-    }
+    // OPERATORS
 
-    void movePeg(uint node, uint value) {A[node].store(value);}
-    const uint pegToHole(uint node) const {return A[node].load();}
-    void swapPegs(uint node1, uint node2){A[node2].store(A[node1].exchange(A[node2].load()));}
-    const uint operator[](uint node) const {return A[node].load(memory_order_relaxed);} // No write access.
-    uint numOfPegs() const {return A.size();}
+    vector<uint> copyPegsToHoles() const;
+    vector<uint> copyHolesToPegs() const;
+
+    void movePeg(uint peg, uint newHole);
+    void movePeg(uint peg, uint oldHole, uint newHole);
+    void swapPegs(uint peg1, uint peg2);
+    void swapPegs(uint peg1, uint peg2, uint hole1, uint hole2);
+
+    uint pegToHole(uint peg) const {return pegsToHoles[peg].load();}
+    uint holeToPeg(uint hole) const {return holesToPegs[hole].load();}
+    uint operator[](uint peg) const {return pegsToHoles[peg].load(memory_order_relaxed);} // No write access.
+    uint numOfPegs() const {return pegNum;}
+    uint numOfHoles() const {return holeNum;}
+
     void compose(const Alignment& other);
 
     uint computeNumAlignedEdges(const Graph& G1, const Graph& G2) const;
@@ -69,10 +78,11 @@ public:
     bool isCorrectlyDefined(const Graph& G1, const Graph& G2) const;
     void printDefinitionErrors(const Graph& G1, const Graph& G2) const;
 
-    void loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName) {}; // TODO
-
 private:
-    vector<atomic_uint> A;
+    unsigned pegNum; // Size of A, used as unassigned value for invA
+    unsigned holeNum; // Size of invA, used as unassigned value for A
+    vector<atomic_uint> pegsToHoles;
+    vector<atomic_uint> holesToPegs;
 };
 
 #endif /* ALIGNMENT_HPP */

--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -22,26 +22,26 @@ class Alignment {
 public:
     Alignment();
     Alignment(const Alignment& alig);
-    Alignment &operator=(const Alignment &); //TODO
-    Alignment(const vector<uint>& mapping, uint n2);
+    Alignment &operator=(Alignment);
+    Alignment(const vector<uint>& mapping);
     Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList);
 
     static Alignment loadEdgeList(const Graph& G1, const Graph& G2, const string& fileName);
+
     //list of pairs of aligned node names, but first node in each pair may be of G2
     static Alignment loadEdgeListUnordered(const Graph& G1, const Graph& G2, const string& fileName);
     static Alignment loadPartialEdgeList(const Graph& G1, const Graph& G2, const string& fileName, bool byName);
-    static Alignment loadMapping(const string& fileName, unsigned n2);
+    static Alignment loadMapping(const string& fileName);
     static Alignment randomColorRestrictedAlignment(const Graph& G1, const Graph& G2);
-
-    // void loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName);
-
+    
     //returns a random alignment from a graph with n1 nodes to a graph with nodes n2 >= n1 nodes
     static Alignment random(uint n1, uint n2);
     static Alignment empty();
+    static Alignment identity(uint n);
 
     //returns an alignment of size n2 that is the inverse of this
     //value 'n1' is used as invalid mapping
-    Alignment reverse(uint n2) const; //TODO
+    Alignment reverse(uint n2) const;
 
     //returns the correct alignment between G1 and G2 by looking at
     //their node names. it assumes that they have the same node names
@@ -57,46 +57,22 @@ public:
         return v;
     }
 
-    uint numOfPegs() const {return n1;}
-    void compose(const Alignment& other); // TODO
+    void movePeg(uint node, uint value) {A[node].store(value);}
+    const uint pegToHole(uint node) const {return A[node].load();}
+    void swapPegs(uint node1, uint node2){A[node2].store(A[node1].exchange(A[node2].load()));}
+    const uint operator[](uint node) const {return A[node].load(memory_order_relaxed);} // No write access.
+    uint numOfPegs() const {return A.size();}
+    void compose(const Alignment& other);
 
     uint computeNumAlignedEdges(const Graph& G1, const Graph& G2) const;
 
-    bool isCorrectlyDefined(const Graph& G1, const Graph& G2) const; // TODO
+    bool isCorrectlyDefined(const Graph& G1, const Graph& G2) const;
     void printDefinitionErrors(const Graph& G1, const Graph& G2) const;
 
-    // This is for relaxed and casual access. No write access!
-    uint operator[](uint peg) const {return A[peg].load(memory_order_relaxed);}
-
-#ifdef PREFERRED_HOLES
-    uint numOfHoles() const {return n2;}
-    uint pegToHole(uint peg) const {return A.at(peg).load();}
-    uint holeToPeg(uint hole) const {return invA.at(hole).load();}
-    void movePeg(uint peg, uint newHole) {
-        assert(invA[newHole].load() == n1);
-        const unsigned oldHole = A[peg].load();
-        A[peg].store(newHole);
-        invA[newHole].store(peg);
-        invA[oldHole].store(n1);
-    }
-    void swapPegs(uint peg1, uint peg2) {
-        const unsigned hole1 = A[peg1];
-        A[peg2].store(A[peg1].exchange(A[peg2].load()));
-    }
-#else
-    uint pegToHole(uint peg) const {return A[peg].load();}
-    void movePeg(uint peg, uint newHole) {A[peg].store(newHole);}
-    void swapPegs(uint peg1, uint peg2) {A[peg2].store(A[peg1].exchange(A[peg2].load()));}
-#endif
+    void loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName) {}; // TODO
 
 private:
-    unsigned n1;
-    unsigned n2;
     vector<atomic_uint> A;
-
-#ifdef PREFERRED_HOLES
-    vector<atomic_uint> invA;
-#endif
 };
 
 #endif /* ALIGNMENT_HPP */

--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -22,29 +22,26 @@ class Alignment {
 public:
     Alignment();
     Alignment(const Alignment& alig);
-    Alignment &operator=(Alignment);
-    Alignment(const vector<uint>& mapping);
+    Alignment &operator=(const Alignment &); //TODO
+    Alignment(const vector<uint>& mapping, uint n2);
     Alignment(const Graph& G1, const Graph& G2, const vector<array<string, 2>>& edgeList);
 
     static Alignment loadEdgeList(const Graph& G1, const Graph& G2, const string& fileName);
-
     //list of pairs of aligned node names, but first node in each pair may be of G2
     static Alignment loadEdgeListUnordered(const Graph& G1, const Graph& G2, const string& fileName);
     static Alignment loadPartialEdgeList(const Graph& G1, const Graph& G2, const string& fileName, bool byName);
-    static Alignment loadMapping(const string& fileName);
+    static Alignment loadMapping(const string& fileName, unsigned n2);
     static Alignment randomColorRestrictedAlignment(const Graph& G1, const Graph& G2);
-    
-    void loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName);
+
+    // void loadAllowedPartners(const Graph& G1, const Graph& G2, const string& fileName);
 
     //returns a random alignment from a graph with n1 nodes to a graph with nodes n2 >= n1 nodes
     static Alignment random(uint n1, uint n2);
     static Alignment empty();
-    static Alignment identity(uint n);
 
     //returns an alignment of size n2 that is the inverse of this
     //value 'n1' is used as invalid mapping
-    Alignment reverse(uint n2) const;
-    uint whichPeg(const uint hole);
+    Alignment reverse(uint n2) const; //TODO
 
     //returns the correct alignment between G1 and G2 by looking at
     //their node names. it assumes that they have the same node names
@@ -60,34 +57,46 @@ public:
         return v;
     }
 
-    void set(uint node, uint value) {A[node].store(value);}
-    const uint getSafe(uint node) const {return A[node].load();}
-    void swap(uint node1, uint node2){A[node2].store(A[node1].exchange(A[node2].load()));}
-    const uint operator[](uint node) const {return A[node].load(memory_order_relaxed);} // This is for relaxed and casual access. No write access, nerds.
-    uint size() const {return A.size();}
-    void compose(const Alignment& other);
+    uint numOfPegs() const {return n1;}
+    void compose(const Alignment& other); // TODO
 
     uint computeNumAlignedEdges(const Graph& G1, const Graph& G2) const;
 
-    bool isCorrectlyDefined(const Graph& G1, const Graph& G2) const;
+    bool isCorrectlyDefined(const Graph& G1, const Graph& G2) const; // TODO
     void printDefinitionErrors(const Graph& G1, const Graph& G2) const;
 
-    unordered_set<uint>& allowedPegs(const uint hole) { return allowedHole2Peg[hole]; }
-    unordered_set<uint>& allowedHoles(const uint peg) { return allowedPeg2Hole[peg]; }
-    bool allowedPartnersEnabled(void) { return allowedPeg2Hole.size() || allowedHole2Peg.size(); }
-    bool isHappy(const uint peg, const uint hole) {
-	if(peg==(uint)(-1) || hole ==(uint)(-1)) return false;
-	assert(allowedPeg2Hole[peg].count(hole)==allowedHole2Peg[hole].count(peg));
-	return allowedPeg2Hole[peg].count(hole);
+    // This is for relaxed and casual access. No write access!
+    uint operator[](uint peg) const {return A[peg].load(memory_order_relaxed);}
+
+#ifdef PREFERRED_HOLES
+    uint numOfHoles() const {return n2;}
+    uint pegToHole(uint peg) const {return A.at(peg).load();}
+    uint holeToPeg(uint hole) const {return invA.at(hole).load();}
+    void movePeg(uint peg, uint newHole) {
+        assert(invA[newHole].load() == n1);
+        const unsigned oldHole = A[peg].load();
+        A[peg].store(newHole);
+        invA[newHole].store(peg);
+        invA[oldHole].store(n1);
     }
-    bool isHappyPeg (const uint peg ) { return isHappy(peg, A[peg]); }
-    bool isHappyHole(const uint hole) { return isHappy(whichPeg(hole), hole); }
+    void swapPegs(uint peg1, uint peg2) {
+        const unsigned hole1 = A[peg1];
+        A[peg2].store(A[peg1].exchange(A[peg2].load()));
+    }
+#else
+    uint pegToHole(uint peg) const {return A[peg].load();}
+    void movePeg(uint peg, uint newHole) {A[peg].store(newHole);}
+    void swapPegs(uint peg1, uint peg2) {A[peg2].store(A[peg1].exchange(A[peg2].load()));}
+#endif
+
 private:
+    unsigned n1;
+    unsigned n2;
     vector<atomic_uint> A;
-    // allowedPeg2Hole should basically be a set of entries of the form <G1node, set of G2 nodes>
-    // allowedHole2Peg is the inverse. Any node not listed is allowed to align anywhere
-    // NOTE: these are both GLOBAL to the Alignment class
-    static unordered_map<uint, unordered_set<uint>> allowedPeg2Hole, allowedHole2Peg;
+
+#ifdef PREFERRED_HOLES
+    vector<atomic_uint> invA;
+#endif
 };
 
 #endif /* ALIGNMENT_HPP */

--- a/src/Alignment.hpp
+++ b/src/Alignment.hpp
@@ -65,8 +65,8 @@ public:
     void swapPegs(uint peg1, uint peg2);
     void swapPegs(uint peg1, uint peg2, uint hole1, uint hole2);
 
-    uint pegToHole(uint peg) const {return pegsToHoles[peg].load();}
-    uint holeToPeg(uint hole) const {return holesToPegs[hole].load();}
+    uint pegToHole(uint peg) const {return pegsToHoles[peg].load(std::memory_order_relaxed);}
+    uint holeToPeg(uint hole) const {return holesToPegs[hole].load(std::memory_order_relaxed);}
     uint operator[](uint peg) const {return pegsToHoles[peg].load(memory_order_relaxed);} // No write access.
     uint numOfPegs() const {return pegNum;}
     uint numOfHoles() const {return holeNum;}

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <fcntl.h>
 #include <regex>
-#include <set>
 
 #ifdef __linux__
 #include <execinfo.h>
@@ -196,7 +195,8 @@ Graph Graph::nodeInducedSubgraph(const vector<unsigned>& nodes) const {
     newNodeNames.reserve(newN);
     vector<array<string, 2>> newNodeNameToColorName;
     bool hasDefColor = colorNames[0] == DEFAULT_COLOR_NAME; //if present, the default color is at index 0
-    for (const Node& node : this->nodes) {
+    for (unsigned i = 0; i < newN; ++i) {
+        const Node &node = this->nodes[nodes[i]];
         newNodeNames.push_back(node.nodeName);
         if (hasDefColor and node.colorID == 0) continue;
         newNodeNameToColorName.push_back({node.nodeName, node.colorName});
@@ -274,6 +274,7 @@ Graph Graph::graphIntersection(const Graph& other, const vector<unsigned>& thisT
 }
 
 #ifdef __linux__
+#ifdef GDB
 void print_stack_trace() {
     const unsigned max_frames = 64;
     void* callstack[max_frames];
@@ -281,10 +282,33 @@ void print_stack_trace() {
     char** symbols = backtrace_symbols(callstack, frames);
 
     for (unsigned i = 0; i < frames; ++i) {
-        std::cout << symbols[i] << std::endl;
+        string symbol(symbols[i]);
+        size_t start = symbol.find('(');
+        size_t end = symbol.find('+', start);
+
+        if (start != string::npos && end != string::npos && start < end) {
+            string mangled = symbol.substr(start + 1, end - start - 1);
+            int status = -1;
+
+            char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, 0, &status);
+
+            if (status == 0 && demangled) {
+                // Success: Print the module, the clean name, and the rest of the offset
+                cerr << symbol.substr(0, start + 1) << demangled
+                     << symbol.substr(end) << endl;
+                free(demangled);
+            } else {
+                // Demangling failed, just print what we have
+                cerr << symbol << endl;
+            }
+        } else {
+            // Not a standard format, print raw
+            cerr << symbol << endl;
+        }
     }
     free(symbols); // Free the memory allocated by backtrace_symbols
 }
+#endif
 #endif
 
 unique_ptr<vector<unsigned>> Graph::getAdjList(unsigned node) const {
@@ -293,9 +317,11 @@ unique_ptr<vector<unsigned>> Graph::getAdjList(unsigned node) const {
         cerr << "Warning, soon to deprecated getAdjList function was used. This should be fixed." <<endl;
         cerr << "It can cause issues if the output is dereferenced as a temporary object." <<endl;
         cerr << "It is also a poorly optimized compatibility function left over from SANA2.0. -Marcus" <<endl;
-        cerr << "If you are on Linux, you should shortly receive a stacktrace for this call..." <<endl;
+        cerr << "If you are on Linux and debugging, you should shortly receive a stacktrace for this call..." <<endl;
 #ifdef __linux__
+#ifdef GDB
         print_stack_trace();
+#endif
 #endif
         gaveWarning = true;
     }
@@ -311,7 +337,9 @@ unique_ptr<vector<vector<unsigned>>> Graph::getAdjLists() const {
         cerr << "NO ONE SHOULD BE USING Graph::getAdjLists() EVER! FIX YO CODE -Marcus" <<endl;
         cerr << "If you are on Linux, you should shortly receive a stacktrace for this offensive call..." <<endl;
 #ifdef __linux__
+#ifdef GDB
         print_stack_trace();
+#endif
 #endif
         gaveWarning = true;
     }
@@ -331,7 +359,9 @@ unique_ptr<vector<unsigned>> Graph::getInjList(unsigned node) const {
         cerr << "It is also a poorly optimized compatibility function left over from SANA2.0. -Marcus" <<endl;
         cerr << "If you are on Linux, you should shortly receive a stacktrace for this call..." <<endl;
 #ifdef __linux__
+#ifdef GDB
         print_stack_trace();
+#endif
 #endif
         gaveWarning = true;
     }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -7,7 +7,7 @@
 #include <regex>
 #include <set>
 
-#ifdef LINUX
+#ifdef __linux__
 #include <execinfo.h>
 #endif
 
@@ -273,7 +273,7 @@ Graph Graph::graphIntersection(const Graph& other, const vector<unsigned>& thisT
                  newNodeNames, {}, newNodeColorPairs); //unweighted result
 }
 
-#ifdef LINUX
+#ifdef __linux__
 void print_stack_trace() {
     const unsigned max_frames = 64;
     void* callstack[max_frames];
@@ -294,7 +294,7 @@ unique_ptr<vector<unsigned>> Graph::getAdjList(unsigned node) const {
         cerr << "It can cause issues if the output is dereferenced as a temporary object." <<endl;
         cerr << "It is also a poorly optimized compatibility function left over from SANA2.0. -Marcus" <<endl;
         cerr << "If you are on Linux, you should shortly receive a stacktrace for this call..." <<endl;
-#ifdef LINUX
+#ifdef __linux__
         print_stack_trace();
 #endif
         gaveWarning = true;
@@ -310,7 +310,7 @@ unique_ptr<vector<vector<unsigned>>> Graph::getAdjLists() const {
     if (!gaveWarning) {
         cerr << "NO ONE SHOULD BE USING Graph::getAdjLists() EVER! FIX YO CODE -Marcus" <<endl;
         cerr << "If you are on Linux, you should shortly receive a stacktrace for this offensive call..." <<endl;
-#ifdef LINUX
+#ifdef __linux__
         print_stack_trace();
 #endif
         gaveWarning = true;
@@ -330,7 +330,7 @@ unique_ptr<vector<unsigned>> Graph::getInjList(unsigned node) const {
         cerr << "It can cause issues if the output is dereferenced as a temporary object." <<endl;
         cerr << "It is also a poorly optimized compatibility function left over from SANA2.0. -Marcus" <<endl;
         cerr << "If you are on Linux, you should shortly receive a stacktrace for this call..." <<endl;
-#ifdef LINUX
+#ifdef __linux__
         print_stack_trace();
 #endif
         gaveWarning = true;
@@ -340,18 +340,8 @@ unique_ptr<vector<unsigned>> Graph::getInjList(unsigned node) const {
         injList->push_back(pair.first);
     return injList;}
 
-const vector<array<unsigned, 2>>* Graph::getEdgeList() const {
-    static bool gaveWarning = false;
-    if (!gaveWarning) {
-        cerr << "Warning, soon to deprecated getEdgeList function was used. This should be fixed." <<endl;
-        cerr << "It is a poorly optimized compatibility function left over from SANA2.0. -Marcus" <<endl;
-        cerr << "If you are on Linux, you should shortly receive a stacktrace for this call..." <<endl;
-#ifdef LINUX
-        print_stack_trace();
-#endif
-        gaveWarning = true;
-    }
-    return &edgeList;
+const vector<array<unsigned, 2>> &Graph::getEdgeList() const {
+    return edgeList;
 }
 
 const unordered_map<string, unsigned>* Graph::getNodeNameToIndexMap() const {

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -131,8 +131,8 @@ public:
     // Your bread and butter getter for interacting with the graph.
     const Node &deliverNode(unsigned nodeID) const {return nodes.at(nodeID);}
 
-    // Marcus: these should only ever be used rarely and only ever when you need ONE random access.
-    // Whenever possible, use deliverNode to receive and store the Node reference.
+    // These should only ever be used rarely and only ever when you need ONE random access.
+    // Whenever possible, use deliverNode to receive and store the Node reference. - ML
     EDGE_T getEdgeWeight(unsigned node1, unsigned node2) const {
         const MAP_TYPE &adjList = nodes.at(node1).adjList;
         const auto it = adjList.find(node2);
@@ -157,7 +157,7 @@ public:
     unique_ptr<vector<unsigned>> getAdjList(unsigned node) const;
     unique_ptr<vector<vector<unsigned>>> getAdjLists() const; // THIS REALLY SHOULD NOT BE USED
     unique_ptr<vector<unsigned>> getInjList(unsigned node) const;
-    const vector<array<unsigned, 2>>* getEdgeList() const;
+    const vector<array<unsigned, 2>> &getEdgeList() const;
     const unordered_map<string,unsigned>* getNodeNameToIndexMap() const;
 
     //things that are computed when called

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -30,7 +30,7 @@ void Report::saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
 
     cout<<"Saving report as \""<<fileName<<"\""<<endl;
     ofstream ofs(fileName);
-    for (uint i = 0; i < A.size(); i++) ofs<<A[i]<<" ";
+    for (uint i = 0; i < A.numOfPegs(); i++) ofs<<A[i]<<" ";
     ofs<<endl;
     ofs << endl << currentDateTime() << endl;
     ofs << "Seed: " << getRandomSeed() << endl;
@@ -280,7 +280,7 @@ void Report::reportAll(const Graph& G1, const Graph& G2, const Alignment& A,
 
     cout << "Saving " << "alignment " + to_string(num) << " report in \"" << baseName + ".out" << "\"" << endl;
     outOfs << "This is alignment " + to_string(num) << endl;
-    for (uint i = 0; i < A.size(); i++) outOfs << A[i] << " ";
+    for (uint i = 0; i < A.numOfPegs(); i++) outOfs << A[i] << " ";
     outOfs << endl;
     outOfs << endl << currentDateTime() << endl;
     outOfs << "Seed: " << getRandomSeed() << endl;

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -22,7 +22,7 @@ void Report::saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
     saveAlignmentAsEdgeList(A, G1, G2, aligFileName);
 
     if (longVersion) {
-        Graph CS = G1.graphIntersection(G2, A.asVector());
+        Graph CS = G1.graphIntersection(G2, A.copyPegsToHoles());
         string aligGraphFileName = baseName+".ccs-el";
         cout<<"Saving common subgraph in edge list format as \""<<aligGraphFileName<<"\""<<endl;
         GraphLoader::saveInEdgeListFormat(CS, aligGraphFileName, false, true, "", " ");        
@@ -75,7 +75,7 @@ void Report::saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
 	Timer T3;
 	T3.start();  
 	ofs << "Common subgraph:" << endl;
-	Graph CS = G1.graphIntersection(G2, A.asVector());
+	Graph CS = G1.graphIntersection(G2, A.copyPegsToHoles());
 	printGraphStats(CS, numCCsToPrint, ofs);
 	auto CCs = CS.connectedComponents();
 	uint numCCs = CCs.size();
@@ -86,18 +86,18 @@ void Report::saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
 	table[0][6] = "ICS"; table[0][7] = "S3"; table[0][8] = "JS";
 
 	table[1][0] = "G1"; table[1][1] = to_string(G1.getNumNodes()); table[1][2] = to_string(G1.getNumEdges());
-	table[1][3] = to_string(A.computeNumAlignedEdges(G1, G2)); table[1][4] = to_string(G2.numEdgesInNodeInducedSubgraph(A.asVector()));
+	table[1][3] = to_string(A.computeNumAlignedEdges(G1, G2)); table[1][4] = to_string(G2.numEdgesInNodeInducedSubgraph(A.copyPegsToHoles()));
 	table[1][5] = to_string(M.eval("ec",A));
 	table[1][6] = to_string(M.eval("ics",A)); table[1][7] = to_string(M.eval("s3",A)); table[1][8] = to_string(M.eval("js", A));
 
 	for (int i = 0; i < tableRows-2; i++) {
 	    Graph H = CS.nodeInducedSubgraph(CCs[i]);
-	    Alignment newA(CCs[i]);
+	    Alignment newA(CCs[i], G2.getNumNodes());
 	    newA.compose(A);
 	    table[i+2][0] = "CCS_"+to_string(i); table[i+2][1] = to_string(H.getNumNodes());
 	    table[i+2][2] = to_string(H.getNumEdges());
 	    table[i+2][3] = to_string(newA.computeNumAlignedEdges(H, G2));
-	    table[i+2][4] = to_string(G2.numEdgesInNodeInducedSubgraph(newA.asVector()));
+	    table[i+2][4] = to_string(G2.numEdgesInNodeInducedSubgraph(newA.copyPegsToHoles()));
 	    EdgeCorrectness ec(&H, &G2, 1);
 	    table[i+2][5] = to_string(ec.eval(newA));
 	    InducedConservedStructure ics(&H, &G2);
@@ -131,7 +131,7 @@ void Report::saveReport(const Graph& G1, const Graph& G2, const Alignment& A,
                     ofs << '\t' << fullCount;
                     vector<uint> localNodes(G1.nodesAround(nodes[i], d));
                     Graph H = CS.nodeInducedSubgraph(localNodes);
-                    Alignment localA(localNodes);
+                    Alignment localA(localNodes, G2.getNumNodes());
                     localA.compose(A);
                     SymmetricSubstructureScore s3(&H, &G2);
                     ofs << '\t' << to_string(s3.eval(localA));
@@ -325,7 +325,7 @@ void Report::reportAll(const Graph& G1, const Graph& G2, const Alignment& A,
 	Timer T3;
 	T3.start();
 	outOfs << "Common subgraph:" << endl;
-	Graph CS = G1.graphIntersection(G2, A.asVector());
+	Graph CS = G1.graphIntersection(G2, A.copyPegsToHoles());
 	printGraphStats(CS, numCCsToPrint, outOfs);
 	auto CCs = CS.connectedComponents();
 	uint numCCs = CCs.size();
@@ -336,18 +336,18 @@ void Report::reportAll(const Graph& G1, const Graph& G2, const Alignment& A,
 	table[0][6] = "ICS"; table[0][7] = "S3"; table[0][8] = "JS";
 
 	table[1][0] = "G1"; table[1][1] = to_string(G1.getNumNodes()); table[1][2] = to_string(G1.getNumEdges());
-	table[1][3] = to_string(A.computeNumAlignedEdges(G1, G2)); table[1][4] = to_string(G2.numEdgesInNodeInducedSubgraph(A.asVector()));
+	table[1][3] = to_string(A.computeNumAlignedEdges(G1, G2)); table[1][4] = to_string(G2.numEdgesInNodeInducedSubgraph(A.copyPegsToHoles()));
 	table[1][5] = to_string(M.eval("ec", A));
 	table[1][6] = to_string(M.eval("ics", A));table[1][7] = to_string(M.eval("s3", A));table[1][8] = to_string(M.eval("js", A));
 
 	for (int i = 0; i < tableRows - 2; i++) {
 	    Graph H = CS.nodeInducedSubgraph(CCs[i]);
-	    Alignment newA(CCs[i]);
+	    Alignment newA(CCs[i], G2.getNumNodes());
 	    newA.compose(A);
 	    table[i+2][0] = "CCS_"+to_string(i); table[i+2][1] = to_string(H.getNumNodes());
 	    table[i+2][2] = to_string(H.getNumEdges());
 	    table[i+2][3] = to_string(newA.computeNumAlignedEdges(H, G2));
-	    table[i+2][4] = to_string(G2.numEdgesInNodeInducedSubgraph(newA.asVector()));
+	    table[i+2][4] = to_string(G2.numEdgesInNodeInducedSubgraph(newA.copyPegsToHoles()));
 	    EdgeCorrectness ec(&H, &G2, 1);
 	    table[i+2][5] = to_string(ec.eval(newA));
 	    InducedConservedStructure ics(&H, &G2);
@@ -381,7 +381,7 @@ void Report::reportAll(const Graph& G1, const Graph& G2, const Alignment& A,
                     outOfs << '\t' << fullCount;
                     vector<uint> localNodes(G1.nodesAround(nodes[i], d));
                     Graph H = CS.nodeInducedSubgraph(localNodes);
-                    Alignment localA(localNodes);
+                    Alignment localA(localNodes, G2.getNumNodes());
                     localA.compose(A);
                     SymmetricSubstructureScore s3(&H, &G2);
                     outOfs << '\t' << to_string(s3.eval(localA));

--- a/src/arguments/GraphLoader.cpp
+++ b/src/arguments/GraphLoader.cpp
@@ -158,10 +158,10 @@ pair<Graph,Graph> GraphLoader::initGraphs(ArgumentParser& args) {
         vector<EDGE_T> g2Weights;
         if (g2HasWeights) {
             g2Weights.reserve(G2->getNumEdges());
-            for (const auto& edge : *(G2->getEdgeList()))
+            for (const auto& edge : G2->getEdgeList())
                 g2Weights.push_back(G2->getEdgeWeight(edge[0], edge[1]));
         }
-        G2.reset(new Graph(G2->directed, G2->getName(), G2->getFilePath(), *(G2->getEdgeList()), g2NodeNames, g2Weights, g2Colors));
+        G2.reset(new Graph(G2->directed, G2->getName(), G2->getFilePath(), G2->getEdgeList(), g2NodeNames, g2Weights, g2Colors));
     }
 
     string path1 = args.strings["-pathmap1"], path2 = args.strings["-pathmap2"];
@@ -224,7 +224,7 @@ void GraphLoader::saveInGWFormat(const Graph& G, const string& outFile, bool sav
     ofs << G.getNumNodes() << endl;
     for (const auto& name : G.getNodeNames()) ofs << "|{" << name << "}|" << endl;
     ofs << G.getNumEdges() << endl;
-    for (const auto& edge : *(G.getEdgeList())) {
+    for (const auto& edge : G.getEdgeList()) {
         ofs << edge[0]+1 << " " << edge[1]+1 << " 0 |{"; //re-indexing to 1-based
         if (saveWeights) ofs << +G.getEdgeWeight(edge[0], edge[1]); //the + makes it print as a number even if it has type char/bool
         ofs << "}|" << endl;
@@ -236,8 +236,8 @@ void GraphLoader::saveInEdgeListFormat(const Graph& G, const string& outFile, bo
                                        const string& headerLine, const string& sep) {
     ofstream ofs(outFile);
     if (headerLine.size() != 0) ofs<<headerLine<<endl;
-    const vector<array<uint, 2>>* edges = G.getEdgeList();
-    for (const auto& edge : *edges) {
+    const vector<array<uint, 2>> &edges = G.getEdgeList();
+    for (const auto& edge : edges) {
         if (namedEdges) ofs<<G.getNodeName(edge[0])<<sep<<G.getNodeName(edge[1]);
         else ofs<<edge[0]<<sep<<edge[1];
         if (weightColumn) ofs<<sep<<+G.getEdgeWeight(edge[0], edge[1]); //the + makes it print as a number even if it has type char/bool

--- a/src/arguments/MethodSelector.cpp
+++ b/src/arguments/MethodSelector.cpp
@@ -124,7 +124,7 @@ SANAThree* MethodSelector::initSANA(const Graph& G1, const Graph& G2,
     if (goldilocksMethodName == "comparison") {
         Alignment startAlig;
         if (startAligName != "") startAlig = Alignment::loadEdgeList(G1, G2, startAligName);
-        if (allowedPartnersName != "") startAlig.loadAllowedPartners(G1, G2, allowedPartnersName);
+        // if (allowedPartnersName != "") startAlig.loadAllowedPartners(G1, G2, allowedPartnersName);
         SANAThree sana(&G1, &G2, 0.0, 0.0, 0, 0, 0.0, 0, &M,
                   args.strings["-combinedScoreAs"], startAlig, "", "", args.doubles["-maxthreads"]);
         goldilocksMethodComparison(&sana);
@@ -163,7 +163,7 @@ SANAThree* MethodSelector::initSANA(const Graph& G1, const Graph& G2,
 
     Alignment startAlig;
     if (startAligName != "") startAlig = Alignment::loadEdgeList(G1, G2, startAligName);
-    if (allowedPartnersName != "") startAlig.loadAllowedPartners(G1, G2, allowedPartnersName);
+    // if (allowedPartnersName != "") startAlig.loadAllowedPartners(G1, G2, allowedPartnersName);
 
     SANAThree* sana = new SANAThree(&G1, &G2, TInitial, TDecay, maxSeconds, maxIterations, tolerance,
         args.bools["-add-hill-climbing"], &M, args.strings["-combinedScoreAs"],

--- a/src/arguments/measureSelector.cpp
+++ b/src/arguments/measureSelector.cpp
@@ -330,7 +330,7 @@ void initMeasures(MeasureCombination& M, const Graph& G1, const Graph& G2, Argum
     }
     else if (G1.hasSameNodeNamesAs(G2)) {
         Alignment a(Alignment::correctMapping(G1,G2));
-        vector<uint> mapping = a.asVector();
+        vector<uint> mapping = a.copyPegsToHoles();
         mapping.push_back(G1.getNumNodes()); //storing the size at the end of the alignment is insane -Nil
         double ncWeight = 0;
         try{  ncWeight = getWeight("nc", G1, G2, args); }

--- a/src/complementaryProteins.cpp
+++ b/src/complementaryProteins.cpp
@@ -36,8 +36,8 @@ vector<vector<string>> getProteinPairs(string complementStatus, bool BioGRIDNetw
 }
 
 vector<vector<string>> getAlignedPairs(const Graph& G1, const Graph& G2, const Alignment& A) {
-    vector<vector<string>> res(A.size(), vector<string> (2));
-    for (uint i = 0; i < A.size(); i++) {
+    vector<vector<string>> res(A.numOfPegs(), vector<string> (2));
+    for (uint i = 0; i < A.numOfPegs(); i++) {
         res[i][0] = G1.getNodeName(i);
         res[i][1] = G2.getNodeName(A[i]);
     }

--- a/src/goldilocksmethods/goldilocksUtils.cpp
+++ b/src/goldilocksmethods/goldilocksUtils.cpp
@@ -38,7 +38,7 @@ void goldilocksMethodComparison(SANAThree *const sana) {
     params.runsPerMethod = 30;
     params.maxResources.numSamples = 60;
     params.maxResources.runtime = 120.0;
-    //params.sampleTime = 4; //max time in seconds for getPBad to reach equilibrium
+    params.sampleTime = 60; //max time in seconds for getPBad to reach equilibrium
     params.errorTol = 0.9; // units in the last place, eg for 0.99 its 0.985 to 0.995, and for 1e-10 it's 5e-11 to 1.5e10.
     params.numValidationSamples = 50; //set to a high value for final experiment (30?)
             //to find the *real* pBad at the temperatures given by the methods

--- a/src/measures/EdgeDifference.cpp
+++ b/src/measures/EdgeDifference.cpp
@@ -18,7 +18,7 @@ double EdgeDifference::eval(const Alignment& A) {
 double EdgeDifference::getEdgeDifferenceSum(const Graph* G1, const Graph* G2, const Alignment &A) {
     double edgeDifferenceSum = 0;
     double c = 0; //use descriptive name please
-    for (const auto& edge : *(G1->getEdgeList())) {
+    for (const auto& edge : G1->getEdgeList()) {
        uint node1 = edge[0], node2 = edge[1];
        double y = abs(G1->getEdgeWeight(node1,node2) - G2->getEdgeWeight(A[node1],A[node2])) - c;
        double t = edgeDifferenceSum + y;

--- a/src/measures/EdgeGeoMean.cpp
+++ b/src/measures/EdgeGeoMean.cpp
@@ -33,8 +33,8 @@ static bool CmpEdge(EDGE_T w1, EDGE_T w2) { return (w1 > w2); }
 
 double EdgeGeoMean::computeDenom(const Graph* G1, const Graph* G2) {
     vector<EDGE_T> W1, W2;
-    for (const auto& edge : *(G1->getEdgeList())) W1.push_back(G1->getEdgeWeight(edge[0],edge[1]));
-    for (const auto& edge : *(G2->getEdgeList())) W2.push_back(G2->getEdgeWeight(edge[0],edge[1]));
+    for (const auto& edge : G1->getEdgeList()) W1.push_back(G1->getEdgeWeight(edge[0],edge[1]));
+    for (const auto& edge : G2->getEdgeList()) W2.push_back(G2->getEdgeWeight(edge[0],edge[1]));
     sort(W1.begin(), W1.end(), CmpEdge);
     sort(W2.begin(), W2.end(), CmpEdge);
     double sum = 0.0;
@@ -45,7 +45,7 @@ double EdgeGeoMean::computeDenom(const Graph* G1, const Graph* G2) {
 
 double EdgeGeoMean::getEdgeGeoMeanSum(const Graph* G1, const Graph* G2, const Alignment &A) {
     double sum = 0;
-    for (const auto& edge : *(G1->getEdgeList())) {
+    for (const auto& edge : G1->getEdgeList()) {
        uint node1 = edge[0], node2 = edge[1];
        if(G2->hasEdge(A[node1],A[node2]))
 	   sum += getEdgeScore(G1->getEdgeWeight(node1,node2), G2->getEdgeWeight(A[node1],A[node2]));
@@ -85,7 +85,6 @@ double EdgeGeoMean::computeIncSwapOp(uint peg1, uint peg2, uint hole1, uint hole
     if (peg1 == peg2) return 0;
     // Handle peg1
     double diff = 0;
-    double c = 0;
     auto pegAdj = G1->getAdjList(peg1);
     for (uint nbr : *pegAdj) {
         if(G2->hasEdge(hole1, A[nbr]))

--- a/src/measures/EdgeMin.cpp
+++ b/src/measures/EdgeMin.cpp
@@ -25,11 +25,11 @@ double EdgeMin::computeDenom() {
     double ew, sumG1=0, sumG2=0;
 
     // Sum edge weights of both graphs
-    for (const auto& edge : *(G1->getEdgeList())) {
+    for (const auto& edge : G1->getEdgeList()) {
 	ew = G1->getEdgeWeight(edge[0], edge[1]);
 	sumG1 += ew;
     }
-    for (const auto& edge : *(G2->getEdgeList())) {
+    for (const auto& edge : G2->getEdgeList()) {
 	ew = G2->getEdgeWeight(edge[0], edge[1]);
 	sumG2 += ew;
     }
@@ -98,7 +98,7 @@ double EdgeMin::computeSum(const Alignment &A) {
 #else
     int ai=0, aSize=G1->getNumEdges();
     assert(aSize <= MAX_A_ARRAY);
-    for (const auto& edge : *(G1->getEdgeList())) {
+    for (const auto& edge : G1->getEdgeList()) {
 	uint node1 = edge[0], node2 = edge[1];
 	a[ai++] = computeAligEdgeScore(node1, node2, A[node1], A[node2]);
 	// NOTE: We don't need to include the reverse edge here in the directed graph case, because *if* a reverse edge of

--- a/src/measures/EdgeMin.cpp
+++ b/src/measures/EdgeMin.cpp
@@ -255,9 +255,9 @@ double EdgeMin::computeIncSwapOp2(const uint peg1, const uint peg2, const uint h
     old +=       scoreOnePegSlow(peg2, peg1, hole2, A); // score out&in as above for peg2 EXCEPT if going to peg1
 
     // NOTE: we must PHYSICALLY swap peg1+peg2 in A, in order to correctly score the new position
-    A.swap(peg1, peg2);
+    A.swapPegs(peg1, peg2);
     double New = scoreOnePegSlow(peg2,noAvoid, hole1, A); // score outward and inward aligned edges of peg1
     New +=       scoreOnePegSlow(peg1,peg2,    hole2, A); // score out&in as above for peg2 EXCEPT if going to peg1
-    A.swap(peg1, peg2);
+    A.swapPegs(peg1, peg2);
     return New - old;
 }

--- a/src/measures/EdgeRatio.cpp
+++ b/src/measures/EdgeRatio.cpp
@@ -60,7 +60,7 @@ double EdgeRatio::computeSum(const Alignment &A) {
 #else
     int ai=0, aSize=G1->getNumEdges();
     assert(aSize <= MAX_A_ARRAY);
-    for (const auto& edge : *(G1->getEdgeList())) {
+    for (const auto& edge : G1->getEdgeList()) {
 	uint node1 = edge[0], node2 = edge[1];
 	a[ai++] = getAligEdgeScore(node1,node2,A[node1],A[node2]);
 	// We don't need to include the reverse edge here in the directed graph case, because *if* a reverse edge of

--- a/src/measures/ExternalWeightedEdgeConservation.cpp
+++ b/src/measures/ExternalWeightedEdgeConservation.cpp
@@ -14,7 +14,7 @@ ExternalWeightedEdgeConservation::ExternalWeightedEdgeConservation(
 
 double ExternalWeightedEdgeConservation::eval(const Alignment& A) {
     double score = 0;
-    for (const auto& edge: *(G1->getEdgeList())) {
+    for (const auto& edge: G1->getEdgeList()) {
         uint node1 = edge[0], node2 = edge[1];
         if (G2->hasEdge(A[node1], A[node2])) {
             string n1s = G1->getNodeName(node1), n2s = G1->getNodeName(node2);

--- a/src/measures/FMeasure.cpp
+++ b/src/measures/FMeasure.cpp
@@ -35,11 +35,11 @@ FMeasure::~FMeasure(){}
 
 double FMeasure::eval(const Alignment& A) {
     if(beta==inf){
-        return (double) A.computeNumAlignedEdges(*G1, *G2)/G2->numEdgesInNodeInducedSubgraph(A.asVector());
+        return (double) A.computeNumAlignedEdges(*G1, *G2)/G2->numEdgesInNodeInducedSubgraph(A.copyPegsToHoles());
     }
     double alignedEdges = A.computeNumAlignedEdges(*G1, *G2);
     double totalEdgesG1 = G1->getNumEdges();
-    double inducedEdgesG2 = G2->numEdgesInNodeInducedSubgraph(A.asVector());
+    double inducedEdgesG2 = G2->numEdgesInNodeInducedSubgraph(A.copyPegsToHoles());
 
     double numerator = (1 + beta * beta) * alignedEdges;
     double denominator = totalEdgesG1 + (beta * beta * inducedEdgesG2);

--- a/src/measures/InducedConservedStructure.cpp
+++ b/src/measures/InducedConservedStructure.cpp
@@ -8,5 +8,5 @@ InducedConservedStructure::~InducedConservedStructure() {
 }
 
 double InducedConservedStructure::eval(const Alignment& A) {
-    return (double) A.computeNumAlignedEdges(*G1, *G2)/G2->numEdgesInNodeInducedSubgraph(A.asVector());
+    return (double) A.computeNumAlignedEdges(*G1, *G2)/G2->numEdgesInNodeInducedSubgraph(A.copyPegsToHoles());
 }

--- a/src/measures/LargestCommonConnectedSubgraph.cpp
+++ b/src/measures/LargestCommonConnectedSubgraph.cpp
@@ -8,7 +8,7 @@ LargestCommonConnectedSubgraph::LargestCommonConnectedSubgraph(const Graph* G1, 
 LargestCommonConnectedSubgraph::~LargestCommonConnectedSubgraph() {}
 
 double LargestCommonConnectedSubgraph::eval(const Alignment& A) {
-    Graph CS = G1->graphIntersection(*G2, A.asVector());
+    Graph CS = G1->graphIntersection(*G2, A.copyPegsToHoles());
     vector<uint> LCCSNodes = (CS.connectedComponents())[0]; //largest CC
     uint n = LCCSNodes.size();
     double N = (double) n/G1->getNumNodes();

--- a/src/measures/MeasureCombination.cpp
+++ b/src/measures/MeasureCombination.cpp
@@ -300,7 +300,7 @@ void MeasureCombination::writeLocalScores(ostream& ofs,
             }
         }
     } else { // output only aligned pairs
-        for(uint i = 0; i < A.size(); ++i) {
+        for(uint i = 0; i < A.numOfPegs(); ++i) {
             edgeStream<<G1.getNodeName(i)<<"\t"<<G2.getNodeName(A[i]);
             ofs<<setw(COL_WIDTH)<<edgeStream.str();
             edgeStream.str("");

--- a/src/measures/MultiS3.cpp
+++ b/src/measures/MultiS3.cpp
@@ -464,7 +464,7 @@ double MultiS3::eval(const Alignment& A) {
 void MultiS3::initDegrees(const Alignment& A, const Graph& G1, const Graph& G2) {
     shadowDegree = vector<uint>(G2.getNumNodes(), 0);
     for (uint i = 0; i < G2.getNumNodes(); i++) shadowDegree[i] = G2.getNumNbrs(i);
-    for (const auto& edge : *(G2.getEdgeList())) {
+    for (const auto& edge : G2.getEdgeList()) {
         auto w = G2.getEdgeWeight(edge[0],edge[1]);
         shadowDegree[edge[0]] += w; // doesn't this overcount by 1 since we already set it to getNumNbrs(i) above?
         if (edge[0] != edge[1]) shadowDegree[edge[1]] += w; //avoid double-counting for self-lopos

--- a/src/measures/NodeCorrectness.cpp
+++ b/src/measures/NodeCorrectness.cpp
@@ -9,7 +9,7 @@ NodeCorrectness::~NodeCorrectness() {}
 
 double NodeCorrectness::eval(const Alignment& A) {
     uint count = 0;
-    for (uint i = 0; i < A.size(); i++) {
+    for (uint i = 0; i < A.numOfPegs(); i++) {
         if (A[i] == trueAWithValidCountAppended[i]) count++;
     }
     return (double) count / trueAWithValidCountAppended.back();

--- a/src/measures/SymmetricSubstructureScore.cpp
+++ b/src/measures/SymmetricSubstructureScore.cpp
@@ -10,5 +10,5 @@ SymmetricSubstructureScore::~SymmetricSubstructureScore() {
 double SymmetricSubstructureScore::eval(const Alignment& A) {
     double aligEdges = A.computeNumAlignedEdges(*G1, *G2);
     return aligEdges / 
-        (G1->getNumEdges() + G2->numEdgesInNodeInducedSubgraph(A.asVector()) - aligEdges);
+        (G1->getNumEdges() + G2->numEdgesInNodeInducedSubgraph(A.copyPegsToHoles()) - aligEdges);
 }

--- a/src/measures/WeightedEdgeConservation.cpp
+++ b/src/measures/WeightedEdgeConservation.cpp
@@ -15,7 +15,7 @@ LocalMeasure* WeightedEdgeConservation::getNodeSimMeasure() {
 double WeightedEdgeConservation::eval(const Alignment& A) {
     vector<vector<float>>* simMatrix = nodeSim->getSimMatrix();
     double score = 0;
-    for (const auto& edge: *(G1->getEdgeList())) {
+    for (const auto& edge: G1->getEdgeList()) {
         uint node1 = edge[0], node2 = edge[1];
         if (G2->hasEdge(A[node1],A[node2])) {
             score += (*simMatrix)[node1][A[node1]];

--- a/src/measures/localMeasures/Importance.cpp
+++ b/src/measures/localMeasures/Importance.cpp
@@ -79,7 +79,7 @@ vector<double> Importance::getImportances(const Graph& G) {
 
     uint n = G.getNumNodes();
     vector<vector<double>> edgeWeights(n, vector<double> (n, 0));
-    for (const auto& edge : *(G.getEdgeList())) {
+    for (const auto& edge : G.getEdgeList()) {
         edgeWeights[edge[0]][edge[1]] = 1;
         edgeWeights[edge[1]][edge[0]] = 1;
     }

--- a/src/methods/BatchHarvester.cpp
+++ b/src/methods/BatchHarvester.cpp
@@ -13,7 +13,6 @@
 #include <cassert>
 #include <csignal>
 #include <cstdio>
-#include <unistd.h>
 
 #include "SANAThree.hpp"
 #include "BatchHarvester.hpp"
@@ -21,170 +20,170 @@
 
 #define DEBUG_HARVESTER 0
 
+/// Returns the probability that a bad move will be accepted.
+///
+/// # Parameters:
+///
+/// const double energyInc: the score improvement of a potential change.
+///
+/// const double temperature: the annealing temperature, higher temperature -> bad change more likely
 double static inline acceptingProbability(const double energyInc, const double temperature) {
-    if (temperature == 0.) return energyInc >= 0;
-    return energyInc >= 0 ? 1 : exp(energyInc / temperature);
+    if (temperature == 0.) // Float comparisons are definitely a bad practice. -ML
+        return energyInc >= 0; // Bool coerced into 0.0 and 1.0. Probably a bad practice - ML
+    return energyInc >= 0 ? 1 : exp(energyInc / temperature); // Potential for -inf here, but exp(-inf) = 0 -ML
 }
 
-#define SCORE_BATCH_SIZE 31
+#define SCORE_BATCH_SIZE 31 // TODO: Borrowed from SANA 2.0. This should probably be looked at -ML
 SANAThree::BatchHarvester::BatchHarvester(const unsigned threadNumber, SANAThree &SANA, unsigned long long bufferSize):
     parent(SANA),
     daughterNum(threadNumber),
-    temperature(0.),
     startedRequests(0),
     finishedRequests(0),
-    numPBad(0),
-    scoreBuffer(SCORE_BATCH_SIZE),
-    pBadBuffer(bufferSize) {
+	currentState(State::pause),
+	daughtersPaused(0),
+	daughtersTerminated(0),
+	totalScore(0.0),
+	totalPBad(0.0),
+    numTotalPBad(0),
+    temperature(0.),
+    scoreCircBuffer(SCORE_BATCH_SIZE),
+    pBadCircBuffer(bufferSize) {
+    unique_lock<mutex> stateLock(stateMutex);
 
-    unique_lock<mutex> stateLock(stateMutex); // Overkill, but I am trying to set a good example to you youngsters
-    currentState = State::pause; // We DO NOT want threads to start calculations yet.
-    daughtersPaused = 0;
-    daughtersTerminated = 0;
-    stateLock.unlock();
-
-    unique_lock<mutex> outputLock(outputMutex);
-    totalEnergy = 0.; // Not strictly required, every function will reset these as necessary anyway
-    totalPBad = 0.;
-    outputLock.unlock();
-
-    numPBad = 0;
-
+    // Seed an initial generator to provide seeds for the daughter threads.
     mt19937_64 generator(random_device{}());
 
+    // Debug
     cerr << "HI THERE! BatchHarvester is using " << threadNumber << " threads\n";
+    if (threadNumber == 0)
+        throw runtime_error("Thread number must be > 0");
 
-    if (threadNumber == 0) throw runtime_error("Thread number must be > 0");
+	// Cast out the necessary number of threads
     threadVector.reserve(threadNumber);
-    stateLock.lock();
     for (unsigned i = 0; i < threadNumber; ++i) {
         threadVector.emplace_back(&BatchHarvester::daughterFunction, this, generator());
     }
-    handlerCondition.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
 
-#if DEBUG_HARVESTER
-    assert(daughtersPaused == daughterNum);
-#endif
+    // Wait for all daughter to pause before exiting constructor.
+    waitMom.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
+	#if DEBUG_HARVESTER
+	    assert(daughtersPaused == daughterNum);
+	#endif
 }
 
-SANAThree::BatchHarvester::~BatchHarvester(){
+// I greatly dislike destructors that are nontrivial, but I do not see a way around it. -ML
+SANAThree::BatchHarvester::~BatchHarvester() {
     unique_lock<mutex> stateLock(stateMutex); // Lock state access
-    currentState = State::terminate; // Set the state to class termination
-    if (daughtersPaused > 0) { // Check if any daughters are paused and wake them if they are
-        daughtersPaused = 0;
-        pausedCondition.notify_all();
-    }
-    handlerCondition.wait(stateLock, [this]{return daughtersTerminated == daughterNum;}); // Wait for all daughters to terminate
-    assert(daughtersTerminated == daughterNum); // This thread should only be woken if all daughters are terminated
-    for (thread& t: threadVector) t.join(); // Join all threads
+
+	// The order here is extremely important or else you will get a data race.
+	// My recommendation is that you do not touch this unless you really know what you are doing.
+	// -ML
+
+	// Set the state to termination and wake up any paused daughter threads.
+	activateDaughters(State::terminate);
+
+    // Wait for all daughters to terminate
+    waitMom.wait(stateLock, [this]{return daughtersTerminated == daughterNum;});
+
+    // This thread should only be successfully woken if all daughters are terminated
+	// If not, then we have a memory leak.
+    assert(daughtersTerminated == daughterNum);
+
+    // Join all threads
+    for (thread& t: threadVector)
+        t.join();
 }
 
 double SANAThree::BatchHarvester::runUntilEquilibrium(double temperature, unsigned timeoutSeconds) {
-    unique_lock<mutex> stateLock(stateMutex);
-    unique_lock<mutex> outputLock(outputMutex, defer_lock);
+	unique_lock<mutex> stateLock(stateMutex); // Held
 
-#if DEBUG_HARVESTER
-    // Are we in a valid state? Did someone forget to clean up?
-    assert(currentState == State::pause);
-    assert(daughtersPaused == daughterNum);
-    assert(daughtersTerminated == 0);
-    stateLock.unlock();
-    // Reset everything in case someone somehow collected a traditional annealing batch before this equilibrium run
-    outputLock.lock();
-    scoreBuffer.resetBuffer();
-    pBadBuffer.resetBuffer();
-    outputLock.unlock();
+	resetCounters();
+
+	#if DEBUG_HARVESTER
+	    // Are we in a valid state? Did someone forget to clean up?
+	    assert(currentState == State::pause);
+	    assert(daughtersPaused == daughterNum);
+	    assert(daughtersTerminated == 0);
+	#endif
+
+	// bufferLock and stateLock should generally NOT be held at the same time.
+	stateLock.unlock();
+
+	unique_lock<mutex> bufferLock(bufferMutex);
+		resetBuffers();
+    bufferLock.unlock();
+
     stateLock.lock();
-#endif
 
-    chrono::duration<double> duration;
-    bool timedOut = false;
+	// Set all daughters loose to equilibrate at this temperature.
+	this->temperature = temperature;
+    activateDaughters(State::equilibrate);
 
-    this->temperature.store(temperature);
-    currentState = State::equilibrate;
-    daughtersPaused = 0;
-    pausedCondition.notify_all();
-    const auto originalTime = chrono::steady_clock::now();
-    if(!handlerCondition.wait_for(stateLock, chrono::seconds(timeoutSeconds), [this]{return daughtersPaused==daughterNum;})) {
-        // Clean up for an early wake.
-        duration = chrono::steady_clock::now() - originalTime;
+	bool timedOut = false;
+	const auto originalTime = chrono::steady_clock::now();
+	// Wait for all daughters to pause unless we time out.
+    if(!waitMom.wait_for(stateLock, chrono::seconds(timeoutSeconds), [this]{return daughtersPaused == daughterNum;})) {
+        // Clean up if we time out.
         timedOut = true;
         currentState = State::pause;
-        handlerCondition.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
+    	// Wait for all daughters to pause.
+        waitMom.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
     }
-    else {
-        duration = chrono::steady_clock::now() - originalTime;
-    }
-#if DEBUG_HARVESTER
-    // We should be safe to unpause and unlock the state
-    assert(currentState == State::pause);
-    assert(daughtersPaused == daughterNum);
-#endif
+	#if DEBUG_HARVESTER
+	    // We should be safe to unpause and unlock the state
+	    assert(currentState == State::pause);
+	    assert(daughtersPaused == daughterNum);
+	#endif
+
+	// Unlock the state, as no more state modifications will be done.
     stateLock.unlock();
 
-    outputLock.lock();
-    // Terminal output
-    const double answer = recentPBadTrue();
-    cout<<"> getEquilibriumPBadAtTemp("<<temperature<<") = "<<answer<<" (score: "<<parent.currentScore<<")"
-    <<" (time: "<<duration.count()<<"s)"
+	// Terminal output of answer.
+    bufferLock.lock();
+	const chrono::duration<double> equilibriumDuration = chrono::steady_clock::now() - originalTime;
+    const double pBadAnswer = pBadCircBuffer.accurateAverage();
+    cout<<"> getEquilibriumPBadAtTemp("<<temperature<<") = "<<pBadAnswer<<" (score: "<<parent.currentScore<<")"
+    <<" (time: "<<equilibriumDuration.count()<<"s)"
     << (timedOut? "[TIMED OUT]" : "")
     <<" iterations = "<< finishedRequests
-    <<", ips = "<< static_cast<double>(finishedRequests) / duration.count() <<endl
+    <<", ips = "<< static_cast<double>(finishedRequests) / equilibriumDuration.count() <<endl
     <<"****************************************"<<endl<<endl;
 
-    // Clean up
-    startedRequests.store(0);
-    finishedRequests.store(0);
-    scoreBuffer.resetBuffer();
-    pBadBuffer.resetBuffer();
-
-    return answer;
+    return pBadAnswer;
 }
 
 SANAThree::batchOutput SANAThree::BatchHarvester::collectBatch(double temperature) {
-    unique_lock<mutex> stateLock(stateMutex);
-    unique_lock<mutex> outputLock(outputMutex, defer_lock);
+    unique_lock<mutex> stateLock(stateMutex); // Held whenever not waiting
 
-#if DEBUG_HARVESTER
-    // Are we in a valid state? Did someone forget to clean up? This entire section can be removed if it is never
-    assert(currentState == State::pause);
-    assert(daughtersPaused == daughterNum);
-    assert(daughtersTerminated == 0);
-    stateLock.unlock();
-    assert(startedRequests == 0); // Atomics don't require locks
-    assert(finishedRequests == 0);
-    outputLock.lock();
-    assert(totalEnergy == 0);
-    assert(totalPBad == 0);
-    assert(numPBad == 0);
-    outputLock.unlock();
-    stateLock.lock();
-#endif
+	#if DEBUG_HARVESTER
+	    // Are we in a valid state? Did someone forget to clean up?
+	    assert(currentState == State::pause);
+	    assert(daughtersPaused == daughterNum);
+	    assert(daughtersTerminated == 0);
+	#endif
 
-    this->temperature.store(temperature);
-    currentState = State::anneal;
-    daughtersPaused = 0;
-    pausedCondition.notify_all();
-    handlerCondition.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
-#if DEBUG_HARVESTER
-    // We should be safe to unpause and unlock the state
-    assert(currentState == State::pause);
-    assert(daughtersPaused == daughterNum);
-    assert(finishedRequests == parent.batchSize);
-    assert(startedRequests >= parent.batchSize);
-#endif
-    // ReSharper disable once CppDFAUnreachableCode
-    stateLock.unlock();
+	// Reset global counters and outputs.
+	resetCounters();
 
-    outputLock.lock();
-    startedRequests.store(0);
-    finishedRequests.store(0);
-    if (numPBad == 0) ++numPBad;
-    const double averageScore = totalEnergy / parent.batchSize;
-    const double averagePBad = totalPBad / numPBad;
-    totalEnergy = 0;
-    totalPBad = 0;
-    numPBad = 0;
+	// Send daughters loose at this temperature annealing.
+    this->temperature = temperature;
+    activateDaughters(State::anneal);
+
+	// Wait for all daughters to pause.
+    waitMom.wait(stateLock, [this]{return daughtersPaused == daughterNum;});
+
+	#if DEBUG_HARVESTER
+	    // We should be safe to unpause and unlock the state
+	    assert(currentState == State::pause);
+	    assert(daughtersPaused == daughterNum);
+	    assert(finishedRequests == parent.batchSize);
+	    assert(startedRequests >= parent.batchSize);
+	#endif
+
+    if (numTotalPBad == 0)
+    	++numTotalPBad;
+    const double averageScore = totalScore / finishedRequests.load();
+    const double averagePBad = totalPBad / numTotalPBad;
 
     return {averageScore, averagePBad};
 }
@@ -193,112 +192,152 @@ SANAThree::batchOutput SANAThree::BatchHarvester::collectBatch(double temperatur
 void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
     mt19937_64 generator(seed);
 
-    cerr << "DAUGHTER FUNCTION HERE\n" ;;
+    unique_lock<mutex> bufferLock(bufferMutex, defer_lock); // Defer
+    unique_lock<mutex> stateLock(stateMutex); // Held
 
-    unique_lock<mutex> outputLock(outputMutex, defer_lock);
-    unique_lock<mutex> stateLock(stateMutex);
+	// To prevent needing more mutex use, we collect these stats on the stack and then forward them
+	// to the Mom thread when we pause
+	double collectedScore = 0.0;
+	double collectedPBad = 0.0;
+	uint64_t processedPBad = 0;
 
+	// Store these locally on the stack.
+	double temperature = this->temperature;
+	const unsigned batchSize = parent.batchSize;
+
+	// Main state loop.
     // After every operation is complete, the function returns to check the current state of the Harvester
-    int whileCount=0;
     while (true) {
-	switch (currentState) { // Always enter with state locked
-        case State::anneal: {
-            stateLock.unlock();
-            if (startedRequests++ >= parent.batchSize) {
-                stateLock.lock();
-                currentState = State::pause;
-                continue;
-            }
-            // Part 1, select request to process
-            changeRequest currentRequest = parent.chooseNextRequest(generator);
+    // CRITICAL: We always enter this switch statement with the stateLock held -ML
+	switch (currentState) {
 
-            // Part 2, assess request
-            assessChange(currentRequest);
-            const double pBad = acceptingProbability(currentRequest.energyInc, temperature);
+		// For this state, all daughters pause operations until Mom tells them to start again.
+		case State::pause: {
 
-            // Part 3, implement (or don't implement) request
-            const double newScore = parent.implementLastRequest(pBad, currentRequest, generator);
+			// Give the Mom thread our results
+			totalScore += collectedScore;
+			totalPBad += collectedPBad;
+			numTotalPBad += collectedPBad;
 
-            // Part 4, record the results
-            outputLock.lock();
-            totalEnergy += newScore;
-            if (currentRequest.energyInc < 0) {
-                totalPBad += pBad;
-                pBadBuffer.insert(pBad);
-                ++numPBad;
-            }
-            outputLock.unlock();
+			// If all daughter threads are paused, then the Mom thread is alerted
+			if (++daughtersPaused == daughterNum)
+				waitMom.notify_all();
 
-            ++finishedRequests;
-            stateLock.lock();
-	    break;
-        }
+			// Now we wait until we told that daughter threads should be unpaused.
+			// A condition is required here because the C++ standard does not guarantee that a
+			// thread will never be woken up without our code asking for it. This is called a
+			// spurious wakeup. -ML
+			waitDaughters.wait(stateLock, [this]{return currentState != State::pause;});
 
-        case State::equilibrate: {
-            stateLock.unlock();
-            ++startedRequests;
-            // Part 1, select request to process
-            changeRequest currentRequest = parent.chooseNextRequest(generator);
+			// Reset our daughter stats.
+			collectedScore = 0.0;
+			collectedPBad = 0.0;
+			processedPBad = 0;
 
-            // Part 2, assess request
-            assessChange(currentRequest);
-            const double pBad = acceptingProbability(currentRequest.energyInc, temperature);
+			// Fetch the current temperature.
+			temperature = this->temperature;
 
-            // Part 3, implement (or don't implement) request
-            const double newScore = parent.implementLastRequest(pBad, currentRequest, generator);
+			continue;
+		}
 
-            // Part 4, record the results
-            stateLock.lock();
-            if (currentState != State::equilibrate) continue; // Esoteric race condition, honestly, user skill issue if
-            // it is encountered. More threads would have to be
-            // assigned by the user than nodes in either G1 or G2.
-            // This is a performance hit that makes me unhappy, but I
-            // feel obligated to accommodate it. -Marcus
-            stateLock.unlock();
-            outputLock.lock();
-            if (currentRequest.energyInc < 0) {
-                pBadBuffer.insert(pBad);
-            }
-            if (++finishedRequests % parent.batchSize == 0) {
-                scoreBuffer.insert(newScore);
-                if (scoreBuffer.isFull() && !scoreBuffer.trendingUpwards()) {
-                    stateLock.lock();
-                    currentState = State::pause;
-                    stateLock.unlock();
-                }
-            }
-            outputLock.unlock();
+		// For this state, the daughters process requests as granted to them by the SANA class.
+		// This means calculating the expected change to the score, the resulting pBad, and then
+		// implementing the change safely if it is accepted. The daughters process exactly one batch
+		// of requests, as determined by the batchSize of the SANA class. Then they self-halt and
+		// notify the Mom thread that unpaused them that the batch is finished.
+	    case State::anneal: {
+	        stateLock.unlock();
 
-            stateLock.lock();
-            break;
-        }
+	        // Pause all threads if we've met the quota. We jump to reassess state.
+	        if (startedRequests++ >= batchSize) {
+	            stateLock.lock();
+	            currentState = State::pause;
+	            continue;
+	        }
 
-        case State::pause: {
-                if (++daughtersPaused == daughterNum) handlerCondition.notify_all();
-                pausedCondition.wait(stateLock, [this]{return daughtersPaused == 0;});
-            break;
-        }
+	        // Part 1, ask the SANA class for a request to process
+	        changeRequest currentRequest = parent.chooseNextRequest(generator);
 
-        case State::terminate: {
-            if (++daughtersTerminated == daughterNum) handlerCondition.notify_all();
-            return;
-	    break;
-        }
-        default: throw runtime_error("Unknown harvester state. Either I messed up or someone touched my code -Marcus");
-	    break;
-    }
-    if(++whileCount%100000==0) printf("bH whileCount %d\n", whileCount);
+	        // Part 2, assess request
+	        double energyInc = assessRequest(currentRequest);
+	        const double pBad = acceptingProbability(energyInc, temperature);
+
+	        // Part 3, implement (or don't implement) request
+	        const double newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator);
+
+	        // Part 4, record the results
+	        collectedScore += newScore;
+			if (energyInc < 0.0) {
+				collectedPBad += pBad;
+				++processedPBad;
+			}
+	        ++finishedRequests;
+
+	        stateLock.lock();
+	        continue;
+	    }
+
+		// This state is very similar to anneal, but we record results in circular buffers and
+		// otherwise process requests indefinitely or until equilibrium is reached.
+	    case State::equilibrate: {
+	        stateLock.unlock();
+	        // Part 1, select request to process
+	        changeRequest currentRequest = parent.chooseNextRequest(generator);
+
+	        // Part 2, assess request
+	        const double energyInc = assessRequest(currentRequest);
+	        const double pBad = acceptingProbability(energyInc, temperature);
+
+	        // Part 3, implement (or don't implement) request
+	        const double newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator);
+
+	    	// Part 4, record the results
+	        bufferLock.lock();
+	        if (energyInc < 0) {
+	            pBadCircBuffer.insert(pBad);
+	        }
+			// Every batchSize, we add a new score to the scoreCircBuffer.
+	        if (++finishedRequests % batchSize == 0) {
+	            scoreCircBuffer.insert(newScore);
+	            if (scoreCircBuffer.isFull() && !scoreCircBuffer.trendingUpwards()) {
+					// This looks a little ridiculous, and it wouldn't really cause a data race if
+	            	// you don't unlock the bufferLock before modifying the state, but I don't want
+	            	// to set a bad example that someone will emulate. And moving this pause
+	            	// requires putting a conditional outside the batchSize modulo check which could
+	            	// slightly reduce performance. Just tolerate this unless entirely refactoring.
+	            	// -ML
+	            	bufferLock.unlock();
+		                stateLock.lock();
+							currentState = State::pause;
+		                stateLock.unlock();
+	            	bufferLock.lock();
+	            }
+	        }
+	        bufferLock.unlock();
+
+	        stateLock.lock();
+	        continue;
+	    }
+
+		// Termination states
+	    case State::terminate: {
+	        if (++daughtersTerminated == daughterNum) waitMom.notify_all();
+	        return;
+	    }
+	    default:
+	        throw runtime_error("Unknown harvester state. Either I messed up or someone touched my code -ML");
+	}
     }
 }
 
+// TODO: Move this out!
+static inline double aligEdgesIncMoveOp(const Graph::Node &peg1, const Graph::Node &hole1,
+	const Graph::Node &hole2, const Alignment &alignment, uint64_t totalEdges, bool directed) {
 
-static inline double aligEdgesIncMoveOp(const Graph::Node &peg1, const Graph::Node &hole1, const Graph::Node &hole2,
-    Alignment &alignment, uint64_t totalEdges, bool directed) {
-
-#ifdef WEIGHT
-    cerr << "EdgeCorrectness should not be used with weight. It is optimized for unweighted graphs and makes incompatible assumptions." <<endl;
-    throw runtime_error("Bad measure used with WEIGHT compiler setting.");
-#else
+	#ifdef WEIGHT
+	    cerr << "EdgeCorrectness should not be used with weight. It is optimized for unweighted graphs and makes incompatible assumptions." <<endl;
+	    throw runtime_error("Bad measure used with WEIGHT compiler setting.");
+	#endif
     int64_t result = 0;
 
     for (const auto &edge: peg1.adjList) {
@@ -320,22 +359,24 @@ static inline double aligEdgesIncMoveOp(const Graph::Node &peg1, const Graph::No
     }
 
     return static_cast<double>(result) / totalEdges;
-#endif
 }
 
-static inline double aligEdgesIncSwapOp(const Graph::Node &peg1, const Graph::Node &peg2, const Graph::Node &hole1, const Graph::Node &hole2,
-    Alignment &alignment, uint64_t totalEdges, bool directed) {
-#ifdef WEIGHT
-    cerr << "EdgeCorrectness should not be used with weight. It is optimized for unweighted graphs and makes incompatible assumptions." <<endl;
-    throw runtime_error("Bad measure used with WEIGHT compiler setting.");
-#else
+// TODO: And this, too!
+static inline double aligEdgesIncSwapOp(const Graph::Node &peg1, const Graph::Node &peg2,
+	const Graph::Node &hole1, const Graph::Node &hole2, const Alignment &alignment,
+	const uint64_t totalEdges, const bool directed) {
+	#ifdef WEIGHT
+	    cerr << "EdgeCorrectness should not be used with weight. It is optimized for unweighted graphs and makes incompatible assumptions." <<endl;
+	    throw runtime_error("Bad measure used with WEIGHT compiler setting.");
+	#endif
     /*
      * Marcus compiler optimizations for multithreading:
-     * Do NOT call alignment[] for the same index twice in a row. You might believe "oh, the compiler will just optimize
-     * it away, its no biggy!" NO, IT WILL NOT, because the alignment can vary while this calculation is ongoing. So the
-     * compiler is going to believe it has to fetch the value again in case it has changed. Now, we don't actually care
-     * if it has changed, but the compiler has no way to know that unless we tell it by manually specifying that YES,
-     * we want to use the same value twice, code transparency be damned.
+     * Do NOT call alignment[] for the same index twice in a row. You might believe "oh, the
+     * compiler will just optimize it away, its no biggy!" IT WILL NOT, because the alignment can
+     * vary while this calculation is ongoing. So the compiler is going to believe it has to fetch
+     * the value again in case it has changed. Now, we don't actually care if it has changed, but
+     * the compiler has no way to know that unless we tell it by manually specifying that YES, we
+     * want to use the same value twice, code transparency be damned.
      */
     int64_t result = 0;
 
@@ -344,21 +385,24 @@ static inline double aligEdgesIncSwapOp(const Graph::Node &peg1, const Graph::No
         result -= hole1.adjList.count(nbrHole);
         result += hole2.adjList.count(nbrHole);
     }
-    // self-loop correction
+    // Self-loop correction.
     if (peg1.adjList.count(peg1.nodeID)) {
         result -= hole2.adjList.count(hole1.nodeID); // Subtract erroneously counted edge
         result += hole2.adjList.count(hole2.nodeID); // Add correct edge
     }
+
     for (const auto &edge: peg2.adjList) {
         const unsigned nbrHole = alignment[edge.first];
         result -= hole2.adjList.count(nbrHole);
         result += hole1.adjList.count(nbrHole);
     }
-    // self-loop correction
+    // Self-loop correction
     if (peg2.adjList.count(peg2.nodeID)) {
         result -= hole1.adjList.count(hole2.nodeID); // Subtract erroneously counted edge
         result += hole1.adjList.count(hole1.nodeID); // Add correct edge
     }
+
+	//
     if(directed) {
         for (const auto &edge: peg1.injList) {
             const unsigned nbrHole = alignment[edge.first];
@@ -373,18 +417,22 @@ static inline double aligEdgesIncSwapOp(const Graph::Node &peg1, const Graph::No
 
         // Directed peg edge correction
         if (peg1.adjList.count(peg2.nodeID)) {
-        if (peg2.adjList.count(peg1.nodeID)) { // peg1 <-> peg2
-            result += hole1.adjList.count(hole2.nodeID);
-            result -= hole1.adjList.count(hole1.nodeID);
-            result -= hole2.adjList.count(hole2.nodeID);
-            result += hole2.adjList.count(hole1.nodeID);
+        // peg1 <-> peg2
+	        if (peg2.adjList.count(peg1.nodeID)) {
+	            result += hole1.adjList.count(hole2.nodeID);
+	            result -= hole1.adjList.count(hole1.nodeID);
+	            result -= hole2.adjList.count(hole2.nodeID);
+	            result += hole2.adjList.count(hole1.nodeID);
+	        }
+	        // peg1 -> peg2
+	        else {
+	            result += hole1.adjList.count(hole2.nodeID);
+	            result += hole2.adjList.count(hole1.nodeID);
+	            result -= hole2.adjList.count(hole2.nodeID);
+	        }
         }
-        else { // peg1 -> peg2
-            result += hole1.adjList.count(hole2.nodeID);
-            result += hole2.adjList.count(hole1.nodeID);
-            result -= hole2.adjList.count(hole2.nodeID);
-        }}
-        else if (peg2.adjList.count(peg1.nodeID)) { // peg1 <- peg2
+    	// peg1 <- peg2
+        else if (peg2.adjList.count(peg1.nodeID)) {
             result += hole2.adjList.count(hole1.nodeID);
             result += hole1.adjList.count(hole2.nodeID);
             result -= hole1.adjList.count(hole1.nodeID);
@@ -398,30 +446,37 @@ static inline double aligEdgesIncSwapOp(const Graph::Node &peg1, const Graph::No
         result += hole2.adjList.count(hole1.nodeID);
     }
     return static_cast<double>(result) / totalEdges;
-#endif
 }
 
-void SANAThree::BatchHarvester::assessMove(changeRequest &input) const {
-    // This is a hack, MC should be providing this information, not SANA!!
-    const Graph::Node &peg1 = parent.G1->deliverNode(input.peg1);
+double SANAThree::BatchHarvester::assessMove_(const changeRequest &input) const {
+	double energyInc = 0.0;
+
+	// This is a hack, MC should be providing this information, not SANA!!
+	const Graph::Node &peg1 = parent.G1->deliverNode(input.peg1);
     const Graph::Node &hole1 = parent.G2->deliverNode(input.hole1);
     const Graph::Node &hole2 = parent.G2->deliverNode(input.hole2);
     if (parent.needEC) {
-        input.energyInc = aligEdgesIncMoveOp(peg1, hole1, hole2, parent.alignment, parent.m1, parent.G1->directed)
-                          * parent.MC->getWeight("ec");
+        energyInc += parent.MC->getWeight("ec") *
+        	aligEdgesIncMoveOp(peg1, hole1, hole2, parent.alignment, parent.m1, parent.G1->directed);
     }
+
+	return energyInc;
 }
 
-void SANAThree::BatchHarvester::assessSwap(changeRequest &input) const {
-    // This is a hack, MC should be providing this information, not SANA!!
+double SANAThree::BatchHarvester::assessSwap_(const changeRequest &input) const {
+	double energyInc = 0.0;
+
+	// This is a hack, MC should be providing this information, not SANA!!
     const Graph::Node &peg1 = parent.G1->deliverNode(input.peg1);
     const Graph::Node &peg2 = parent.G1->deliverNode(input.peg2);
     const Graph::Node &hole1 = parent.G2->deliverNode(input.hole1);
     const Graph::Node &hole2 = parent.G2->deliverNode(input.hole2);
     if (parent.needEC) {
-        input.energyInc = aligEdgesIncSwapOp(peg1, peg2, hole1, hole2, parent.alignment, parent.m1, parent.G1->directed)
-                          * parent.MC->getWeight("ec");
+        energyInc += parent.MC->getWeight("ec") *
+        	aligEdgesIncSwapOp(peg1, peg2, hole1, hole2, parent.alignment, parent.m1, parent.G1->directed);
     }
+
+	return energyInc;
 }
 
 

--- a/src/methods/BatchHarvester.cpp
+++ b/src/methods/BatchHarvester.cpp
@@ -28,9 +28,9 @@
 ///
 /// const double temperature: the annealing temperature, higher temperature -> bad change more likely
 double static inline acceptingProbability(const double energyInc, const double temperature) {
-	// Float comparisons are definitely a bad practice, we need to find an epsilon for this. -ML
+	// Float comparisons are usually a bad practice, this case is fine -ML
 	if (temperature == 0.) {
-    	return energyInc >= 0; // Bool coerced into 0.0 and 1.0. Probably also a bad practice - ML
+    	return energyInc >= 0; // Bool coerced into 0.0 and 1.0
     }
 
 	if (energyInc >= 0.) {
@@ -204,6 +204,7 @@ SANAThree::batchOutput SANAThree::BatchHarvester::collectBatch(double temperatur
 
 void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
     mt19937_64 generator(seed);
+	auto randomReal = uniform_real_distribution<>(0, 1);
 
     unique_lock<mutex> bufferLock(bufferMutex, defer_lock); // Defer
     unique_lock<mutex> stateLock(stateMutex); // Held
@@ -236,11 +237,25 @@ void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
 			if (++daughtersPaused == daughterNum)
 				waitMom.notify_all();
 
+			uint64_t lastActivation = activationID;
+
 			// Now we wait until we told that daughter threads should be unpaused.
+			//
 			// A condition is required here because the C++ standard does not guarantee that a
 			// thread will never be woken up without our code asking for it. This is called a
-			// spurious wakeup. -ML
-			waitDaughters.wait(stateLock, [this]{return currentState != State::pause;});
+			// spurious wakeup. Originally, the condition was currentState != State::pause.
+			//
+			// So why activationID instead? My code is sometimes so fast that the threads will
+			// finish a batch before all of them have been woken up. This is bad, because it means
+			// we return to the pause state before the sleepy thread can wake up, which means it
+			// never does a state machine loop to increment daughtersPaused which means Mom is never
+			// woken up. So we cannot rely on pause to tell threads to wake up, we need a different indicator.
+			// This is called the ABA problem. The solution is to have a counter we can check that
+			// will never return to the same state.
+			// -ML
+			waitDaughters.wait(stateLock, [this, lastActivation]{
+				return activationID != lastActivation;
+			});
 
 			// Reset our daughter stats.
 			collectedScore = 0.0;
@@ -261,32 +276,39 @@ void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
 	    case State::anneal: {
 	        stateLock.unlock();
 
-	        // Pause all threads if we've met the quota. We jump to reassess state.
-	        if (startedRequests++ >= batchSize) {
-	            stateLock.lock();
-	            currentState = State::pause;
-	            continue;
-	        }
+			while (true) {
+				uint64_t newStartedRequests = startedRequests.fetch_add(CHUNK_SIZE);
 
-	        // Part 1, ask the SANA class for a request to process
-	        changeRequest currentRequest = parent.chooseNextRequest(generator);
+				// Break if we've met the quota.
+				if (newStartedRequests >= batchSize) {
+					break;
+				}
 
-	        // Part 2, assess request
-	        double energyInc = assessRequest(currentRequest);
-	        const double pBad = acceptingProbability(energyInc, temperature);
+				for (size_t i = 0; i < CHUNK_SIZE; ++i) {
+					// Part 1, ask the SANA class for a request to process
+					changeRequest currentRequest = parent.chooseNextRequest(generator);
 
-	        // Part 3, implement (or don't implement) request
-	        const double newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator);
+					// Part 2, assess request
+					double energyInc = assessRequest(currentRequest);
+					const double pBad = acceptingProbability(energyInc, temperature);
 
-	        // Part 4, record the results
-	        collectedScore += newScore;
-			if (energyInc < 0.0) {
-				collectedPBad += pBad;
-				++processedPBad;
+					// Part 3, implement (or don't implement) request
+					const double newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator, randomReal);
+
+					// Part 4, record the results
+					collectedScore += newScore;
+					if (energyInc < 0.0) {
+						collectedPBad += pBad;
+						++processedPBad;
+					}
+				}
+				finishedRequests.fetch_add(CHUNK_SIZE);
 			}
-	        ++finishedRequests;
 
 	        stateLock.lock();
+			if (currentState != State::terminate) {
+				currentState = State::pause;
+			}
 	        continue;
 	    }
 
@@ -294,39 +316,44 @@ void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
 		// otherwise process requests indefinitely or until equilibrium is reached.
 	    case State::equilibrate: {
 	        stateLock.unlock();
-	        // Part 1, select request to process
-	        changeRequest currentRequest = parent.chooseNextRequest(generator);
 
-	        // Part 2, assess request
-	        const double energyInc = assessRequest(currentRequest);
-	        const double pBad = acceptingProbability(energyInc, temperature);
+			double newScore = 0.0;
+			for (size_t i = 0; i < CHUNK_SIZE; ++i) {
+				// Part 1, select request to process
+				changeRequest currentRequest = parent.chooseNextRequest(generator);
 
-	        // Part 3, implement (or don't implement) request
-	        const double newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator);
+				// Part 2, assess request
+				const double energyInc = assessRequest(currentRequest);
+				const double pBad = acceptingProbability(energyInc, temperature);
 
-	    	// Part 4, record the results
-	        bufferLock.lock();
-	        if (energyInc < 0) {
-	            pBadCircBuffer.insert(pBad);
-	        }
-			// Every batchSize, we add a new score to the scoreCircBuffer.
-	        if (++finishedRequests % batchSize == 0) {
-	            scoreCircBuffer.insert(newScore);
-	            if (scoreCircBuffer.isFull() && !scoreCircBuffer.trendingUpwards()) {
-					// This looks a little ridiculous, and it wouldn't really cause a data race if
-	            	// you don't unlock the bufferLock before modifying the state, but I don't want
-	            	// to set a bad example that someone will emulate. And moving this pause
-	            	// requires putting a conditional outside the batchSize modulo check which could
-	            	// slightly reduce performance. Just tolerate this unless entirely refactoring.
-	            	// -ML
-	            	bufferLock.unlock();
-		                stateLock.lock();
-							currentState = State::pause;
-		                stateLock.unlock();
-	            	bufferLock.lock();
-	            }
-	        }
-	        bufferLock.unlock();
+				// Part 3, implement (or don't implement) request
+				newScore = parent.implementLastRequest(pBad, energyInc, currentRequest, generator, randomReal);
+
+				// Part 4, record the results
+				bufferLock.lock();
+				if (energyInc < 0) {
+					pBadCircBuffer.insert(pBad);
+				}
+				bufferLock.unlock();
+			}
+
+	        uint64_t newFinishedRequests = finishedRequests.fetch_add(CHUNK_SIZE);
+			if (newFinishedRequests % batchSize == 0) {
+				bufferLock.lock();
+				scoreCircBuffer.insert(newScore);
+				if (scoreCircBuffer.isFull() && !scoreCircBuffer.trendingUpwards()) {
+					bufferLock.unlock();
+					stateLock.lock();
+					if (currentState != State::terminate) {
+						currentState = State::pause;
+						continue; // We can do this because stateLock() is held.
+					}
+					stateLock.unlock();
+				}
+				else {
+					bufferLock.unlock();
+				}
+			}
 
 	        stateLock.lock();
 	        continue;

--- a/src/methods/BatchHarvester.cpp
+++ b/src/methods/BatchHarvester.cpp
@@ -30,7 +30,14 @@
 double static inline acceptingProbability(const double energyInc, const double temperature) {
     if (temperature == 0.) // Float comparisons are definitely a bad practice. -ML
         return energyInc >= 0; // Bool coerced into 0.0 and 1.0. Probably a bad practice - ML
-    return energyInc >= 0 ? 1 : exp(energyInc / temperature); // Potential for -inf here, but exp(-inf) = 0 -ML
+	if (energyInc >= 0.)
+		return 1.0;
+
+	const double exponent = energyInc / temperature;
+	if (exponent < -700)
+		return 0.0;
+
+	return exp(exponent);
 }
 
 #define SCORE_BATCH_SIZE 31 // TODO: Borrowed from SANA 2.0. This should probably be looked at -ML
@@ -217,7 +224,7 @@ void SANAThree::BatchHarvester::daughterFunction(uint64_t seed) {
 			// Give the Mom thread our results
 			totalScore += collectedScore;
 			totalPBad += collectedPBad;
-			numTotalPBad += collectedPBad;
+			numTotalPBad += processedPBad;
 
 			// If all daughter threads are paused, then the Mom thread is alerted
 			if (++daughtersPaused == daughterNum)

--- a/src/methods/BatchHarvester.cpp
+++ b/src/methods/BatchHarvester.cpp
@@ -28,14 +28,20 @@
 ///
 /// const double temperature: the annealing temperature, higher temperature -> bad change more likely
 double static inline acceptingProbability(const double energyInc, const double temperature) {
-    if (temperature == 0.) // Float comparisons are definitely a bad practice. -ML
-        return energyInc >= 0; // Bool coerced into 0.0 and 1.0. Probably a bad practice - ML
-	if (energyInc >= 0.)
+	// Float comparisons are definitely a bad practice, we need to find an epsilon for this. -ML
+	if (temperature == 0.) {
+    	return energyInc >= 0; // Bool coerced into 0.0 and 1.0. Probably also a bad practice - ML
+    }
+
+	if (energyInc >= 0.) {
 		return 1.0;
+	}
 
 	const double exponent = energyInc / temperature;
-	if (exponent < -700)
+	// That is, if the exponent would produce a subnormal number, truncate final answer to zero.
+	if (exponent < -700) {
 		return 0.0;
+	}
 
 	return exp(exponent);
 }

--- a/src/methods/BatchHarvester.hpp
+++ b/src/methods/BatchHarvester.hpp
@@ -6,68 +6,96 @@
 #include "SANAThree.hpp"
 
 class SANAThree::BatchHarvester {
+    // The internal state of the Harvester.
+    // This is the primary way to communicate to the daughter threads what they should be doing.
     enum struct State {
-        anneal,
-        equilibrate,
-        pause,
-        terminate
+        pause, // All daughters should be sleeping
+        anneal, // All threads should compute a combined batchNumber of requests
+        equilibrate, // All threads should compute requests until equilibrium is reached
+        terminate // All threads should terminate
     };
 public:
-    // The handler starts the threads as soon as it is constructed and terminates them when it
-    // is deconstructed. Therefore, it should only ever exist as a local object at the smallest
-    // possible scope to ensure that the computer threads are not being hogged by a greedy SANA.
-    // -Marcus
     BatchHarvester(unsigned threadNumber, SANAThree &SANA, unsigned long long bufferSize);
     ~BatchHarvester();
 
-    // This is the proper way to interface with collectBatch
-    // -Marcus
+    // Collect a batch from BatchHarvester for annealing purposes. Note that this WILL mutate the
+    // alignment (which is its job, after all)
     batchOutput collectBatch(double temperature);
 
+    // Find the equilibrium pBad of the annealing process at a certain temperature, timing out if
+    // timeoutSeconds is exceeded.
+    // This will also mutate the alignment.
     double runUntilEquilibrium(double temperature, unsigned timeoutSeconds);
-
-    double recentPBadQuick() const {return pBadBuffer.quickAverage();}
-
-    double recentPBadTrue() {return pBadBuffer.accurateAverage();}
-
-    unsigned pBadsInBuffer() const {return pBadBuffer.size();}
-
-    void resetBuffers() {pBadBuffer.resetBuffer(); scoreBuffer.resetBuffer();}
 
 private:
     SANAThree &parent;
 
+    const unsigned daughterNum;
+
+    // threadVector is the "fishing line" to pull each thread back in for termination.
     vector<thread> threadVector;
 
+    atomic_uint64_t startedRequests; // changeRequests that have begun
+    atomic_uint64_t finishedRequests; // changeRequests that have finished processing
+
     // State System
-    const unsigned daughterNum;
-    mutex stateMutex; // All indented members below should only be accessed if this mutex is locked.
+    // All indented members below should only be accessed if stateMutex is held.
+    // Yes, even the member functions!
+    // I really wish C++ had a way to enforce this at compile-time -ML
+    mutex stateMutex;
         State currentState;
+        condition_variable waitDaughters;
+        condition_variable waitMom;
+
         unsigned daughtersPaused;
-        unsigned daughtersTerminated;
-        condition_variable pausedCondition;
-        condition_variable handlerCondition;
-    atomic<double> temperature; // Write only if stateMutex is locked.
+        unsigned daughtersTerminated; // Technically redundant, but we have the padding room we can use for clarity of purpose
 
-    atomic_uint64_t startedRequests;
-    atomic_uint64_t finishedRequests;
+        // Activate the daughter threads with a certain state.
+        void activateDaughters(const State state) {
+            currentState = state;
+            daughtersPaused = 0;
+            waitDaughters.notify_all();
+        }
 
-    // Output system
-    mutex outputMutex; // All indented members below should only be accessed if this mutex is locked.
-        double totalEnergy;
-        double totalPBad;
-        uint64_t numPBad;
-        CircularBuffer<double> scoreBuffer;
-        CircularBuffer<double> pBadBuffer;
+        double totalScore; // Total score of a batch; Used for calculating score averages
+        double totalPBad; // Total pBad of a batch; Used for calculating pBad averages
+        uint64_t numTotalPBad; // Number of pBad encountered; Used for calculating pBad averages
+        void resetCounters() {
+            startedRequests.store(0);
+            finishedRequests.store(0);
 
+            totalScore = 0;
+            totalPBad = 0;
+            numTotalPBad = 0;
+        }
+
+        double temperature;
+
+    // This mutex is vestigial from an older version of SANAThree, but I found no easy way to
+    // remove it for the temperature equilibrium calculation. In the future, it should be removed
+    // from the class for a massive potential speedup. My recommendation is a message passing system
+    // where the Mom thread handles the buffers.
+    mutex bufferMutex;
+        CircularBuffer<double> scoreCircBuffer;
+        CircularBuffer<double> pBadCircBuffer;
+        void resetBuffers() {
+            pBadCircBuffer.resetBuffer();
+            scoreCircBuffer.resetBuffer();
+        }
+
+    // All daughters of the BatchHarvestor are controlled from this loop and these functions.
+    // This function operates as a state-machine for each thread, though with a shared state across
+    // all daughters. -ML
     void daughterFunction(uint64_t seed);
-    void assessChange(changeRequest& currentRequest) const {
-        if (currentRequest.twoPegs) assessSwap(currentRequest);
-        else assessMove(currentRequest);
+
+    // Calculate the expected results of a request.
+    double assessRequest(const changeRequest& currentRequest) const {
+        if (currentRequest.twoPegs)
+            return assessSwap_(currentRequest);
+        return assessMove_(currentRequest);
     }
-    void assessMove(changeRequest &input) const; // One pin
-    void assessSwap(changeRequest &input) const; // Two pins
-    bool allDaughtersPaused() const {return daughtersPaused == daughterNum;} // ONLY CALL IF STATE MUTEX IS HELD!
+    double assessMove_(const changeRequest &input) const; // One pin
+    double assessSwap_(const changeRequest &input) const; // Two pins
 };
 
 #endif //MOVECALCULATOR_HPP

--- a/src/methods/BatchHarvester.hpp
+++ b/src/methods/BatchHarvester.hpp
@@ -1,6 +1,8 @@
 #ifndef BATCHHARVESTER_HPP
 #define BATCHHARVESTER_HPP
 
+#define CHUNK_SIZE 4096
+
 #include <condition_variable>
 
 #include "SANAThree.hpp"
@@ -43,6 +45,7 @@ private:
     // Yes, even the member functions!
     // I really wish C++ had a way to enforce this at compile-time -ML
     mutex stateMutex;
+        uint64_t activationID = 0;
         State currentState;
         condition_variable waitDaughters;
         condition_variable waitMom;
@@ -54,6 +57,7 @@ private:
         void activateDaughters(const State state) {
             currentState = state;
             daughtersPaused = 0;
+            ++activationID;
             waitDaughters.notify_all();
         }
 

--- a/src/methods/HillClimbing.cpp
+++ b/src/methods/HillClimbing.cpp
@@ -42,7 +42,7 @@ HillClimbing::HillClimbing(const Graph* G1, const Graph* G2, MeasureCombination*
         startA = Alignment::random(n1, n2);
     }
     else {
-        startA = Alignment::loadMapping(startAName);
+        startA = Alignment::loadMapping(startAName, *G1, *G2);
     }
 
     random_device rd;
@@ -68,7 +68,7 @@ Alignment HillClimbing::run() {
     throw runtime_error("Hill climbing only supports ec/ics/s3/wec/local measures");
 #else
     uint n1 = G1->getNumNodes(), n2 = G2->getNumNodes();
-    vector<uint> A(startA.asVector());
+    Alignment A = startA;
 
     vector<bool> assignedNodesG2(n2, false);
     for (uint i = 0; i < n1; i++) {
@@ -90,10 +90,10 @@ Alignment HillClimbing::run() {
     double g1Edges = G1->getNumEdges();
     double g1Nodes = n1;
 
-    int aligEdges = Alignment(A).computeNumAlignedEdges(*G1, *G2);
+    int aligEdges = A.computeNumAlignedEdges(*G1, *G2);
     bool needG2InducedEdges = (icsWeight > 0 or s3Weight > 0);
     int g2InducedEdges;
-    if (needG2InducedEdges) g2InducedEdges = G2->numEdgesInNodeInducedSubgraph(A);
+    if (needG2InducedEdges) g2InducedEdges = G2->numEdgesInNodeInducedSubgraph(A.copyPegsToHoles());
     else g2InducedEdges = 1; //dummy value
 
     //initialize data structures for incremental evaluation of local measures
@@ -296,7 +296,7 @@ Alignment HillClimbing::run() {
         if (useChangeOperator) {
             uint newTarget = unassignedNodesG2[bestNewTargetIndex];
             uint oldTarget = A[bestSource];
-            A[bestSource] = newTarget;
+            A.movePeg(bestSource, oldTarget, newTarget);
             unassignedNodesG2[bestNewTargetIndex] = oldTarget;
             assignedNodesG2[oldTarget] = false;
             assignedNodesG2[newTarget] = true;
@@ -304,8 +304,7 @@ Alignment HillClimbing::run() {
         }
         else {
             uint target1 = A[bestSource1], target2 = A[bestSource2];
-            A[bestSource1] = target2;
-            A[bestSource2] = target1;
+            A.swapPegs(bestSource1, bestSource2, target1, target2);
         }
     }
     return A;

--- a/src/methods/NoneMethod.cpp
+++ b/src/methods/NoneMethod.cpp
@@ -10,7 +10,7 @@ NoneMethod::NoneMethod(const Graph* G1, const Graph* G2, string startAName):
         uint n2 = G2->getNumNodes();
         A = Alignment(Alignment::random(n1, n2));
     } else {
-        A = Alignment(Alignment::loadMapping(startAName));
+        A = Alignment(Alignment::loadMapping(startAName, *G1, *G2));
     }
     A = Alignment::loadEdgeList(*G1, *G2, startAName);
 }

--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -151,7 +151,7 @@ Alignment SANAThree::runUsingConfidenceIntervals() {
 void SANAThree::initDataStructures() {
     auto assignedNodesG2 = vector<char> (n2);
 
-    if (startingAlignment.size() == 0) alignment = Alignment::randomColorRestrictedAlignment(*G1, *G2);
+    if (startingAlignment.numOfPegs() == 0) alignment = Alignment::randomColorRestrictedAlignment(*G1, *G2);
     else alignment = startingAlignment;
 
     //init holeToColorID. For each node, we do the following transformations:
@@ -184,7 +184,7 @@ void SANAThree::initDataStructures() {
 
 // TODO:
 // This is terribly outdated. I'll buy a (soft) cider for anyone who takes it upon themselves to
-// make a better version, but this relatively low priority.
+// make a better version, but this relatively low priority. -Marcus
 void SANAThree::describeParameters(ostream &stream) const {
     stream << "Temperature goldilocks:" << endl;
     stream << "T_initial: " << tInitial << endl;
@@ -420,84 +420,84 @@ void SANAThree::runHillClimbing() {
     cout<<"Hill climbing took "<<T.elapsedString()<<"s"<<endl;
 }
 
-#if 0
-    Note: The deterministic if-cascade below may instead need to use randomness to choose among the possibilities.
-       One way to do this could be to do a "normal" (Marcus) move, perhaps with probability (1-tau) \in [0,1], so that
-       we initially do mostly "Marcus" moves, transitioning to "allowed Partner" moves as the anneal progresses.
-Basic idea:
-    pick any hole at random (possibly restricted to those that are either EMPTY or UNHAPPY)
-    if hole has no allowed partner pegs
-	pick ANY (unhappy?) peg and pull it here
-    else
-	if hole has any unhappy partner pegs
-	    pick one and pull it here
-	else
-	    pick an already happy partner peg and pull it here
-	fi
-    fi
-    // NOTE: "pull it here" means "move" it if the hole was empty, otherwise "swap" with the hole the other peg is in.
-#endif
-// Special case of allowedPartners requests (which is incompatible with node color system)
-SANAThree::changeRequest SANAThree::allowedPartnersRequest(mt19937_64 &generator) {
-    assert(G1->numColors()==1 && G2->numColors()==1);
-    const unsigned color = 0;
-
+#ifdef PREFERRED_HOLES
+#define RESTRICT_P 1
+SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64& generator) {
     unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex, defer_lock);
+
     // Request parameters
-    bool twoPegs = false;
-    unsigned peg1, peg2 = -1; // Garbage allocation so that an exception will occur if not set and then used
-    unsigned hole1, hole2;
+    bool twoPegs;
+
+    unsigned peg1;
+    unsigned peg2;
+    unsigned hole1;
+    unsigned hole2;
+
     unsigned hole2unassignedID = -1;
+    unsigned color = -1;
 
-    while(true) {
-	// pick hole2 first since it's the only one that could potentially be empty
-	lockAlignmentAndHoles.lock();
-	// hole2 = G2->getNumNodes() * randomReal(generator); // pick any hole
-	do {
-	    hole2 = G2->getNumNodes() * randomReal(generator);
-	} while(alignment.isHappyHole(hole2)); // isHappyHole is false if the hole is empty
-	peg2 = alignment.whichPeg(hole2); // can be (-1)
-	assert(peg2 == (unsigned)(-1) || peg2 < G1->getNumNodes());
+    // Loop while we look for a valid adjacent alignment.
+    while (true) {
+        // Part 1, select a random peg1
+        peg1 = randIndex_64(n1, generator);
 
-	if(alignment.allowedPegs(hole2).size() == 0) // if no partners exist, pick a random UNHAPPY peg
-	    do peg1 = G1->getNumNodes() * randomReal(generator);
-	    while(alignment.isHappyPeg(peg1));
-	else {
-	    unordered_set<uint> myUnhappyPegs;
-	    for(const auto peg : alignment.allowedPegs(hole2))
-		if(peg!=peg2 && !alignment.isHappy(peg, hole2))
-		    myUnhappyPegs.insert(peg);
-	    if(myUnhappyPegs.size()) { // there exist unhappy pegs; choose one and pull it here
-		uint randIndex = myUnhappyPegs.size() * randomReal(generator);
-		auto it = myUnhappyPegs.begin(); std::advance(it, randIndex);
-		peg1 = *it;
-	    } else { // all of hole2's allowed pegs are already happy, but pick one and pull it here anyay
-		uint randIndex = alignment.allowedPegs(hole2).size() * randomReal(generator);
-		auto it = alignment.allowedPegs(hole2).begin(); std::advance(it, randIndex);
-		peg1 = *it;
-	    }
-	}
-	assert(peg1 < G1->getNumNodes());
-	hole1 = alignment[peg1];
-	if(peg2 == (uint)(-1)) {
-	    twoPegs = false;
-            const unsigned numUnassignedHoles = colorUnassignedNodes.at(color).size();
-	    hole2unassignedID = (hole1+hole2) % numUnassignedHoles;
-	    colorUnassignedNodes[color][hole2unassignedID] = hole2;
-	} else
-	    twoPegs = true;
-	if (holeLocks[hole1] || holeLocks[hole2]) {
-	    lockAlignmentAndHoles.unlock();
-	    continue;
-	}
-	holeLocks[hole1] = holeLocks[hole2] = true;
-	return {twoPegs, peg1, peg2, hole1, hole2, hole2unassignedID, color, 0.0};
+        // We want: p(adjAli) = 1 / numAdjAlignments
+        // What we get: p(adjAli(peg1, hole2)) = (1 / n1) * (1 / numPerfHoles(peg1))
+        // How: p(adjAli(peg1, hole2)) = (numPerHoles(peg1) / numAdjAlignments) * (1 / numPerfHoles(peg1))
+
+        // Part 2, find hole2. We either select an allowed hole2 from peg1's list of preferred
+        if (randomReal(generator) <= RESTRICT_P) {
+            const unsigned hole2Idx = randIndex_64(PREFERRED_HOLES[peg1].len(), generator);
+            hole2 = PREFERRED_HOLES[peg1][hole2Idx];
+        }
+        else {
+            hole2 = randIndex_64(n2, generator);
+        }
+
+        // Part 3: check for locks
+        lockAlignmentAndHoles.lock();
+        hole1 = alignment[peg1];
+        if (holeLocks[hole1] || holeLocks[hole2]) {
+            lockAlignmentAndHoles.unlock();
+            continue;
+        }
+        holeLocks[hole1] = holeLocks[hole2] = true;
+        peg2 = INVERSE_ALIGNMENT[hole2];
+        lockAlignmentAndHoles.unlock();
+
+
+        if (peg2 == -1) twoPegs = false;
+        else twoPegs = true;
+
+        return {twoPegs, peg1, peg2, hole1, hole2, hole2unassignedID, color};
     }
 }
 
-SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
-    if(alignment.allowedPartnersEnabled()) return allowedPartnersRequest(generator);
+double SANAThree::new_implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator) {
+    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
 
+    holeLocks[input.hole1] = holeLocks[input.hole2] = false;
+    if (input.twoPegs) totalSwapsCalculated++;
+    else totalMovesCalculated++;
+
+    if (randomReal(generator) >= pBad) return currentScore;
+
+    if (input.twoPegs) {
+        alignment.swapPegs(input.peg1, input.peg2);
+        totalSwapsAccepted++;
+    }
+    else {
+        alignment.movePeg(input.peg1, input.hole2);
+        totalMovesAccepted++;
+    }
+
+    const double val = currentScore.load() + input.energyInc;
+    currentScore.store(val);
+    return val;
+}
+#else
+
+SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
     unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex, defer_lock);
 
     // Request parameters
@@ -570,8 +570,8 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
             peg1 = (*G1->getNodesWithColor(color))[peg1colorID];
             peg2 = (*G1->getNodesWithColor(color))[peg2colorID];
             lockAlignmentAndHoles.lock();
-            hole1 = alignment[peg1];
-            hole2 = alignment[peg2];
+            hole1 = alignment.pegToHole(peg1);
+            hole2 = alignment.pegToHole(peg2);
         }
         // Move Logic
         else {
@@ -593,7 +593,7 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
 
             peg1 = (*G1->getNodesWithColor(color))[peg1colorID];
             lockAlignmentAndHoles.lock();
-            hole1 = alignment[peg1];
+            hole1 = alignment.pegToHole(peg1);
             hole2 = colorUnassignedNodes[color][hole2unassignedID];
         }
         // I.E., if invalid, reroll. Rejection sampling, google it
@@ -607,9 +607,6 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
     }
 }
 
-// This probably deserves a rework. I am uncomfortable with the current implementation and pushing
-// it all off into its own function has solved this only marginally. It works, but there has got to
-// be a less intrusive way to do this!
 double SANAThree::implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator) {
     double randomNum = randomReal(generator); // MARCUS says it's better to generate before the mutex...
     unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
@@ -620,11 +617,11 @@ double SANAThree::implementLastRequest(double pBad, const changeRequest &input, 
     if (randomNum >= pBad) return currentScore;
 
     if (input.twoPegs) {
-        alignment.swap(input.peg1, input.peg2);
+        alignment.swapPegs(input.peg1, input.peg2);
         totalSwapsAccepted++;
     }
     else {
-        alignment.set(input.peg1, input.hole2);
+        alignment.movePeg(input.peg1, input.hole2);
         colorUnassignedNodes[input.color][input.hole2unassignedID] = input.hole1; // Move
         totalMovesAccepted++;
     }
@@ -633,6 +630,8 @@ double SANAThree::implementLastRequest(double pBad, const changeRequest &input, 
     currentScore.store(val);
     return val;
 }
+
+#endif
 
 // TODO
 // This function should NOT be re-written in C++, because C++ sucks at formatted output

--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -42,7 +42,7 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, const double TInitial, co
     tolerance(tolerance),
     maxSeconds(maxSeconds),
     maxIterations(maxIterations),
-    batchSize(max<uint64_t>(15000u,n2)),
+    batchSize((max<uint64_t>(CHUNK_SIZE * threadNumber * 2, G2->getNumEdges()) / CHUNK_SIZE) * CHUNK_SIZE),
     threadNumber(threadNumber),
     hillClimbing(addHillClimbing),
     needEC(MC->getWeight("ec") > 0),
@@ -54,7 +54,11 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, const double TInitial, co
     localScoresFileName(localScoresFileName),
     tInitial(TInitial),
     tDecay(TDecay),
-    holeLocks(n2) {
+    holeLocks(n2)
+    {
+    if (batchSize % CHUNK_SIZE != 0) {
+        throw runtime_error("batchSize needs to be a multiple of CHUNK_SIZE!");
+    }
     // This should never happen, and if it does, it is 100% user error.
     if (threadNumber >= n1 / 2) {
         throw runtime_error(
@@ -78,8 +82,6 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, const double TInitial, co
                 "sums.\n If you really need a complex aggregation, either wait for a new version or"
                 "run the old version." << endl;
     }
-
-    randomReal = uniform_real_distribution<>(0, 1);
 
     // NODE COLOR SYSTEM initialization
     // TODO: Preferred Holes
@@ -117,11 +119,6 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, const double TInitial, co
     if (numAdjacentAlignments == 0)
         throw runtime_error(
             "There is a unique valid alignment, so running SANA is pointless");
-
-    totalMovesCalculated = 0;
-    totalMovesAccepted = 0;
-    totalSwapsCalculated = 0;
-    totalSwapsAccepted = 0;
 
     if (startingAlignment.numOfPegs() == 0)
         alignment = Alignment::randomColorRestrictedAlignment(*G1, *G2);
@@ -184,26 +181,22 @@ double SANAThree::getEquilibriumPBadAtTemp(double temperature, unsigned timeoutS
 Alignment SANAThree::run() {
     setInterruptSignal();
 
+    uint64_t iter;
     if (tolerance > 0)
-        runConfidenceIntervals();
+        iter = runConfidenceIntervals();
     else
-        runIterations();
+        iter = runIterations();
 
-    if (hillClimbing) runHillClimbing();
+    if (hillClimbing) iter += runHillClimbing();
 
-    cout<<"Calculated "<< totalMovesCalculated <<" moves\n";
-    cout<<"Calculated "<< totalSwapsCalculated <<" swaps\n";
-    cout<<"Calculated "<< totalMovesCalculated + totalSwapsCalculated <<" total iterations\n";
-    cout<<"Accepted "<< totalMovesAccepted <<" moves\n";
-    cout<<"Accepted "<< totalSwapsAccepted <<" swaps\n";
-    cout<<"Accepted "<< totalMovesAccepted + totalSwapsAccepted <<" total iterations\n";
+    cout<<"Calculated "<<iter<<" total iterations."<<endl;
 
     return alignment;
 }
 
 #define LEEWAY 1.75
 #define temperatureFunction(f, i, d) ((i) * exp(-(d) * (f)))
-void SANAThree::runIterations() {
+uint64_t SANAThree::runIterations() {
     double maxSecondsWithLeeway;
     long long unsigned maxBatches;
     unsigned batchesPerStep;
@@ -227,29 +220,28 @@ void SANAThree::runIterations() {
         maxBatches = 1 + maxIterations / batchSize;
         maxSecondsWithLeeway = 0;
     }
-    totalMovesCalculated = 0;
-    totalMovesAccepted = 0;
-    totalSwapsCalculated = 0;
-    totalSwapsAccepted = 0;
     resetAlignment();
     T.start();
-    long long unsigned iter = 0;
+    long long unsigned batch = 0;
     double temperature = tInitial;
-    for (; iter < maxBatches; iter += 1) {
-        temperature = temperatureFunction(static_cast<double>(iter)/static_cast<double>(maxBatches),
-                                                 tInitial, tDecay);
-        const batchOutput output = threadPool->collectBatch(temperature);
+    for (; batch < maxBatches; batch += 1) {
+        if (userInterrupted) {handleInterruption();}
         if (saveAligAndExitOnInterruption) break;
         if (saveAligAndContOnInterruption) printReportOnInterruption();
-        if (iter % batchesPerStep == 0) {
+
+        temperature = temperatureFunction(static_cast<double>(batch)/static_cast<double>(maxBatches),
+                                                 tInitial, tDecay);
+        const batchOutput output = threadPool->collectBatch(temperature);
+        if (batch % batchesPerStep == 0) {
             currentScore = MC->eval(alignment);
-            trackProgress(iter * batchSize, static_cast<double>(iter)/static_cast<double>(maxBatches), T.elapsed(),
+            trackProgress(batch * batchSize, static_cast<double>(batch)/static_cast<double>(maxBatches), T.elapsed(),
                 temperature, output.averagePBad);
         }
         if (maxSecondsWithLeeway != 0. and T.elapsed() > maxSecondsWithLeeway) break;
     }
-    trackProgress(iter * batchSize, static_cast<double>(iter)/static_cast<double>(maxBatches), T.elapsed(),
+    trackProgress(batch * batchSize, static_cast<double>(batch)/static_cast<double>(maxBatches), T.elapsed(),
                 temperature, 0.);
+    return batch * batchSize;
 }
 
 // All of these are purely heuristic -Wayne (I think, at least -Marcus)
@@ -260,7 +252,7 @@ void SANAThree::runIterations() {
 #define HAPPY_BATCHES MIN(10000, (int)(m1+m2))
 #define MIN_CONFIDENCE 0.99999
 #define TOL_SAFETY_MARGIN 1.07 // empirically this seems to cut failure rates to below 5%.
-void SANAThree::runConfidenceIntervals() {
+uint64_t SANAThree::runConfidenceIntervals() {
     TimerTrue T;
 
     // TODO: make all of these changeable on the command line
@@ -280,12 +272,8 @@ void SANAThree::runConfidenceIntervals() {
 
     // TODO: add batchesPerStep from runIterations for a regular re-eval of score
     long int lastBatchCount=0;
-    double previousScore = currentScore;
+    double previousScore = currentScore.load();
     double temperature = 0;
-    totalMovesCalculated = 0;
-    totalMovesAccepted = 0;
-    totalSwapsCalculated = 0;
-    totalSwapsAccepted = 0;
     resetAlignment();
 
     double lastPBad = 0.0;
@@ -300,6 +288,7 @@ void SANAThree::runConfidenceIntervals() {
 	// Now the "inner loop"
 	bool satisfied = false;
 	while(!satisfied) {
+	    if (userInterrupted) {handleInterruption();}
 	    if (saveAligAndExitOnInterruption) break;
 	    if (saveAligAndContOnInterruption) printReportOnInterruption();
 
@@ -308,6 +297,10 @@ void SANAThree::runConfidenceIntervals() {
 	    StatAddSample(scoreBatchMeans, output.averageScore);
 	    StatAddSample(pBadBatchMeans, output.averagePBad);
 	    lastPBad = output.averagePBad;
+
+	    if (batchesThisTemperature % MIN_BATCHES) {
+	        currentScore = MC->eval(alignment);
+	    }
 
 	    if(StatNumSamples(scoreBatchMeans)>=MIN_BATCHES) {
 		double pBadInterval = tolPerStep;
@@ -381,6 +374,7 @@ void SANAThree::runConfidenceIntervals() {
     }
     cout<<"Performed "<<batch<<" total batches\n";
     trackProgress(batch * batchSize, tau, T.elapsed(), temperature, lastPBad);
+    return batch * batchSize;
 }
 
 // I stole this duration from SANA proper. I will repeat the comment there that this is
@@ -388,28 +382,25 @@ void SANAThree::runConfidenceIntervals() {
 // class?? TODO: fix this
 // -Marcus
 #define HILLCLIMB_DURATION 10000000000u
-void SANAThree::runHillClimbing() {
+uint64_t SANAThree::runHillClimbing() {
     Timer T;
     T.start();
 
     const unsigned long runTime = 1 + HILLCLIMB_DURATION / batchSize;
-    unsigned long long iter = 0;
-    for (; iter < runTime; iter++) {
+    unsigned long long batch = 0;
+    for (; batch < runTime; batch++) {
         threadPool->collectBatch(0.);
         currentScore = MC->eval(alignment);
     }
     cout<<"Hill climbing took "<<T.elapsedString()<<"s"<<endl;
+    return batch * batchSize;
 }
 
 SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
-
-    // Request parameters
-    bool twoPegs = true;
-
-    // Garbage allocation so that an exception will occur if not set and then used
-
     // Loop while we look for a valid adjacent alignment.
     while (true) {
+        bool twoPegs = true;
+
         unsigned peg1 = randIndex_64(n1, generator);
         unsigned hole1 = alignment.pegToHole(peg1);
 
@@ -430,7 +421,7 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
             continue;
         }
 
-        if (alignment.pegToHole(peg1) != hole1 || alignment.pegToHole(peg2) != hole2) {
+        if (alignment.pegToHole(peg1) != hole1 || alignment.holeToPeg(hole2) != peg2) {
             releaseHoles(hole1, hole2);
             continue;
         }
@@ -492,32 +483,25 @@ void SANAThree::releaseHoles(unsigned hole1, unsigned hole2) {
 }
 
 
-double SANAThree::implementLastRequest(const double pBad, const double energyInc, const changeRequest &input, mt19937_64 &generator) {
-    if (input.twoPegs)
-        totalSwapsCalculated++;
-    else
-        totalMovesCalculated++;
-
-    if (randomReal(generator) >= pBad) {
+double SANAThree::implementLastRequest(const double pBad, const double energyInc, const changeRequest &input, mt19937_64 &generator, uniform_real_distribution<> &dist) {
+    if (dist(generator) >= pBad) {
         releaseHoles(input.hole1, input.hole2);
         return currentScore;
     }
 
     if (input.twoPegs) {
-        alignment.swapPegs(input.peg1, input.peg2);
-        totalSwapsAccepted++;
+        alignment.swapPegs(input.peg1, input.peg2, input.hole1, input.hole2);
     }
     else {
-        alignment.movePeg(input.peg1, input.hole2);
-        totalMovesAccepted++;
+        alignment.movePeg(input.peg1, input.hole1, input.hole2);
     }
     releaseHoles(input.hole1, input.hole2);
 
     // Yes, this causes a data race if two thread try to adjust the score at once. Too bad!
     // The energyInc is already stale and we've already got floating point error accumulation.
-    // So this is acceptable
-    const double val = currentScore.load() + energyInc;
-    currentScore.store(val);
+    // So this is acceptable, as long as we don't drift too far.
+    const double val = currentScore.load(memory_order_relaxed) + energyInc;
+    currentScore.store(val, memory_order_relaxed);
     return val;
 }
 
@@ -541,35 +525,44 @@ void SANAThree::trackProgress(long long unsigned iter, double fractionTime, doub
     fflush(stdout);
 }
 
+volatile sig_atomic_t SANAThree::userInterrupted = 0;
+
 void sigHandlerThree(const int s) {
-    string line;
-    if(s == SIGINT) {
-        int c = 3; // default to save and continue
-        // probably an interactive ^C
-        do {
-            cout<<"Select an option (0 - 3):"<<endl<<"  (0) Do nothing and continue"<<endl<<"  (1) Exit"<<endl
-            <<"  (2) Save Alignment and Exit"<<endl<<"  (3) Save Alignment and Continue"<<endl<<">> ";
-            cin >> c;
-            if (cin.eof()) { // hmm, assume ^D means "save and continue"
-                SANAThree::saveAligAndContOnInterruption = true;
-                cin.clear();
-                return;
-            }
-            if (cin.fail()) {
-                c = -1;
-                cin.clear();
-                cin.ignore(numeric_limits<streamsize>::max(), '\n');
-            }
-            if      (c == 0) cout<<"Continuing..."<<endl;
-            else if (c == 1) exit(0);
-            else if (c == 2) SANAThree::saveAligAndExitOnInterruption = true;
-            else if (c == 3) SANAThree::saveAligAndContOnInterruption = true;
-        } while (c < 0 || c > 3);
+    if (s == SIGINT || s == SIGTERM || s == SIGHUP) {
+        SANAThree::userInterrupted = 1;
     }
-    else if(s == SIGTERM) // probably sent via top(1), so save and exit
-        SANAThree::saveAligAndExitOnInterruption = true;
-    else // any other signal (eg USR1 or something unexpected), save and continue
-        SANAThree::saveAligAndContOnInterruption = true;
+}
+
+void SANAThree::handleInterruption() {
+    userInterrupted = 0; // Reset the flag
+
+    int c = 3;
+    do {
+        cout << "\n--- SANA Interrupted ---" << endl;
+        cout << "Select an option (0 - 3):" << endl
+             << "  (0) Do nothing and continue" << endl
+             << "  (1) Exit" << endl
+             << "  (2) Save Alignment and Exit" << endl
+             << "  (3) Save Alignment and Continue" << endl << ">> ";
+
+        cin >> c;
+        if (cin.eof()) {
+            saveAligAndContOnInterruption = true;
+            cin.clear();
+            return;
+        }
+        if (cin.fail()) {
+            c = -1;
+            cin.clear();
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+        }
+
+        if      (c == 0) cout << "Continuing..." << endl;
+        else if (c == 1) exit(0);
+        else if (c == 2) saveAligAndExitOnInterruption = true;
+        else if (c == 3) saveAligAndContOnInterruption = true;
+
+    } while (c < 0 || c > 3);
 }
 
 void SANAThree::setInterruptSignal() {

--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -41,7 +41,7 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, double TInitial, double T
     tolerance(tolerance),
     maxSeconds(maxSeconds),
     maxIterations(maxIterations),
-    batchSize(max(n1,n2)),
+    batchSize(max<uint64_t>(15000u,n2)),
     threadNumber(threadNumber),
     MC(MC),
     startingAlignment(optionalStartAlig),

--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -199,8 +199,6 @@ string SANAThree::fileNameSuffix(const Alignment& Al) const {
     return "_" + extractDecimals(MC->eval(Al),3);
 }
 
-unsigned SANAThree::pBadsInBuffer() const {return threadPool->pBadsInBuffer();}
-
 double SANAThree::getEquilibriumPBadAtTemp(double temperature, unsigned timeoutSeconds) const {
     return threadPool->runUntilEquilibrium(temperature, timeoutSeconds);
 }
@@ -256,7 +254,6 @@ void SANAThree::runIterations() {
     totalSwapsCalculated = 0;
     totalSwapsAccepted = 0;
     initDataStructures();
-    threadPool->resetBuffers();
     T.start();
     long long unsigned iter = 0;
     double temperature = tInitial;
@@ -303,7 +300,7 @@ void SANAThree::runConfidenceIntervals() {
     STAT *scoreBatchMeans = StatAlloc(0, 0.0, 0.0, false, false);
     STAT *pBadBatchMeans = StatAlloc(0, 0.0, 0.0, false, false);
 
-    // TODO: add batchesPerStep from runIterations for a re-eval of score
+    // TODO: add batchesPerStep from runIterations for a regular re-eval of score
     long int lastBatchCount=0;
     double previousScore = currentScore;
     double temperature = 0;
@@ -312,10 +309,14 @@ void SANAThree::runConfidenceIntervals() {
     totalSwapsCalculated = 0;
     totalSwapsAccepted = 0;
     initDataStructures();
-    threadPool->resetBuffers();
+
+    double lastPBad = 0.0;
+
     T.start();
+
+    // Technical start of the loop, we do not indent for aesthetic reasons
     for (tau = 0; tau <= 1; tau += tauStep) {
-	int batchesPerTemperature = 0;
+	int batchesThisTemperature = 0;
         temperature = temperatureFunction(tau, tInitial, tDecay);
 
 	// Now the "inner loop"
@@ -325,10 +326,10 @@ void SANAThree::runConfidenceIntervals() {
 	    if (saveAligAndContOnInterruption) printReportOnInterruption();
 
 	    const batchOutput output = threadPool->collectBatch(temperature);
-
-            ++batch; ++batchesPerTemperature;
+        ++batch; ++batchesThisTemperature;
 	    StatAddSample(scoreBatchMeans, output.averageScore);
 	    StatAddSample(pBadBatchMeans, output.averagePBad);
+	    lastPBad = output.averagePBad;
 
 	    if(StatNumSamples(scoreBatchMeans)>=MIN_BATCHES) {
 		double pBadInterval = tolPerStep;
@@ -343,7 +344,7 @@ void SANAThree::runConfidenceIntervals() {
 		// HOWEVER, we also slowly decrease the tolerance (by slowly increasing the Interval), because
 		// sometimes we can get "stuck" for a VERY long time at one temperature because the score
 		// is fluctuating too much. Let's not get stuck too long.
-		relativeMultiplier *= (1+log(batchesPerTemperature));
+		relativeMultiplier *= (1+log(batchesThisTemperature));
 
 		scoreInterval *= relativeMultiplier;
 		pBadInterval *= relativeMultiplier;
@@ -375,10 +376,12 @@ void SANAThree::runConfidenceIntervals() {
 		}
 	    }
 	}
-        currentScore = MC->eval(alignment);
-        trackProgress(batch * batchSize, tau, T.elapsed(), temperature, threadPool->recentPBadTrue(), batchesPerTemperature,
-                      StatMean(scoreBatchMeans), StatMean(pBadBatchMeans));
-	if(tauStep < MAX_TAU_STEP) {
+
+    currentScore = MC->eval(alignment);
+    trackProgress(batch * batchSize, tau, T.elapsed(), temperature, lastPBad, batchesThisTemperature,
+                  StatMean(scoreBatchMeans), StatMean(pBadBatchMeans));
+
+    if(tauStep < MAX_TAU_STEP) {
 	    if(StatNumSamples(scoreBatchMeans) < HAPPY_BATCHES) {
 		if(verbose) printf(" *****> doing OK at tau %g & %d batches; increasing tauStep from %g",
 		    tau, StatNumSamples(scoreBatchMeans), tauStep);
@@ -399,7 +402,7 @@ void SANAThree::runConfidenceIntervals() {
 	StatReset(scoreBatchMeans); StatReset(pBadBatchMeans);
     }
     cout<<"Performed "<<batch<<" total batches\n";
-    trackProgress(batch * batchSize, tau, T.elapsed(), temperature, threadPool->recentPBadQuick());
+    trackProgress(batch * batchSize, tau, T.elapsed(), temperature, lastPBad);
 }
 
 // I stole this duration from SANA proper. I will repeat the comment there that this is
@@ -593,7 +596,7 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
 
             peg1 = (*G1->getNodesWithColor(color))[peg1colorID];
             lockAlignmentAndHoles.lock();
-            hole1 = alignment.pegToHole(peg1);
+            hole1 = alignment[peg1];
             hole2 = colorUnassignedNodes[color][hole2unassignedID];
         }
         // I.E., if invalid, reroll. Rejection sampling, google it
@@ -607,7 +610,7 @@ SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
     }
 }
 
-double SANAThree::implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator) {
+double SANAThree::implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator) {
     double randomNum = randomReal(generator); // MARCUS says it's better to generate before the mutex...
     unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
     holeLocks[input.hole1] = holeLocks[input.hole2] = false;
@@ -626,7 +629,7 @@ double SANAThree::implementLastRequest(double pBad, const changeRequest &input, 
         totalMovesAccepted++;
     }
 
-    const double val = currentScore.load() + input.energyInc;
+    const double val = currentScore.load() + energyInc;
     currentScore.store(val);
     return val;
 }

--- a/src/methods/SANAThree.cpp
+++ b/src/methods/SANAThree.cpp
@@ -16,6 +16,9 @@
 #include <cstdio>
 
 #include "SANAThree.hpp"
+
+#include <cinttypes>
+
 #include "BatchHarvester.hpp"
 
 #include "../measures/SquaredEdgeScore.hpp"
@@ -25,41 +28,47 @@
 
 bool SANAThree::saveAligAndExitOnInterruption = false;
 bool SANAThree::saveAligAndContOnInterruption = false;
-SANAThree::SANAThree(const Graph* G1, const Graph* G2, double TInitial, double TDecay, double maxSeconds,
-        long long maxIterations, double tolerance, bool addHillClimbing, const MeasureCombination* MC,
-        const string& scoreAggrStr, const Alignment& optionalStartAlig, const string& outputFileName,
-        const string& localScoresFileName, unsigned threadNumber):
+SANAThree::SANAThree(const Graph* G1, const Graph* G2, const double TInitial, const double TDecay,
+    const double maxSeconds, const long long maxIterations, const double tolerance,
+    const bool addHillClimbing, const MeasureCombination* MC, const string& scoreAggrStr,
+    const Alignment& optionalStartAlig, const string& outputFileName,
+    const string& localScoresFileName, unsigned threadNumber):
+
     Method(G1, G2, "SANAThree_" + MC->toString()),
     n1(G1->getNumNodes()),
     n2(G2->getNumNodes()),
     m1(G1->getNumEdges()),
     m2(G2->getNumEdges()),
-    hillClimbing(addHillClimbing),
-    needEC(MC->getWeight("ec") > 0),
-    needEM(MC->getWeight("emin") > 0),
-    needER(MC->getWeight("er") > 0),
     tolerance(tolerance),
     maxSeconds(maxSeconds),
     maxIterations(maxIterations),
     batchSize(max<uint64_t>(15000u,n2)),
     threadNumber(threadNumber),
+    hillClimbing(addHillClimbing),
+    needEC(MC->getWeight("ec") > 0),
+    needEM(MC->getWeight("emin") > 0),
+    needER(MC->getWeight("er") > 0),
     MC(MC),
     startingAlignment(optionalStartAlig),
     outputFileName(outputFileName),
     localScoresFileName(localScoresFileName),
     tInitial(TInitial),
     tDecay(TDecay),
-    holeLocks(n2, false) {
+    holeLocks(n2) {
     // This should never happen, and if it does, it is 100% user error.
     if (threadNumber >= n1 / 2) {
         throw runtime_error(
-            "You should not request more threads than you have G1 nodes.");
+            "You should not request more threads than half the network size of G1.");
     }
 
     if (tolerance > 0) {
         if (maxIterations > 0 or maxSeconds > 0)
             throw runtime_error(
                 "To use iterations or time, first set \"-tolerance 0\" on the command line (NOT RECOMMENDED!)");
+    }
+
+    for (size_t i = 0; i < n2; ++i) {
+        holeLocks[i].clear(std::memory_order_relaxed);
     }
 
     currentScore = 0.;
@@ -70,20 +79,15 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, double TInitial, double T
                 "run the old version." << endl;
     }
 
-
     randomReal = uniform_real_distribution<>(0, 1);
 
     // NODE COLOR SYSTEM initialization
+    // TODO: Preferred Holes
 
     assert(G1->numColors() <= G2->numColors());
 
-
-    swapsPerColor.reserve(G1->numColors() + 1);
-    movesPerColor.reserve(G1->numColors() + 1);
-    swapsPerColor.push_back(0);
-    movesPerColor.push_back(0);
-    numSwaps = 0;
-    numAdjacentAlignments  = 0;
+    uint64_t numSwaps = 0;
+    uint64_t numAdjacentAlignments  = 0;
     for (uint g1Id = 0; g1Id < G1->numColors(); g1Id++) {
         string colName = G1->getColorName(g1Id);
         if (not G2->hasColor(colName))
@@ -99,9 +103,7 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, double TInitial, double T
         const uint64_t numNeighbors = numSwapNeighbors + numMoveNeighbors;
 
         numSwaps += numSwapNeighbors;
-        swapsPerColor.push_back(numSwaps);
         numAdjacentAlignments += numSwapNeighbors + numMoveNeighbors;
-        movesPerColor.push_back(numAdjacentAlignments - numSwaps);
         if (true) {
             cerr << "SANAThree:: color " << colName << " has " << numSwapNeighbors << " possible swaps and "
                     << numMoveNeighbors << " possible moves (" << numNeighbors << " total)" << endl;
@@ -116,15 +118,17 @@ SANAThree::SANAThree(const Graph* G1, const Graph* G2, double TInitial, double T
         throw runtime_error(
             "There is a unique valid alignment, so running SANA is pointless");
 
-    //things initialized in initDataStructures because they depend on the starting alignment
-    //they have the same size for every run, so we can allocate the size here
-    colorUnassignedNodes = vector<vector<uint>>(swapsPerColor.size());
-
     totalMovesCalculated = 0;
     totalMovesAccepted = 0;
     totalSwapsCalculated = 0;
     totalSwapsAccepted = 0;
-    initDataStructures();
+
+    if (startingAlignment.numOfPegs() == 0)
+        alignment = Alignment::randomColorRestrictedAlignment(*G1, *G2);
+    else
+        alignment = startingAlignment;
+    currentScore = MC->eval(alignment);
+
     threadPool = new BatchHarvester {threadNumber, *this, batchSize / 2};
 }
 
@@ -148,35 +152,9 @@ Alignment SANAThree::runUsingConfidenceIntervals() {
     return run();
 }
 
-void SANAThree::initDataStructures() {
-    auto assignedNodesG2 = vector<char> (n2);
-
+void SANAThree::resetAlignment() {
     if (startingAlignment.numOfPegs() == 0) alignment = Alignment::randomColorRestrictedAlignment(*G1, *G2);
     else alignment = startingAlignment;
-
-    //init holeToColorID. For each node, we do the following transformations:
-    //g2Node -> g2ColorId -> g1ColorId -> actColId
-    vector<uint> g2ToG1ColorIdMap = G2->myColorIdsToOtherGraphColorIds(*G1);
-    auto holeToColorID = vector<uint>(n2, n1);
-    for (uint g2Node = 0; g2Node < n2; g2Node++) {
-        uint g2ColorId = G2->getNodeColor(g2Node);
-        uint color = g2ToG1ColorIdMap[g2ColorId];
-        if (color == Graph::INVALID_COLOR_ID) continue; //no node in G1 has this color
-        holeToColorID[g2Node] = color;
-    }
-
-    for (uint i = 0; i < n2; i++) assignedNodesG2[i] = false;
-    for (uint i = 0; i < n1; i++) assignedNodesG2[alignment[i]] = true;
-    //initialize actColToUnassignedG2Nodes (the size was already set in the constructor)
-    for (auto & colorUnassignedNode : colorUnassignedNodes)
-        colorUnassignedNode.clear();
-    for (uint g2Node = 0; g2Node < n2; g2Node++) {
-        if (assignedNodesG2[g2Node]) continue;
-        uint actColId = holeToColorID[g2Node];
-        if (actColId != n1) {
-            colorUnassignedNodes[actColId].push_back(g2Node);
-        }
-    }
 
     currentScore = MC->eval(alignment);
 }
@@ -253,7 +231,7 @@ void SANAThree::runIterations() {
     totalMovesAccepted = 0;
     totalSwapsCalculated = 0;
     totalSwapsAccepted = 0;
-    initDataStructures();
+    resetAlignment();
     T.start();
     long long unsigned iter = 0;
     double temperature = tInitial;
@@ -294,7 +272,7 @@ void SANAThree::runConfidenceIntervals() {
     if(confidence < MIN_CONFIDENCE) confidence = MIN_CONFIDENCE; // doesn't add much CPU to increase confidence.
 
     bool verbose = true;
-    if(verbose) printf("SANAThree::runConfidenceIntervals Parameters: batchSize %llu confidence %g tolerance per step %g\n",
+    if(verbose) printf("SANAThree::runConfidenceIntervals Parameters: batchSize %" PRIu64 " confidence %g tolerance per step %g\n",
 	batchSize, confidence, tolPerStep);
 
     STAT *scoreBatchMeans = StatAlloc(0, 0.0, 0.0, false, false);
@@ -308,7 +286,7 @@ void SANAThree::runConfidenceIntervals() {
     totalMovesAccepted = 0;
     totalSwapsCalculated = 0;
     totalSwapsAccepted = 0;
-    initDataStructures();
+    resetAlignment();
 
     double lastPBad = 0.0;
 
@@ -423,201 +401,107 @@ void SANAThree::runHillClimbing() {
     cout<<"Hill climbing took "<<T.elapsedString()<<"s"<<endl;
 }
 
-#ifdef PREFERRED_HOLES
-#define RESTRICT_P 1
-SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64& generator) {
-    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex, defer_lock);
+SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
 
     // Request parameters
-    bool twoPegs;
+    bool twoPegs = true;
 
-    unsigned peg1;
-    unsigned peg2;
-    unsigned hole1;
-    unsigned hole2;
-
-    unsigned hole2unassignedID = -1;
-    unsigned color = -1;
+    // Garbage allocation so that an exception will occur if not set and then used
 
     // Loop while we look for a valid adjacent alignment.
     while (true) {
-        // Part 1, select a random peg1
-        peg1 = randIndex_64(n1, generator);
+        unsigned peg1 = randIndex_64(n1, generator);
+        unsigned hole1 = alignment.pegToHole(peg1);
 
-        // We want: p(adjAli) = 1 / numAdjAlignments
-        // What we get: p(adjAli(peg1, hole2)) = (1 / n1) * (1 / numPerfHoles(peg1))
-        // How: p(adjAli(peg1, hole2)) = (numPerHoles(peg1) / numAdjAlignments) * (1 / numPerfHoles(peg1))
-
-        // Part 2, find hole2. We either select an allowed hole2 from peg1's list of preferred
-        if (randomReal(generator) <= RESTRICT_P) {
-            const unsigned hole2Idx = randIndex_64(PREFERRED_HOLES[peg1].len(), generator);
-            hole2 = PREFERRED_HOLES[peg1][hole2Idx];
-        }
-        else {
-            hole2 = randIndex_64(n2, generator);
-        }
-
-        // Part 3: check for locks
-        lockAlignmentAndHoles.lock();
-        hole1 = alignment[peg1];
-        if (holeLocks[hole1] || holeLocks[hole2]) {
-            lockAlignmentAndHoles.unlock();
+        // TODO: Preferred Hole System
+        unsigned color = G1->getNodeColor(peg1);
+        unsigned colorNum = G2->getNodesWithColor(color)->size();
+        unsigned hole2 = G2->getNodesWithColor(color)->at(randIndex_64(colorNum, generator));
+        if (hole1 == hole2) {
             continue;
         }
-        holeLocks[hole1] = holeLocks[hole2] = true;
-        peg2 = INVERSE_ALIGNMENT[hole2];
-        lockAlignmentAndHoles.unlock();
+        unsigned peg2 = alignment.holeToPeg(hole2);
 
-
-        if (peg2 == -1) twoPegs = false;
-        else twoPegs = true;
-
-        return {twoPegs, peg1, peg2, hole1, hole2, hole2unassignedID, color};
-    }
-}
-
-double SANAThree::new_implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator) {
-    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
-
-    holeLocks[input.hole1] = holeLocks[input.hole2] = false;
-    if (input.twoPegs) totalSwapsCalculated++;
-    else totalMovesCalculated++;
-
-    if (randomReal(generator) >= pBad) return currentScore;
-
-    if (input.twoPegs) {
-        alignment.swapPegs(input.peg1, input.peg2);
-        totalSwapsAccepted++;
-    }
-    else {
-        alignment.movePeg(input.peg1, input.hole2);
-        totalMovesAccepted++;
-    }
-
-    const double val = currentScore.load() + input.energyInc;
-    currentScore.store(val);
-    return val;
-}
-#else
-
-SANAThree::changeRequest SANAThree::chooseNextRequest(mt19937_64 &generator) {
-    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex, defer_lock);
-
-    // Request parameters
-    bool twoPegs;
-
-    unsigned peg1;
-    unsigned peg2 = -1; // Garbage allocation so that an exception will occur if not set and then used
-    unsigned hole1;
-    unsigned hole2;
-
-    unsigned peg1colorID;
-    unsigned peg2colorID = -1;
-    unsigned hole2unassignedID = -1;
-
-    unsigned color = 0;
-
-    while (true) {
-        uint64_t alignmentNumber = randIndex_64(numAdjacentAlignments, generator);
-
-        // Swap Logic
-        if (alignmentNumber < numSwaps) {
-            twoPegs = true;
-
-            // Find the active color
-            {
-                auto colorIter = upper_bound(swapsPerColor.begin(), swapsPerColor.end(), alignmentNumber) - 1;
-                color = colorIter - swapsPerColor.begin();
-                alignmentNumber = alignmentNumber - *colorIter;
-            }
-
-            // We consider each swap possibility of this color to be ordered in the following way:
-            // (0, 1), (0, 2), ..., (0, n), (1, 2), ..., (n-1, n)
-            // Ignoring symmetrical options (it's the same swap, after all), this means that the first
-            // (n - 1) indices for these options have peg1 = 0, then the next (n - 2) for these options
-            // have peg1 = 1 and so on. What this next complicated bit does is transform an index into
-            // these possibilities into the actual possibility.
-
-            // Enclosed in brackets so that these temporary variables keep in scope.
-            {
-                const unsigned numColorPegs = G1->numNodesWithColor(color);
-                // Calculating peg1. There is a quadratic inequality I use that derives from the fact that
-                // cumulativeSwaps(peg1) <= alignmentNumber < cumulativeSwaps(peg1 + 1). Do the math
-                // if you are confused, it's a good exercise.
-                const auto n = static_cast<double>(numColorPegs);
-                const auto Ad = static_cast<double>(alignmentNumber); // Narrowing cast, yuck!
-                const double discriminant = (2. * n - 1) * (2. * n - 1) - 8. * Ad;
-                peg1colorID = 1U + static_cast<unsigned>(ceil((2. * n - 1. - sqrt(discriminant)) / 2.));
-
-                // These are the possibilities that have already been counted for all first pegs that
-                // are less than the current one
-                uint64_t cumulativeSwaps = peg1colorID * (2ULL * numColorPegs - peg1colorID - 1ULL) / 2;
-
-                // Because any conversion from a double to an unsigned is sus, we ensure that we
-                // do indeed fulfill the inequality of:
-                // cumSwaps(peg1) <= alignmentNumber < cumSwaps(peg1  + 1)
-                while (alignmentNumber < cumulativeSwaps) {
-                    cumulativeSwaps -= numColorPegs - peg1colorID;
-                    peg1colorID--;
-                }
-                while (alignmentNumber >= cumulativeSwaps + numColorPegs - peg1colorID - 1) {
-                    cumulativeSwaps += numColorPegs - peg1colorID - 1;
-                    peg1colorID++;
-                }
-
-                // peg2's ID is just the offset from alignmentNumber - cumSwaps(peg1) and then offset
-                // again by peg1 + 1;
-                peg2colorID = static_cast<unsigned>(alignmentNumber - cumulativeSwaps + peg1colorID + 1);
-            }
-
-            peg1 = (*G1->getNodesWithColor(color))[peg1colorID];
-            peg2 = (*G1->getNodesWithColor(color))[peg2colorID];
-            lockAlignmentAndHoles.lock();
-            hole1 = alignment.pegToHole(peg1);
-            hole2 = alignment.pegToHole(peg2);
-        }
-        // Move Logic
-        else {
+        if (peg2 == n1) {
             twoPegs = false;
-
-            alignmentNumber -= numSwaps;
-
-            // Find the active color
-            {
-                auto colorIter = upper_bound(movesPerColor.begin(), movesPerColor.end(), alignmentNumber) - 1;
-                color = colorIter - movesPerColor.begin();
-                alignmentNumber = alignmentNumber - *colorIter;
-            }
-
-            // YES, IT IS REALLY THIS EASY FOR THE MOVE CASE COMPARED TO THE SWAP CASE
-            const unsigned numUnassignedHoles = colorUnassignedNodes.at(color).size();
-            peg1colorID = alignmentNumber / numUnassignedHoles;
-            hole2unassignedID = alignmentNumber % numUnassignedHoles;
-
-            peg1 = (*G1->getNodesWithColor(color))[peg1colorID];
-            lockAlignmentAndHoles.lock();
-            hole1 = alignment[peg1];
-            hole2 = colorUnassignedNodes[color][hole2unassignedID];
         }
-        // I.E., if invalid, reroll. Rejection sampling, google it
-        if (holeLocks[hole1] || holeLocks[hole2]) {
-            lockAlignmentAndHoles.unlock();
+
+        if (!tryToLockHoles(hole1, hole2)) {
             continue;
         }
 
-        holeLocks[hole1] = holeLocks[hole2] = true;
-        return {twoPegs, peg1, peg2, hole1, hole2, hole2unassignedID, color, 0.0};
+        if (alignment.pegToHole(peg1) != hole1 || alignment.pegToHole(peg2) != hole2) {
+            releaseHoles(hole1, hole2);
+            continue;
+        }
+
+        return {twoPegs, peg1, peg2, hole1, hole2};
     }
 }
 
-double SANAThree::implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator) {
-    double randomNum = randomReal(generator); // MARCUS says it's better to generate before the mutex...
-    unique_lock<mutex> lockAlignmentAndHoles(alignmentMutex);
-    holeLocks[input.hole1] = holeLocks[input.hole2] = false;
-    if (input.twoPegs) totalSwapsCalculated++;
-    else totalMovesCalculated++;
 
-    if (randomNum >= pBad) return currentScore;
+bool SANAThree::tryToLockHoles(unsigned hole1, unsigned hole2) {
+    if (hole1 == hole2) {
+        return false;
+    }
+
+    // Philosopher's problem solution using a canonical locking order
+    unsigned holeA, holeB;
+    if (hole1 < hole2) {
+        holeA = hole1;
+        holeB = hole2;
+    }
+    else {
+        holeA = hole2;
+        holeB = hole1;
+    }
+
+    // test_and_set returns TRUE if the hole is already "locked"
+    if (holeLocks[holeA].test_and_set(memory_order_acquire)) {
+        return false;
+    }
+    if (holeLocks[holeB].test_and_set(memory_order_acquire)) {
+        holeLocks[holeA].clear(memory_order_release); // Clear first "lock"
+        return false;
+    }
+
+    // test_and_set "acquired" both "locks" successfully (this code is technically lockless)
+
+    return true;
+}
+
+void SANAThree::releaseHoles(unsigned hole1, unsigned hole2) {
+    if (hole1 == hole2) { // This should never happen.
+        holeLocks[hole1].clear(memory_order_release);
+        return;
+    }
+
+    // Philosopher's problem solution using a canonical locking order
+    unsigned holeA, holeB;
+    if (hole1 < hole2) {
+        holeA = hole1;
+        holeB = hole2;
+    }
+    else {
+        holeA = hole2;
+        holeB = hole1;
+    }
+
+    holeLocks[holeB].clear(memory_order_release);
+    holeLocks[holeA].clear(memory_order_release);
+}
+
+
+double SANAThree::implementLastRequest(const double pBad, const double energyInc, const changeRequest &input, mt19937_64 &generator) {
+    if (input.twoPegs)
+        totalSwapsCalculated++;
+    else
+        totalMovesCalculated++;
+
+    if (randomReal(generator) >= pBad) {
+        releaseHoles(input.hole1, input.hole2);
+        return currentScore;
+    }
 
     if (input.twoPegs) {
         alignment.swapPegs(input.peg1, input.peg2);
@@ -625,19 +509,18 @@ double SANAThree::implementLastRequest(double pBad, double energyInc, const chan
     }
     else {
         alignment.movePeg(input.peg1, input.hole2);
-        colorUnassignedNodes[input.color][input.hole2unassignedID] = input.hole1; // Move
         totalMovesAccepted++;
     }
+    releaseHoles(input.hole1, input.hole2);
 
+    // Yes, this causes a data race if two thread try to adjust the score at once. Too bad!
+    // The energyInc is already stale and we've already got floating point error accumulation.
+    // So this is acceptable
     const double val = currentScore.load() + energyInc;
     currentScore.store(val);
     return val;
 }
 
-#endif
-
-// TODO
-// This function should NOT be re-written in C++, because C++ sucks at formatted output
 void SANAThree::trackProgress(long long unsigned iter, double fractionTime, double elapsedTime,
     double temperature, double lastAvgPBad, unsigned batches, double batchScore, double batchPbad) const {
 

--- a/src/methods/SANAThree.hpp
+++ b/src/methods/SANAThree.hpp
@@ -139,7 +139,6 @@ private:
         Alignment alignment;
         vector<bool> holeLocks;
     changeRequest chooseNextRequest(mt19937_64 &generator);
-    changeRequest allowedPartnersRequest(mt19937_64 &generator);
     double implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator); // Returns if accepted or rejected
 
     // TRACKING SYSTEM

--- a/src/methods/SANAThree.hpp
+++ b/src/methods/SANAThree.hpp
@@ -18,16 +18,6 @@
 
 using namespace std;
 
-// Big Picture TODO list by priority:
-// 0.) Fix Happy Batches System
-// 1.) Refactor and cleanly implement the stationary node system from 2.0
-// 2.) Individual node KE system
-// 3.) Multi-pairwise SANA reimplemented
-// If you have ideas for any of this, my element is @malongo:matrix.org
-// -Marcus
-
-
-
 class SANAThree: public Method {
     class BatchHarvester;
 public:
@@ -65,14 +55,8 @@ private:
         const unsigned hole1;
         const unsigned hole2;
 
-        const unsigned hole2unassignedID;
-
-        const unsigned color;
-
-        changeRequest(bool two_pegs, unsigned peg1, unsigned peg2, unsigned hole1, unsigned hole2,
-        unsigned hole2unassignedID, unsigned colorID, double energyInc):
-            twoPegs(two_pegs), peg1(peg1), peg2(peg2), hole1(hole1), hole2(hole2), hole2unassignedID(hole2unassignedID),
-            color(colorID) {
+        changeRequest(bool two_pegs, unsigned peg1, unsigned peg2, unsigned hole1, unsigned hole2):
+            twoPegs(two_pegs), peg1(peg1), peg2(peg2), hole1(hole1), hole2(hole2) {
         }
     };
 
@@ -85,12 +69,12 @@ private:
     const uint64_t n1, n2, m1, m2;
 
     // Control variables, keep constant -Marcus
-    const bool hillClimbing, needEC, needEM, needER;
     const double tolerance;
     const double maxSeconds;
-    const unsigned long long maxIterations;
-    const unsigned long long batchSize;
+    const uint64_t maxIterations;
+    const uint64_t batchSize;
     const unsigned threadNumber;
+    const bool hillClimbing, needEC, needEM, needER;
     const MeasureCombination *const MC;
     const Alignment startingAlignment; // Give an empty alignment for a scramble
     const string outputFileName;
@@ -102,8 +86,11 @@ private:
 
     BatchHarvester *threadPool;
 
+    atomic<double> currentScore;
+    Alignment alignment;
+
     // Set-up function
-    void initDataStructures();
+    void resetAlignment();
 
     // Main run function and variables
     uint64_t totalMovesCalculated;
@@ -115,21 +102,13 @@ private:
     void runHillClimbing();
 
     // THE REQUEST SYSTEM
-
     uniform_real_distribution<> randomReal;
-    vector<vector<unsigned>> colorUnassignedNodes;
-    // Keeps track of the total number of alignments, swaps, and moves we have access to as changes
-    uint64_t numAdjacentAlignments;
-    uint64_t numSwaps;
-    vector<uint64_t> swapsPerColor;
-    vector<uint64_t> movesPerColor;
 
-    // These mess with these mutexes.
-    mutex scoreMutex;
-        atomic<double> currentScore;
-    mutex alignmentMutex;
-        Alignment alignment;
-        vector<bool> holeLocks;
+    // Hole locking system
+    vector<atomic_flag> holeLocks;
+    bool tryToLockHoles(unsigned hole1, unsigned hole2);
+    void releaseHoles(unsigned hole1, unsigned hole2);
+
     changeRequest chooseNextRequest(mt19937_64 &generator);
     double implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator); // Returns if accepted or rejected
 

--- a/src/methods/SANAThree.hpp
+++ b/src/methods/SANAThree.hpp
@@ -54,8 +54,6 @@ public:
     //requires TInitial and TFinal to be already initialized
     void setTDecayFromTempRange() {tDecay = -log(tFinal/tInitial);}
 
-    unsigned pBadsInBuffer() const;
-
 private:
 
     struct changeRequest {
@@ -71,14 +69,10 @@ private:
 
         const unsigned color;
 
-        // Request output
-        double energyInc;
-
         changeRequest(bool two_pegs, unsigned peg1, unsigned peg2, unsigned hole1, unsigned hole2,
         unsigned hole2unassignedID, unsigned colorID, double energyInc):
             twoPegs(two_pegs), peg1(peg1), peg2(peg2), hole1(hole1), hole2(hole2), hole2unassignedID(hole2unassignedID),
             color(colorID) {
-            this->energyInc = energyInc;
         }
     };
 
@@ -120,8 +114,6 @@ private:
     void runConfidenceIntervals();
     void runHillClimbing();
 
-    void scramble();
-
     // THE REQUEST SYSTEM
 
     uniform_real_distribution<> randomReal;
@@ -139,7 +131,7 @@ private:
         Alignment alignment;
         vector<bool> holeLocks;
     changeRequest chooseNextRequest(mt19937_64 &generator);
-    double implementLastRequest(double pBad, const changeRequest &input, mt19937_64 &generator); // Returns if accepted or rejected
+    double implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator); // Returns if accepted or rejected
 
     // TRACKING SYSTEM
     void trackProgress(long long unsigned iter, double fractionTime, double elapsedTime,

--- a/src/methods/SANAThree.hpp
+++ b/src/methods/SANAThree.hpp
@@ -1,5 +1,6 @@
 #ifndef SANATHREE_HPP
 #define SANATHREE_HPP
+#include <csignal>
 #include <mutex>
 #include <map>
 #include <ctime>
@@ -72,7 +73,7 @@ private:
     const double tolerance;
     const double maxSeconds;
     const uint64_t maxIterations;
-    const uint64_t batchSize;
+    const uint64_t batchSize; // MUST BE A MULTIPLE OF CHUNK_SIZE!!
     const unsigned threadNumber;
     const bool hillClimbing, needEC, needEM, needER;
     const MeasureCombination *const MC;
@@ -92,34 +93,30 @@ private:
     // Set-up function
     void resetAlignment();
 
-    // Main run function and variables
-    uint64_t totalMovesCalculated;
-    uint64_t totalMovesAccepted;
-    uint64_t totalSwapsCalculated;
-    uint64_t totalSwapsAccepted;
-    void runIterations();
-    void runConfidenceIntervals();
-    void runHillClimbing();
+    uint64_t runIterations();
+    uint64_t runConfidenceIntervals();
+    uint64_t runHillClimbing();
 
     // THE REQUEST SYSTEM
-    uniform_real_distribution<> randomReal;
-
     // Hole locking system
     vector<atomic_flag> holeLocks;
     bool tryToLockHoles(unsigned hole1, unsigned hole2);
     void releaseHoles(unsigned hole1, unsigned hole2);
 
     changeRequest chooseNextRequest(mt19937_64 &generator);
-    double implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator); // Returns if accepted or rejected
+    double implementLastRequest(double pBad, double energyInc, const changeRequest &input, mt19937_64 &generator, uniform_real_distribution<> &dist); // Returns if accepted or rejected
 
     // TRACKING SYSTEM
     void trackProgress(long long unsigned iter, double fractionTime, double elapsedTime,
         double temperature, double lastAvgPBad, unsigned batches = 0, double batchScore = 0., double batchPbad = 0.) const;
+
+    static void handleInterruption();
+
     static void setInterruptSignal(); // Control+C during execution offers options
     void printReportOnInterruption() const;
 public:
     // Interrupt handler
-    // These need to be public to be set from the interruption handler
+    static volatile std::sig_atomic_t userInterrupted;
     static bool saveAligAndExitOnInterruption;
     static bool saveAligAndContOnInterruption;
 };

--- a/src/methods/wrappers/HubAlignWrapper.cpp
+++ b/src/methods/wrappers/HubAlignWrapper.cpp
@@ -33,12 +33,12 @@ HubAlignWrapper::HubAlignWrapper(const Graph* G1, const Graph* G2, double alpha)
 void HubAlignWrapper::generateEdgeListFile(int graphNum) {
     const Graph* G = (graphNum == 1 ? G1 : G2);
 
-    const vector<array<uint, 2>>* edgeList = G->getEdgeList();
+    const vector<array<uint, 2>> &edgeList = G->getEdgeList();
     uint m = G->getNumEdges();
     vector<vector<string>> edgeListNames(m, vector<string> (2));
     for (uint i = 0; i < m; i++) {
-        edgeListNames[i][0] = G->getNodeName((*edgeList)[i][0]);
-        edgeListNames[i][1] = G->getNodeName((*edgeList)[i][1]);
+        edgeListNames[i][0] = G->getNodeName(edgeList[i][0]);
+        edgeListNames[i][1] = G->getNodeName(edgeList[i][1]);
     }
 
     //to avoid the case where aligning a network to itself

--- a/src/methods/wrappers/MIGRAALWrapper.cpp
+++ b/src/methods/wrappers/MIGRAALWrapper.cpp
@@ -43,7 +43,7 @@ Alignment MIGRAALWrapper::loadAlignment(const Graph* G1, const Graph* G2, string
         cout << node1 << " " << node2 << endl;
         mapping[G1->getNameIndex(node1)] = G2->getNameIndex(node2);
     }
-    return Alignment(mapping);
+    return Alignment(mapping, G2->getNumNodes());
 }
 
 void MIGRAALWrapper::deleteAuxFiles() {

--- a/src/methods/wrappers/MagnaWrapper.cpp
+++ b/src/methods/wrappers/MagnaWrapper.cpp
@@ -41,7 +41,7 @@ Alignment MagnaWrapper::loadAlignment(const Graph* G1, const Graph* G2, string f
         cout << node1 << " " << node2 << endl;
         mapping[G1->getNameIndex(node1)] = G2->getNameIndex(node2);
     }
-    return Alignment(mapping);
+    return Alignment(mapping, G2->getNumNodes());
 }
 
 void MagnaWrapper::deleteAuxFiles() {

--- a/src/methods/wrappers/NETALWrapper.cpp
+++ b/src/methods/wrappers/NETALWrapper.cpp
@@ -54,7 +54,7 @@ Alignment NETALWrapper::loadAlignment(const Graph* G1, const Graph* G2, string f
         mapping[stoi(words[0])] = stoi(words[2]);
         }
     }
-    return Alignment(mapping);
+    return Alignment(mapping, G2->getNumNodes());
 }
 
 void NETALWrapper::deleteAuxFiles() {

--- a/src/modes/AlphaEstimation.cpp
+++ b/src/modes/AlphaEstimation.cpp
@@ -27,9 +27,9 @@ double AlphaEstimation::computeAlpha(Graph& G1, Graph& G2, string methodName, Me
     if (not FileIO::fileExists(aligFileAlpha0)) return -1;
     if (not FileIO::fileExists(aligFileAlpha1)) return -1;
 
-    double topScore = topMeasure->eval(Alignment::loadMapping(aligFileAlpha0));
+    double topScore = topMeasure->eval(Alignment::loadMapping(aligFileAlpha0, G1, G2));
     Sequence seq(&G1, &G2);
-    double seqScore = seq.eval(Alignment::loadMapping(aligFileAlpha1));
+    double seqScore = seq.eval(Alignment::loadMapping(aligFileAlpha1, G1, G2));
 
     return topScore/(topScore+seqScore);
 }
@@ -93,7 +93,7 @@ double AlphaEstimation::computeAlphaSANA(Graph& G1, Graph& G2, Measure* topMeasu
             sampleCount--;
         }
         else {
-            topScore += topMeasure->eval(Alignment::loadMapping(aligFileAlpha0));
+            topScore += topMeasure->eval(Alignment::loadMapping(aligFileAlpha0, G1, G2));
         }
 
     }
@@ -114,7 +114,7 @@ double AlphaEstimation::computeAlphaSANA(Graph& G1, Graph& G2, Measure* topMeasu
             sampleCount--;
         }
         else {
-            seqScore += seq.eval(Alignment::loadMapping(aligFileAlpha1));
+            seqScore += seq.eval(Alignment::loadMapping(aligFileAlpha1, G1, G2));
         }
     }
     seqScore /= sampleCount;

--- a/src/modes/AnalysisMode.cpp
+++ b/src/modes/AnalysisMode.cpp
@@ -14,7 +14,7 @@ Alignment loadAlignment(int format, const string& file, const Graph& G1, const G
         throw runtime_error("When using analysis mode you must specify both -alignFile and -alignFormat. "+errorHelpMsg);
 
     switch (format) {
-    case 1: return Alignment::loadMapping(file);
+    case 1: return Alignment::loadMapping(file, G1, G2);
     case 2: return Alignment::loadEdgeList(G1, G2, file);
     case 3: return Alignment::loadPartialEdgeList(G1, G2, file, true);
     case 4: return Alignment::loadPartialEdgeList(G1, G2, file, false);

--- a/src/modes/CreateShadow.cpp
+++ b/src/modes/CreateShadow.cpp
@@ -180,7 +180,7 @@ void CreateShadow::createShadow(const string& outFile, const vector<string>& gra
         }
 
         //add the edges
-        for (const auto& edge : (*G.getEdgeList())) {
+        for (const auto& edge : G.getEdgeList()) {
             string gName1 = G.getNodeName(edge[0]), gName2 = G.getNodeName(edge[1]);
             assert(gNameToSName.count(gName1));
             assert(gNameToSName.count(gName2));

--- a/src/modes/Experiment.cpp
+++ b/src/modes/Experiment.cpp
@@ -233,17 +233,17 @@ double Experiment::getAverageScore(string method, string G1Name,
     return -1;
 }
 
-double Experiment::computeScore(string method, string G1Name,
-        string G2Name, uint numSub, Measure* measure) {
+double Experiment::computeScore(string method, string G1Name, string G2Name, uint numSub,
+    Measure* measure, Graph &G1, Graph &G2) {
 
     string subId = getSubId(method, G1Name, G2Name, numSub);
     string resultFile = resultsFolder+subId+".out";
 
     bool NA = measure->getName() == "invalid" or not FileIO::fileExists(resultFile);
     double score;
-    if (NA) score = -1;
+    if (NA) score = -1.;
     else {
-        Alignment A = Alignment::loadMapping(resultFile);
+        Alignment A = Alignment::loadMapping(resultFile, G1, G2);
         score = measure->eval(A);
     }
     return score;
@@ -269,7 +269,7 @@ void Experiment::collectResults() {
             for (string method : methods) {
                 for (uint numSub = 0; numSub < nSubs; numSub++) {
                     string resultKey = getResultId(method, G1Name, G2Name, numSub, measureName);
-                    double score = computeScore(method, G1Name, G2Name, numSub, measure);
+                    double score = computeScore(method, G1Name, G2Name, numSub, measure, *G1, *G2);
                     resultMap[resultKey] = score;
                 }
             }
@@ -575,7 +575,7 @@ Measure* Experiment::loadMeasure(Graph* G1, Graph* G2, string name) {
     if (name == "nc") {
         if (NodeCorrectness::fulfillsPrereqs(G1, G2)) {
             auto alig = Alignment::correctMapping(*G1, *G2);
-            return new NodeCorrectness(alig.asVector());
+            return new NodeCorrectness(alig.copyPegsToHoles());
         } else {
             return new InvalidMeasure();
         }

--- a/src/modes/Experiment.hpp
+++ b/src/modes/Experiment.hpp
@@ -85,7 +85,7 @@ private:
     double getAverageScore(string method, string G1Name,
         string G2Name, string measure);
     double computeScore(string method, string G1Name,
-        string G2Name, uint numSub, Measure* measure);
+                        string G2Name, uint numSub, Measure *measure, Graph &G1, Graph &G2);
 
 
 

--- a/src/modes/NormalMode.cpp
+++ b/src/modes/NormalMode.cpp
@@ -92,7 +92,7 @@ void NormalMode::run(ArgumentParser& args) {
         ofstream localMeasureOfs(localMeasureFileName);
 
         if (!multi_iter_only) {
-            Graph CS = G1.graphIntersection(G2, A.asVector());
+            Graph CS = G1.graphIntersection(G2, A.copyPegsToHoles());
             string aligGraphFileName = baseName + ".ccs-el";
             cout << "Saving common subgraph in edge list format as \"" << aligGraphFileName << "\"" << endl;
             GraphLoader::saveInEdgeListFormat(CS, aligGraphFileName, false, true, "", " ");

--- a/src/modes/ParameterEstimation.cpp
+++ b/src/modes/ParameterEstimation.cpp
@@ -119,7 +119,7 @@ void ParameterEstimation::submitScriptsToCluster() {
 
 double ParameterEstimation::getScore(double k, double l) {
     string aligFileName = getAlignmentFileName(k, l);
-    Alignment A = Alignment::loadMapping(aligFileName);
+    Alignment A = Alignment::loadMapping(aligFileName, *G1, *G2);
     return measure->eval(A);
 }
 

--- a/src/utils/CircularBuffer.hpp
+++ b/src/utils/CircularBuffer.hpp
@@ -14,7 +14,7 @@ using namespace std;
 template<typename T, typename = typename enable_if<is_arithmetic<T>::value>::type>
 class CircularBuffer {
 public:
-    explicit CircularBuffer(unsigned long long size) {
+    explicit CircularBuffer(size_t size) {
         full = false;
         default_fill = 0;
         sum = 0;
@@ -22,7 +22,7 @@ public:
         currentPlace = data.begin();
     }
 
-    CircularBuffer(unsigned long long size, T default_fill) {
+    CircularBuffer(size_t size, T default_fill) {
         full = true;
         sum = default_fill * size;
         this->default_fill = default_fill;
@@ -81,6 +81,7 @@ public:
         return quickAverage();
     }
 
+    // TODO: This bad and borrowed from SANA 2. This is just not a great equilibrium, it should be fixed. -ML
     bool trendingUpwards() const {
         int trend = 0;
         auto end = full ? data.end() : currentPlace;
@@ -109,12 +110,12 @@ protected:
 template<typename T, typename = typename enable_if<is_arithmetic<T>::value>::type>
 class CircularSTATBuffer final : public CircularBuffer<T> {
 public:
-    explicit CircularSTATBuffer(unsigned long long size):
+    explicit CircularSTATBuffer(size_t size):
         CircularBuffer<T>(size) {
         sumSquared = 0;
     }
 
-    CircularSTATBuffer(unsigned long long size, T default_fill):
+    CircularSTATBuffer(size_t size, T default_fill):
         CircularBuffer<T>(size, default_fill) {
         sumSquared = default_fill * default_fill * size;
     }

--- a/src/utils/ComputeGraphletsWrapper.cpp
+++ b/src/utils/ComputeGraphletsWrapper.cpp
@@ -43,7 +43,7 @@ vector<vector<uint>> ComputeGraphletsWrapper::computeGraphletDegreeVectors(const
     cout<<"Computing Graphlet Degree Vectors... "<<endl;
     FILE *fp = tmpfile();
     fprintf(fp, "%d %d\n", G.getNumNodes(), G.getNumEdges()); 
-    for (const auto& edge : *(G.getEdgeList())) {
+    for (const auto& edge : G.getEdgeList()) {
         fprintf(fp, "%d %d\n", edge[0], edge[1]);
     }
     rewind(fp); //because computeGraphlets starts reading the file from the start


### PR DESCRIPTION
Valgrind, Helgrind (with cavets that it complains about atomics), and Thread Sanitizer all confirm the variety of my changes and I have profiled the changes.

It is confirmed: SANA 3.5.1 is faster and safer than 3.3. There should also be no merge conflicts.

<img width="644" height="398" alt="Average Core Usage vs Thread Number (Data Challenge)" src="https://github.com/user-attachments/assets/9fcd476d-009f-4784-ba24-b07aa8a7c8ef" />
<img width="644" height="398" alt="Iterations Per Second vs Thread Number (Data Challenge)" src="https://github.com/user-attachments/assets/21dc4e77-62da-4722-b607-59d9fa11723f" />
<img width="644" height="398" alt="Average Core Usage vs Thread Number (Yeast against HSapiens)" src="https://github.com/user-attachments/assets/07cf5ba5-f1ff-4ba7-8f44-78479d02bb09" />
<img width="644" height="398" alt="Iterations Per Second vs Thread Number (Yeast against HSapiens)" src="https://github.com/user-attachments/assets/c6b37780-f0ef-4092-97df-3556365578d2" />
